### PR TITLE
Analyzer: Fix the storage trend, estimate days until full, and warn before space runs out

### DIFF
--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/LowStorage.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/LowStorage.kt
@@ -1,0 +1,23 @@
+package eu.darken.sdmse.stats.core
+
+/**
+ * The single definition of "this storage is running out of space", shared by the dashboard
+ * forecast, the home-screen widget and the settings screen that configures it.
+ */
+object LowStorage {
+
+    const val AUTO_PERCENT = 5
+    const val AUTO_MAX_BYTES = 2L * 1024 * 1024 * 1024
+
+    /**
+     * [customThresholdBytes] null means automatic: the historical rule, the smaller of 5% of
+     * capacity and 2 GiB. A non-null value is used exactly — no capacity clamp.
+     */
+    fun resolveThreshold(capacityBytes: Long, customThresholdBytes: Long?): Long = when {
+        customThresholdBytes != null -> customThresholdBytes.coerceAtLeast(0L)
+        else -> minOf(capacityBytes * AUTO_PERCENT / 100, AUTO_MAX_BYTES)
+    }
+
+    /** Inclusive: exactly at the threshold counts as low. */
+    fun isLow(spaceFreeBytes: Long, thresholdBytes: Long): Boolean = spaceFreeBytes <= thresholdBytes
+}

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageForecaster.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageForecaster.kt
@@ -36,11 +36,14 @@ object StorageForecaster {
 
         val trend = StorageTrendCalculator.dailyTrend(history) ?: return StorageForecast.InsufficientData
         if (trend.observedDays < MIN_OBSERVED_DAYS) return StorageForecast.InsufficientData
+        if (trend.usableRateCount < MIN_OBSERVED_DAYS - 1) return StorageForecast.InsufficientData
         if (trend.maxGapDays > MAX_GAP_DAYS) return StorageForecast.InsufficientData
 
         val bytesPerDay = trend.bytesPerDay
-        if (trend.spreadBytes > MAX_SPREAD_RATIO * bytesPerDay.absoluteValue) return StorageForecast.Erratic
+        // The spread gate is relative to the rate, so it only means anything once the rate itself
+        // is meaningful: near a zero median any jitter would look erratic.
         if (bytesPerDay <= 0L || bytesPerDay < capacity / MIN_RATE_DIVISOR) return StorageForecast.Stable
+        if (trend.spreadBytes > MAX_SPREAD_RATIO * bytesPerDay.absoluteValue) return StorageForecast.Erratic
 
         val headroom = current.spaceFree - floor
         // Ceiling division: floor division reports "About 0 days" whenever the headroom is under a

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageForecaster.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageForecaster.kt
@@ -1,0 +1,58 @@
+package eu.darken.sdmse.stats.core.forecast
+
+import eu.darken.sdmse.stats.core.SpaceTracker
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import kotlin.math.absoluteValue
+
+/**
+ * Estimates how long a storage lasts before it hits the low-space floor.
+ *
+ * The rate comes from [history], everything else from the LIVE reading: routine sampling is
+ * six-hourly, so the newest persisted row can be hours stale and a download that already crossed
+ * the floor would still be reported as [StorageForecast.Filling].
+ */
+object StorageForecaster {
+
+    const val FLOOR_PERCENT = 5
+    const val FLOOR_MAX_BYTES = 2L * 1024 * 1024 * 1024
+    const val MIN_OBSERVED_DAYS = 5
+    const val MAX_GAP_DAYS = 2L
+    const val MIN_RATE_DIVISOR = 400
+    const val MAX_SPREAD_RATIO = 2
+    const val DISPLAY_HORIZON_DAYS = 120L
+    const val URGENT_DAYS = 14L
+    const val URGENT_FREE_PERCENT = 20
+    const val URGENT_FREE_MAX_BYTES = 25L * 1024 * 1024 * 1024
+
+    fun forecast(
+        history: List<SpaceSnapshotEntity>,
+        current: SpaceTracker.StorageSnapshot,
+    ): StorageForecast {
+        val capacity = current.spaceCapacity
+        if (capacity <= 0L) return StorageForecast.InsufficientData
+
+        val floor = minOf(capacity * FLOOR_PERCENT / 100, FLOOR_MAX_BYTES)
+        if (current.spaceFree <= floor) return StorageForecast.BelowFloor
+
+        val trend = StorageTrendCalculator.dailyTrend(history) ?: return StorageForecast.InsufficientData
+        if (trend.observedDays < MIN_OBSERVED_DAYS) return StorageForecast.InsufficientData
+        if (trend.maxGapDays > MAX_GAP_DAYS) return StorageForecast.InsufficientData
+
+        val bytesPerDay = trend.bytesPerDay
+        if (trend.spreadBytes > MAX_SPREAD_RATIO * bytesPerDay.absoluteValue) return StorageForecast.Erratic
+        if (bytesPerDay <= 0L || bytesPerDay < capacity / MIN_RATE_DIVISOR) return StorageForecast.Stable
+
+        val headroom = current.spaceFree - floor
+        // Ceiling division: floor division reports "About 0 days" whenever the headroom is under a
+        // day's worth of growth, and biases every other estimate early.
+        val daysUntilFloor = (headroom - 1) / bytesPerDay + 1
+        if (daysUntilFloor > DISPLAY_HORIZON_DAYS) return StorageForecast.Stable
+
+        val urgentFreeCeiling = minOf(capacity * URGENT_FREE_PERCENT / 100, URGENT_FREE_MAX_BYTES)
+        return StorageForecast.Filling(
+            daysUntilFloor = daysUntilFloor,
+            bytesPerDay = bytesPerDay,
+            isUrgent = daysUntilFloor <= URGENT_DAYS && current.spaceFree <= urgentFreeCeiling,
+        )
+    }
+}

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageForecaster.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageForecaster.kt
@@ -40,10 +40,13 @@ object StorageForecaster {
         if (trend.maxGapDays > MAX_GAP_DAYS) return StorageForecast.InsufficientData
 
         val bytesPerDay = trend.bytesPerDay
-        // The spread gate is relative to the rate, so it only means anything once the rate itself
-        // is meaningful: near a zero median any jitter would look erratic.
-        if (bytesPerDay <= 0L || bytesPerDay < capacity / MIN_RATE_DIVISOR) return StorageForecast.Stable
-        if (trend.spreadBytes > MAX_SPREAD_RATIO * bytesPerDay.absoluteValue) return StorageForecast.Erratic
+        // The spread test is relative to the rate, so near a zero median it would flag single-byte
+        // jitter. The noise floor gives it an absolute minimum, which keeps a device that swings
+        // gigabytes a day around a zero median erratic instead of stable.
+        val noiseFloor = capacity / MIN_RATE_DIVISOR
+        val spreadThreshold = maxOf(MAX_SPREAD_RATIO * bytesPerDay.absoluteValue, noiseFloor)
+        if (trend.spreadBytes > spreadThreshold) return StorageForecast.Erratic
+        if (bytesPerDay <= 0L || bytesPerDay < noiseFloor) return StorageForecast.Stable
 
         val headroom = current.spaceFree - floor
         // Ceiling division: floor division reports "About 0 days" whenever the headroom is under a

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageForecaster.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageForecaster.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.stats.core.forecast
 
+import eu.darken.sdmse.stats.core.LowStorage
 import eu.darken.sdmse.stats.core.SpaceTracker
 import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
 import kotlin.math.absoluteValue
@@ -13,8 +14,6 @@ import kotlin.math.absoluteValue
  */
 object StorageForecaster {
 
-    const val FLOOR_PERCENT = 5
-    const val FLOOR_MAX_BYTES = 2L * 1024 * 1024 * 1024
     const val MIN_OBSERVED_DAYS = 5
     const val MAX_GAP_DAYS = 2L
     const val MIN_RATE_DIVISOR = 400
@@ -24,15 +23,21 @@ object StorageForecaster {
     const val URGENT_FREE_PERCENT = 20
     const val URGENT_FREE_MAX_BYTES = 25L * 1024 * 1024 * 1024
 
+    /**
+     * [lowStorageThresholdBytes] is the resolved low-storage floor, see [LowStorage.resolveThreshold].
+     * Deliberately without a default: the user can configure this, so every call site has to state
+     * which value it is forecasting against.
+     */
     fun forecast(
         history: List<SpaceSnapshotEntity>,
         current: SpaceTracker.StorageSnapshot,
+        lowStorageThresholdBytes: Long,
     ): StorageForecast {
         val capacity = current.spaceCapacity
         if (capacity <= 0L) return StorageForecast.InsufficientData
 
-        val floor = minOf(capacity * FLOOR_PERCENT / 100, FLOOR_MAX_BYTES)
-        if (current.spaceFree <= floor) return StorageForecast.BelowFloor
+        val floor = lowStorageThresholdBytes
+        if (LowStorage.isLow(current.spaceFree, floor)) return StorageForecast.BelowFloor
 
         val trend = StorageTrendCalculator.dailyTrend(history) ?: return StorageForecast.InsufficientData
         if (trend.observedDays < MIN_OBSERVED_DAYS) return StorageForecast.InsufficientData

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageTrend.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageTrend.kt
@@ -1,0 +1,37 @@
+package eu.darken.sdmse.stats.core.forecast
+
+/**
+ * A robust per-day storage growth estimate derived from a single storage's snapshot history.
+ *
+ * [bytesPerDay] is a median of per-day rates, not a first-to-last delta, so a cleanup inside the
+ * window (which forces a snapshot with sharply more free space) can no longer flip the trend.
+ */
+data class DailyTrend(
+    /** Positive means the storage is filling up. */
+    val bytesPerDay: Long,
+    /** Number of distinct calendar day buckets that contributed a reading. */
+    val observedDays: Int,
+    /** Calendar days between the first and the last bucket. */
+    val elapsedDays: Long,
+    /** Largest hole between two consecutive buckets, in days. */
+    val maxGapDays: Long,
+    /** Median absolute deviation of the per-day rates. */
+    val spreadBytes: Long,
+)
+
+sealed interface StorageForecast {
+
+    data class Filling(
+        val daysUntilFloor: Long,
+        val bytesPerDay: Long,
+        val isUrgent: Boolean,
+    ) : StorageForecast
+
+    data object Stable : StorageForecast
+
+    data object Erratic : StorageForecast
+
+    data object InsufficientData : StorageForecast
+
+    data object BelowFloor : StorageForecast
+}

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageTrend.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageTrend.kt
@@ -11,6 +11,8 @@ data class DailyTrend(
     val bytesPerDay: Long,
     /** Number of distinct calendar day buckets that contributed a reading. */
     val observedDays: Int,
+    /** Number of consecutive bucket pairs that actually yielded a rate, i.e. the sample size. */
+    val usableRateCount: Int,
     /** Calendar days between the first and the last bucket. */
     val elapsedDays: Long,
     /** Largest hole between two consecutive buckets, in days. */

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageTrendCalculator.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageTrendCalculator.kt
@@ -51,6 +51,7 @@ object StorageTrendCalculator {
         return DailyTrend(
             bytesPerDay = bytesPerDay,
             observedDays = buckets.size,
+            usableRateCount = rates.size,
             elapsedDays = ChronoUnit.DAYS.between(buckets.first().day, buckets.last().day),
             maxGapDays = maxGapDays,
             spreadBytes = median(rates.map { (it - bytesPerDay).absoluteValue }),

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageTrendCalculator.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/forecast/StorageTrendCalculator.kt
@@ -1,0 +1,96 @@
+package eu.darken.sdmse.stats.core.forecast
+
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import kotlin.math.absoluteValue
+
+/**
+ * Turns raw space snapshots into a per-day growth rate.
+ *
+ * A snapshot is forced after every task, so a first-to-last delta over the window reports a net
+ * free-space gain whenever the user cleaned up inside it. Bucketing per day and taking the median
+ * of the per-day rates survives that.
+ */
+object StorageTrendCalculator {
+
+    /**
+     * @param snapshots snapshots of a SINGLE storage; callers with mixed storages must group first.
+     */
+    fun dailyTrend(snapshots: List<SpaceSnapshotEntity>, zone: ZoneId = ZoneOffset.UTC): DailyTrend? {
+        val sorted = validSorted(snapshots)
+        if (sorted.size < 2) return null
+
+        val buckets = sorted
+            .groupBy { it.recordedAt.atZone(zone).toLocalDate() }
+            .toSortedMap()
+            .map { (day, entries) ->
+                val reading = entries.last()
+                Bucket(
+                    day = day,
+                    used = reading.spaceCapacity - reading.spaceFree,
+                    capacity = reading.spaceCapacity,
+                )
+            }
+        if (buckets.size < 2) return null
+
+        val rates = mutableListOf<Long>()
+        var maxGapDays = 0L
+        buckets.zipWithNext { earlier, later ->
+            val gap = ChronoUnit.DAYS.between(earlier.day, later.day)
+            if (gap > maxGapDays) maxGapDays = gap
+            // A capacity flip is a StorageStatsManager/File-fallback disagreement, not user growth.
+            if (earlier.capacity == later.capacity) rates.add((later.used - earlier.used) / gap)
+        }
+        if (rates.isEmpty()) return null
+
+        val bytesPerDay = median(rates)
+
+        return DailyTrend(
+            bytesPerDay = bytesPerDay,
+            observedDays = buckets.size,
+            elapsedDays = ChronoUnit.DAYS.between(buckets.first().day, buckets.last().day),
+            maxGapDays = maxGapDays,
+            spreadBytes = median(rates.map { (it - bytesPerDay).absoluteValue }),
+        )
+    }
+
+    /**
+     * Total used-space change across the window, in bytes. Positive means the storage filled up.
+     *
+     * Falls back to the raw first-to-last delta for histories too short to bucket into days, so
+     * sub-day windows keep rendering a value instead of a blank.
+     */
+    fun windowTotal(snapshots: List<SpaceSnapshotEntity>): Long? {
+        dailyTrend(snapshots)?.let { return it.bytesPerDay * it.elapsedDays }
+
+        val sorted = validSorted(snapshots)
+        if (sorted.size < 2) return null
+        return sorted.last().usedSpace - sorted.first().usedSpace
+    }
+
+    private fun validSorted(snapshots: List<SpaceSnapshotEntity>): List<SpaceSnapshotEntity> = snapshots
+        .filter { it.spaceCapacity > 0L && it.spaceFree >= 0L && it.spaceFree <= it.spaceCapacity }
+        .sortedWith(compareBy({ it.recordedAt }, { it.id }))
+
+    private fun median(values: List<Long>): Long {
+        val sorted = values.sorted()
+        val mid = sorted.size / 2
+        return if (sorted.size % 2 == 1) {
+            sorted[mid]
+        } else {
+            (sorted[mid - 1] + sorted[mid]).floorDiv(2L)
+        }
+    }
+
+    private val SpaceSnapshotEntity.usedSpace: Long
+        get() = spaceCapacity - spaceFree
+
+    private data class Bucket(
+        val day: LocalDate,
+        val used: Long,
+        val capacity: Long,
+    )
+}

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryScreen.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryScreen.kt
@@ -396,7 +396,7 @@ private fun UpgradeCard(onUpgradeClick: () -> Unit) {
                 style = MaterialTheme.typography.titleMedium,
             )
             Text(
-                text = stringResource(R.string.stats_space_history_upgrade_body),
+                text = stringResource(R.string.stats_space_history_upgrade_body_v2),
                 style = MaterialTheme.typography.bodyMedium,
             )
             Row(modifier = Modifier.padding(top = 4.dp)) {

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryViewModel.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryViewModel.kt
@@ -18,6 +18,7 @@ import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.stats.core.SpaceHistoryRepo
 import eu.darken.sdmse.stats.core.db.ReportEntity
 import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import eu.darken.sdmse.stats.core.forecast.StorageTrendCalculator
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -124,11 +125,7 @@ class SpaceHistoryViewModel @Inject constructor(
             currentUsed = snapshots.lastOrNull()?.let { it.spaceCapacity - it.spaceFree },
             minUsed = snapshots.minOfOrNull { it.spaceCapacity - it.spaceFree },
             maxUsed = snapshots.maxOfOrNull { it.spaceCapacity - it.spaceFree },
-            deltaUsed = if (snapshots.size >= 2) {
-                val lastUsed = snapshots.last().let { it.spaceCapacity - it.spaceFree }
-                val firstUsed = snapshots.first().let { it.spaceCapacity - it.spaceFree }
-                lastUsed - firstUsed
-            } else null,
+            deltaUsed = StorageTrendCalculator.windowTotal(snapshots),
         )
     }.safeStateIn(
         initialValue = State(),

--- a/app-common-stats/src/main/res/values/strings.xml
+++ b/app-common-stats/src/main/res/values/strings.xml
@@ -54,6 +54,9 @@
     <string name="stats_space_history_delta_in_x">%1$s in %2$s</string>
     <string name="stats_space_history_upgrade_title">Full history is a Pro feature</string>
     <string name="stats_space_history_upgrade_body">Upgrade to unlock the full 90-day trend view for each storage device.</string>
+    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
+         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
+    <string name="stats_space_history_upgrade_body_v2">Upgrade to unlock the full 90-day trend view for each storage device, and get a warning before you run out of space.</string>
     <string name="stats_space_history_marker_freed">Freed %1$s</string>
     <string name="stats_storage_type_primary">Primary storage</string>
     <string name="stats_storage_type_secondary">Secondary storage</string>

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/LowStorageTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/LowStorageTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.sdmse.stats.core
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class LowStorageTest : BaseTest() {
+
+    @Test
+    fun `automatic caps at 2 GiB on a large volume`() {
+        // 5% of 512 GB would be 25.6 GB, which is far more headroom than "running out".
+        LowStorage.resolveThreshold(
+            capacityBytes = 512_000_000_000L,
+            customThresholdBytes = null,
+        ) shouldBe LowStorage.AUTO_MAX_BYTES
+    }
+
+    @Test
+    fun `automatic yields 5 percent on a small volume`() {
+        LowStorage.resolveThreshold(
+            capacityBytes = 8_000_000_000L,
+            customThresholdBytes = null,
+        ) shouldBe 400_000_000L
+    }
+
+    @Test
+    fun `automatic on a zero capacity yields zero`() {
+        LowStorage.resolveThreshold(
+            capacityBytes = 0L,
+            customThresholdBytes = null,
+        ) shouldBe 0L
+    }
+
+    @Test
+    fun `a custom value is returned unchanged on a large volume`() {
+        LowStorage.resolveThreshold(
+            capacityBytes = 512_000_000_000L,
+            customThresholdBytes = 10_000_000_000L,
+        ) shouldBe 10_000_000_000L
+    }
+
+    @Test
+    fun `a custom value is returned unchanged on a small volume, without a capacity clamp`() {
+        LowStorage.resolveThreshold(
+            capacityBytes = 8_000_000_000L,
+            customThresholdBytes = 10_000_000_000L,
+        ) shouldBe 10_000_000_000L
+    }
+
+    @Test
+    fun `a negative custom value clamps to zero`() {
+        LowStorage.resolveThreshold(
+            capacityBytes = 8_000_000_000L,
+            customThresholdBytes = -1L,
+        ) shouldBe 0L
+    }
+
+    @Test
+    fun `above the threshold is not low`() {
+        LowStorage.isLow(spaceFreeBytes = 1_001L, thresholdBytes = 1_000L) shouldBe false
+    }
+
+    @Test
+    fun `exactly at the threshold is low`() {
+        LowStorage.isLow(spaceFreeBytes = 1_000L, thresholdBytes = 1_000L) shouldBe true
+    }
+
+    @Test
+    fun `below the threshold is low`() {
+        LowStorage.isLow(spaceFreeBytes = 999L, thresholdBytes = 1_000L) shouldBe true
+    }
+}

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageForecasterTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageForecasterTest.kt
@@ -45,6 +45,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate),
             current = current(free = 1_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.BelowFloor
     }
 
@@ -53,6 +54,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate),
             current = current(free = floor),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.BelowFloor
     }
 
@@ -61,6 +63,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate),
             current = current(free = 20_000_000_000L, capacity = 0L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.InsufficientData
     }
 
@@ -73,6 +76,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = sameDay,
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.InsufficientData
     }
 
@@ -81,6 +85,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate, days = StorageForecaster.MIN_OBSERVED_DAYS - 1),
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.InsufficientData
     }
 
@@ -89,6 +94,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate, days = StorageForecaster.MIN_OBSERVED_DAYS),
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Filling(daysUntilFloor = 72, bytesPerDay = minRate, isUrgent = false)
     }
 
@@ -98,6 +104,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = gapped,
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.InsufficientData
     }
 
@@ -107,6 +114,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = gapped,
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Filling(daysUntilFloor = 72, bytesPerDay = minRate, isUrgent = false)
     }
 
@@ -125,6 +133,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = alternating,
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.InsufficientData
     }
 
@@ -143,6 +152,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = erratic,
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Erratic
     }
 
@@ -161,6 +171,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = jittery,
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Stable
     }
 
@@ -179,6 +190,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = swinging,
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Erratic
     }
 
@@ -187,6 +199,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = 0L),
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Stable
     }
 
@@ -195,6 +208,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = -minRate, startUsed = 50_000_000_000L),
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Stable
     }
 
@@ -203,6 +217,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate - 1),
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Stable
     }
 
@@ -211,6 +226,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate),
             current = current(free = 20_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Filling(daysUntilFloor = 72, bytesPerDay = minRate, isUrgent = false)
     }
 
@@ -219,6 +235,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = 1_000_000_000L),
             current = current(free = floor + 1),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Filling(daysUntilFloor = 1, bytesPerDay = 1_000_000_000L, isUrgent = true)
     }
 
@@ -227,6 +244,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = 1_000_000_000L),
             current = current(free = floor + 2_500_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Filling(daysUntilFloor = 3, bytesPerDay = 1_000_000_000L, isUrgent = true)
     }
 
@@ -235,6 +253,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = 1_000_000_000L),
             current = current(free = floor + 3_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Filling(daysUntilFloor = 3, bytesPerDay = 1_000_000_000L, isUrgent = true)
     }
 
@@ -243,6 +262,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate),
             current = current(free = floor + minRate * StorageForecaster.DISPLAY_HORIZON_DAYS),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Filling(
             daysUntilFloor = StorageForecaster.DISPLAY_HORIZON_DAYS,
             bytesPerDay = minRate,
@@ -255,6 +275,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate),
             current = current(free = floor + minRate * StorageForecaster.DISPLAY_HORIZON_DAYS + 1),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Stable
     }
 
@@ -263,6 +284,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate),
             current = current(free = floor + minRate * StorageForecaster.URGENT_DAYS),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Filling(
             daysUntilFloor = StorageForecaster.URGENT_DAYS,
             bytesPerDay = minRate,
@@ -275,6 +297,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate),
             current = current(free = floor + minRate * StorageForecaster.URGENT_DAYS + 1),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Filling(
             daysUntilFloor = StorageForecaster.URGENT_DAYS + 1,
             bytesPerDay = minRate,
@@ -289,6 +312,7 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = 5_000_000_000L),
             current = current(free = 25_000_000_000L),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.Filling(daysUntilFloor = 5, bytesPerDay = 5_000_000_000L, isUrgent = false)
     }
 
@@ -299,6 +323,29 @@ class StorageForecasterTest : BaseTest() {
         StorageForecaster.forecast(
             history = history(ratePerDay = minRate),
             current = current(free = floor - 1),
+            lowStorageThresholdBytes = floor,
         ) shouldBe StorageForecast.BelowFloor
+    }
+
+    @Test
+    fun `a custom threshold above the automatic one moves the floor earlier`() {
+        // 5 GB configured on a device with 4 GB free: the automatic 2 GiB floor would still be
+        // days away, but the user asked to be told sooner than that.
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate),
+            current = current(free = 4_000_000_000L),
+            lowStorageThresholdBytes = 5_000_000_000L,
+        ) shouldBe StorageForecast.BelowFloor
+    }
+
+    @Test
+    fun `a custom threshold below the automatic one moves the floor later`() {
+        // 1 GB configured with 1.5 GB free: the automatic 2 GiB floor would already report
+        // BelowFloor, the custom one still forecasts.
+        StorageForecaster.forecast(
+            history = history(ratePerDay = 500_000_000L),
+            current = current(free = 1_500_000_000L),
+            lowStorageThresholdBytes = 1_000_000_000L,
+        ) shouldBe StorageForecast.Filling(daysUntilFloor = 1, bytesPerDay = 500_000_000L, isUrgent = true)
     }
 }

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageForecasterTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageForecasterTest.kt
@@ -165,6 +165,24 @@ class StorageForecasterTest : BaseTest() {
     }
 
     @Test
+    fun `large swings around a zero median are erratic, not stable`() {
+        // Rates of [3000M, -3000M, 3000M, -3000M]: the median is 0, but the spread is gigabytes a
+        // day, so the rate gate alone would report a wildly moving device as stable.
+        val swinging = listOf(
+            10_000_000_000L,
+            13_000_000_000L,
+            10_000_000_000L,
+            13_000_000_000L,
+            10_000_000_000L,
+        ).mapIndexed { index, used -> snap(day = index.toLong(), used = used) }
+
+        StorageForecaster.forecast(
+            history = swinging,
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.Erratic
+    }
+
+    @Test
     fun `a flat history is stable`() {
         StorageForecaster.forecast(
             history = history(ratePerDay = 0L),

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageForecasterTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageForecasterTest.kt
@@ -111,19 +111,57 @@ class StorageForecasterTest : BaseTest() {
     }
 
     @Test
+    fun `enough day buckets but too few usable rates is insufficient data`() {
+        // Capacity readings alternating between the StorageStatsManager and the File fallback fill
+        // every day bucket while leaving a single usable pair, which is not a trend.
+        val alternating = listOf(0L, 1L, 2L, 3L, 4L).map {
+            snap(
+                day = it,
+                used = 10_000_000_000L + 1_000_000_000L * it,
+                // Days 0-4 read as A,B,A,B,B, so only the final pair yields a rate.
+                capacity = if (it == 0L || it == 2L) capacity else capacity - 1_000_000_000L,
+            )
+        }
+        StorageForecaster.forecast(
+            history = alternating,
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.InsufficientData
+    }
+
+    @Test
     fun `a series that swings both ways is erratic`() {
+        // Rates of [300M, 400M, 3000M, -2000M]: the median is a solid 350M/day, but the spread
+        // around it is far wider than the rate itself.
         val erratic = listOf(
             10_000_000_000L,
-            10_100_000_000L,
-            9_800_000_000L,
             10_300_000_000L,
-            10_100_000_000L,
+            10_700_000_000L,
+            13_700_000_000L,
+            11_700_000_000L,
         ).mapIndexed { index, used -> snap(day = index.toLong(), used = used) }
 
         StorageForecaster.forecast(
             history = erratic,
             current = current(free = 20_000_000_000L),
         ) shouldBe StorageForecast.Erratic
+    }
+
+    @Test
+    fun `jitter around a zero median is stable, not erratic`() {
+        // Rates of [1, -1, 2, -2]: the median is 0 and the spread is 1, so a purely relative
+        // spread gate would call a device that is not moving at all erratic.
+        val jittery = listOf(
+            10_000_000_000L,
+            10_000_000_001L,
+            10_000_000_000L,
+            10_000_000_002L,
+            10_000_000_000L,
+        ).mapIndexed { index, used -> snap(day = index.toLong(), used = used) }
+
+        StorageForecaster.forecast(
+            history = jittery,
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.Stable
     }
 
     @Test

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageForecasterTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageForecasterTest.kt
@@ -1,0 +1,248 @@
+package eu.darken.sdmse.stats.core.forecast
+
+import eu.darken.sdmse.stats.core.SpaceTracker
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class StorageForecasterTest : BaseTest() {
+
+    private val base = LocalDate.parse("2026-06-01")
+    private val capacity = 100_000_000_000L
+    private val floor = 2_147_483_648L
+    private val minRate = capacity / StorageForecaster.MIN_RATE_DIVISOR
+
+    private fun snap(
+        day: Long,
+        used: Long,
+        capacity: Long = this.capacity,
+        hour: Long = 12L,
+    ) = SpaceSnapshotEntity(
+        storageId = "a",
+        recordedAt = base.plusDays(day).atStartOfDay(ZoneOffset.UTC).toInstant().plus(Duration.ofHours(hour)),
+        spaceFree = capacity - used,
+        spaceCapacity = capacity,
+    )
+
+    private fun history(
+        ratePerDay: Long,
+        days: Int = 7,
+        startUsed: Long = 10_000_000_000L,
+    ): List<SpaceSnapshotEntity> = (0 until days).map { snap(day = it.toLong(), used = startUsed + ratePerDay * it) }
+
+    private fun current(free: Long, capacity: Long = this.capacity) = SpaceTracker.StorageSnapshot(
+        storageId = "a",
+        spaceFree = free,
+        spaceCapacity = capacity,
+    )
+
+    @Test
+    fun `already below the floor short-circuits everything`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate),
+            current = current(free = 1_000_000_000L),
+        ) shouldBe StorageForecast.BelowFloor
+    }
+
+    @Test
+    fun `exactly at the floor counts as below it`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate),
+            current = current(free = floor),
+        ) shouldBe StorageForecast.BelowFloor
+    }
+
+    @Test
+    fun `a zero capacity reading is insufficient data`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate),
+            current = current(free = 20_000_000_000L, capacity = 0L),
+        ) shouldBe StorageForecast.InsufficientData
+    }
+
+    @Test
+    fun `a history without a daily trend is insufficient data`() {
+        val sameDay = listOf(
+            snap(day = 0, used = 10_000_000_000L, hour = 1),
+            snap(day = 0, used = 11_000_000_000L, hour = 5),
+        )
+        StorageForecaster.forecast(
+            history = sameDay,
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.InsufficientData
+    }
+
+    @Test
+    fun `fewer observed days than the minimum is insufficient data`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate, days = StorageForecaster.MIN_OBSERVED_DAYS - 1),
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.InsufficientData
+    }
+
+    @Test
+    fun `exactly the minimum observed days is enough`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate, days = StorageForecaster.MIN_OBSERVED_DAYS),
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.Filling(daysUntilFloor = 72, bytesPerDay = minRate, isUrgent = false)
+    }
+
+    @Test
+    fun `a gap larger than the maximum is insufficient data`() {
+        val gapped = listOf(0L, 1L, 2L, 3L, 7L).map { snap(day = it, used = 10_000_000_000L + minRate * it) }
+        StorageForecaster.forecast(
+            history = gapped,
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.InsufficientData
+    }
+
+    @Test
+    fun `a gap at the maximum is still usable`() {
+        val gapped = listOf(0L, 1L, 2L, 3L, 5L).map { snap(day = it, used = 10_000_000_000L + minRate * it) }
+        StorageForecaster.forecast(
+            history = gapped,
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.Filling(daysUntilFloor = 72, bytesPerDay = minRate, isUrgent = false)
+    }
+
+    @Test
+    fun `a series that swings both ways is erratic`() {
+        val erratic = listOf(
+            10_000_000_000L,
+            10_100_000_000L,
+            9_800_000_000L,
+            10_300_000_000L,
+            10_100_000_000L,
+        ).mapIndexed { index, used -> snap(day = index.toLong(), used = used) }
+
+        StorageForecaster.forecast(
+            history = erratic,
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.Erratic
+    }
+
+    @Test
+    fun `a flat history is stable`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = 0L),
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.Stable
+    }
+
+    @Test
+    fun `a shrinking history is stable`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = -minRate, startUsed = 50_000_000_000L),
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.Stable
+    }
+
+    @Test
+    fun `a rate just under the noise threshold is stable`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate - 1),
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.Stable
+    }
+
+    @Test
+    fun `a rate exactly at the noise threshold is a forecast`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate),
+            current = current(free = 20_000_000_000L),
+        ) shouldBe StorageForecast.Filling(daysUntilFloor = 72, bytesPerDay = minRate, isUrgent = false)
+    }
+
+    @Test
+    fun `headroom below a single day of growth is one day, never zero`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = 1_000_000_000L),
+            current = current(free = floor + 1),
+        ) shouldBe StorageForecast.Filling(daysUntilFloor = 1, bytesPerDay = 1_000_000_000L, isUrgent = true)
+    }
+
+    @Test
+    fun `a partial day rounds up`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = 1_000_000_000L),
+            current = current(free = floor + 2_500_000_000L),
+        ) shouldBe StorageForecast.Filling(daysUntilFloor = 3, bytesPerDay = 1_000_000_000L, isUrgent = true)
+    }
+
+    @Test
+    fun `an exact day count is not rounded up further`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = 1_000_000_000L),
+            current = current(free = floor + 3_000_000_000L),
+        ) shouldBe StorageForecast.Filling(daysUntilFloor = 3, bytesPerDay = 1_000_000_000L, isUrgent = true)
+    }
+
+    @Test
+    fun `exactly at the display horizon still forecasts`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate),
+            current = current(free = floor + minRate * StorageForecaster.DISPLAY_HORIZON_DAYS),
+        ) shouldBe StorageForecast.Filling(
+            daysUntilFloor = StorageForecaster.DISPLAY_HORIZON_DAYS,
+            bytesPerDay = minRate,
+            isUrgent = false,
+        )
+    }
+
+    @Test
+    fun `one byte past the display horizon is stable`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate),
+            current = current(free = floor + minRate * StorageForecaster.DISPLAY_HORIZON_DAYS + 1),
+        ) shouldBe StorageForecast.Stable
+    }
+
+    @Test
+    fun `exactly at the urgent day count is urgent`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate),
+            current = current(free = floor + minRate * StorageForecaster.URGENT_DAYS),
+        ) shouldBe StorageForecast.Filling(
+            daysUntilFloor = StorageForecaster.URGENT_DAYS,
+            bytesPerDay = minRate,
+            isUrgent = true,
+        )
+    }
+
+    @Test
+    fun `one byte past the urgent day count is not urgent`() {
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate),
+            current = current(free = floor + minRate * StorageForecaster.URGENT_DAYS + 1),
+        ) shouldBe StorageForecast.Filling(
+            daysUntilFloor = StorageForecaster.URGENT_DAYS + 1,
+            bytesPerDay = minRate,
+            isUrgent = false,
+        )
+    }
+
+    @Test
+    fun `a roomy device is not urgent even when the floor is days away`() {
+        // 25 GB free on a 100 GB device is above the urgency ceiling, so a 5 day estimate still
+        // renders calm: there is plenty of room to react.
+        StorageForecaster.forecast(
+            history = history(ratePerDay = 5_000_000_000L),
+            current = current(free = 25_000_000_000L),
+        ) shouldBe StorageForecast.Filling(daysUntilFloor = 5, bytesPerDay = 5_000_000_000L, isUrgent = false)
+    }
+
+    @Test
+    fun `the live reading wins over a stale history`() {
+        // Sampling is six-hourly: a download since the newest persisted row can already have
+        // crossed the floor while the history still describes a comfortable fill rate.
+        StorageForecaster.forecast(
+            history = history(ratePerDay = minRate),
+            current = current(free = floor - 1),
+        ) shouldBe StorageForecast.BelowFloor
+    }
+}

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageTrendCalculatorTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageTrendCalculatorTest.kt
@@ -158,6 +158,24 @@ class StorageTrendCalculatorTest : BaseTest() {
     }
 
     @Test
+    fun `alternating capacities leave only the surviving pairs as usable rates`() {
+        // A ROM whose capacity flips between the StorageStatsManager and the File fallback still
+        // fills every day bucket, but almost every pair is unusable.
+        val snapshots = listOf(
+            snap(day = 0, used = 100, capacity = 1000),
+            snap(day = 1, used = 1100, capacity = 2000),
+            snap(day = 2, used = 200, capacity = 1000),
+            snap(day = 3, used = 1200, capacity = 2000),
+            snap(day = 4, used = 1300, capacity = 2000),
+        )
+        val trend = StorageTrendCalculator.dailyTrend(snapshots).shouldNotBeNull()
+        trend.observedDays shouldBe 5
+        trend.usableRateCount shouldBe 1
+        trend.bytesPerDay shouldBe 100L
+        trend.spreadBytes shouldBe 0L
+    }
+
+    @Test
     fun `a capacity change on every pair leaves no rate at all`() {
         val snapshots = listOf(
             snap(day = 0, used = 100, capacity = 1000),

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageTrendCalculatorTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/forecast/StorageTrendCalculatorTest.kt
@@ -1,0 +1,258 @@
+package eu.darken.sdmse.stats.core.forecast
+
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class StorageTrendCalculatorTest : BaseTest() {
+
+    private val base = LocalDate.parse("2026-06-01")
+    private val capacity = 1_000_000L
+
+    private fun raw(
+        day: Long,
+        free: Long,
+        capacity: Long,
+        id: Long = 0L,
+        hour: Long = 12L,
+    ) = SpaceSnapshotEntity(
+        id = id,
+        storageId = "a",
+        recordedAt = base.plusDays(day).atStartOfDay(ZoneOffset.UTC).toInstant().plus(Duration.ofHours(hour)),
+        spaceFree = free,
+        spaceCapacity = capacity,
+    )
+
+    private fun snap(
+        day: Long,
+        used: Long,
+        capacity: Long = this.capacity,
+        id: Long = 0L,
+        hour: Long = 12L,
+    ) = raw(day = day, free = capacity - used, capacity = capacity, id = id, hour = hour)
+
+    private fun series(days: LongRange, used: (Long) -> Long) = days.map { snap(day = it, used = used(it)) }
+
+    @Test
+    fun `a steady fill yields its own rate`() {
+        val trend = StorageTrendCalculator.dailyTrend(series(0L..6L) { 20_000 + 100 * it }).shouldNotBeNull()
+        trend.bytesPerDay shouldBe 100L
+        trend.observedDays shouldBe 7
+        trend.elapsedDays shouldBe 6L
+        trend.maxGapDays shouldBe 1L
+        trend.spreadBytes shouldBe 0L
+        StorageTrendCalculator.windowTotal(series(0L..6L) { 20_000 + 100 * it }) shouldBe 600L
+    }
+
+    @Test
+    fun `a mid-window cleanup does not drag the rate down`() {
+        val snapshots = series(0L..6L) { 20_000 + 100 * it - if (it >= 3) 2_000 else 0 }
+        StorageTrendCalculator.dailyTrend(snapshots).shouldNotBeNull().bytesPerDay shouldBe 100L
+        StorageTrendCalculator.windowTotal(snapshots) shouldBe 600L
+    }
+
+    @Test
+    fun `a cleanup on the last day cannot flip a filling window negative`() {
+        // The task coordinator forces a snapshot after every task, so the newest point of a window
+        // that ends in a cleanup shows sharply more free space. First-to-last would report -50.
+        val snapshots = series(0L..6L) { if (it == 6L) 19_950 else 20_000 + 100 * it }
+        rawFirstToLast(snapshots) shouldBe -50L
+        StorageTrendCalculator.windowTotal(snapshots) shouldBe 600L
+    }
+
+    @Test
+    fun `a single large install does not inflate the rate`() {
+        val snapshots = series(0L..6L) { 20_000 + 100 * it + if (it >= 3) 47_000 else 0 }
+        StorageTrendCalculator.dailyTrend(snapshots).shouldNotBeNull().bytesPerDay shouldBe 100L
+        StorageTrendCalculator.windowTotal(snapshots) shouldBe 600L
+    }
+
+    @Test
+    fun `input order does not matter`() {
+        val snapshots = series(0L..6L) { 20_000 + 100 * it }
+        StorageTrendCalculator.windowTotal(snapshots.shuffled()) shouldBe 600L
+    }
+
+    @Test
+    fun `equal timestamps are broken by id, highest wins the bucket`() {
+        val snapshots = listOf(
+            snap(day = 0, used = 100, id = 2),
+            snap(day = 0, used = 300, id = 7),
+            snap(day = 1, used = 400, id = 9),
+        )
+        StorageTrendCalculator.dailyTrend(snapshots).shouldNotBeNull().bytesPerDay shouldBe 100L
+        StorageTrendCalculator.windowTotal(snapshots) shouldBe 100L
+    }
+
+    @Test
+    fun `a missing intermediate day still totals the true span`() {
+        val snapshots = listOf(
+            snap(day = 0, used = 100),
+            snap(day = 2, used = 300),
+        )
+        val trend = StorageTrendCalculator.dailyTrend(snapshots).shouldNotBeNull()
+        trend.bytesPerDay shouldBe 100L
+        trend.observedDays shouldBe 2
+        trend.elapsedDays shouldBe 2L
+        StorageTrendCalculator.windowTotal(snapshots) shouldBe 200L
+    }
+
+    @Test
+    fun `gaps are reported as the largest hole between buckets`() {
+        val oneDay = listOf(snap(day = 0, used = 100), snap(day = 1, used = 200))
+        StorageTrendCalculator.dailyTrend(oneDay).shouldNotBeNull().maxGapDays shouldBe 1L
+
+        val twoDays = listOf(
+            snap(day = 0, used = 100),
+            snap(day = 1, used = 200),
+            snap(day = 3, used = 400),
+        )
+        val trend = StorageTrendCalculator.dailyTrend(twoDays).shouldNotBeNull()
+        trend.maxGapDays shouldBe 2L
+        trend.observedDays shouldBe 3
+        trend.elapsedDays shouldBe 3L
+    }
+
+    @Test
+    fun `same-day snapshots have no daily trend but keep a raw window total`() {
+        val snapshots = listOf(
+            snap(day = 0, used = 100, hour = 1),
+            snap(day = 0, used = 200, hour = 2),
+        )
+        StorageTrendCalculator.dailyTrend(snapshots).shouldBeNull()
+        StorageTrendCalculator.windowTotal(snapshots) shouldBe 100L
+    }
+
+    @Test
+    fun `a single snapshot has neither trend nor total`() {
+        val snapshots = listOf(snap(day = 0, used = 100))
+        StorageTrendCalculator.dailyTrend(snapshots).shouldBeNull()
+        StorageTrendCalculator.windowTotal(snapshots).shouldBeNull()
+    }
+
+    @Test
+    fun `an empty history has neither trend nor total`() {
+        StorageTrendCalculator.dailyTrend(emptyList()).shouldBeNull()
+        StorageTrendCalculator.windowTotal(emptyList()).shouldBeNull()
+    }
+
+    @Test
+    fun `a capacity change skips the pair it spans`() {
+        val snapshots = listOf(
+            snap(day = 0, used = 100, capacity = 1000),
+            snap(day = 1, used = 200, capacity = 1000),
+            snap(day = 2, used = 1200, capacity = 2000),
+            snap(day = 3, used = 1300, capacity = 2000),
+        )
+        val trend = StorageTrendCalculator.dailyTrend(snapshots).shouldNotBeNull()
+        trend.bytesPerDay shouldBe 100L
+        trend.spreadBytes shouldBe 0L
+        trend.elapsedDays shouldBe 3L
+        StorageTrendCalculator.windowTotal(snapshots) shouldBe 300L
+    }
+
+    @Test
+    fun `a capacity change on every pair leaves no rate at all`() {
+        val snapshots = listOf(
+            snap(day = 0, used = 100, capacity = 1000),
+            snap(day = 1, used = 200, capacity = 2000),
+            snap(day = 2, used = 300, capacity = 3000),
+        )
+        StorageTrendCalculator.dailyTrend(snapshots).shouldBeNull()
+    }
+
+    @Test
+    fun `invalid rows are dropped before anything else`() {
+        val snapshots = listOf(
+            snap(day = 0, used = 100),
+            raw(day = 1, free = -5, capacity = capacity),
+            raw(day = 2, free = capacity + 1, capacity = capacity),
+            raw(day = 3, free = 0, capacity = 0),
+            snap(day = 4, used = 500),
+        )
+        val trend = StorageTrendCalculator.dailyTrend(snapshots).shouldNotBeNull()
+        trend.observedDays shouldBe 2
+        trend.elapsedDays shouldBe 4L
+        trend.maxGapDays shouldBe 4L
+        trend.bytesPerDay shouldBe 100L
+        StorageTrendCalculator.windowTotal(snapshots) shouldBe 400L
+    }
+
+    @Test
+    fun `a cleanup outlier at the minimum length leaves the spread at zero`() {
+        // Four rates of [1, 1, 1, -100]: the interquartile range would call this erratic, the
+        // median absolute deviation correctly reports no spread at all.
+        val snapshots = listOf(
+            snap(day = 0, used = 1000),
+            snap(day = 1, used = 1001),
+            snap(day = 2, used = 1002),
+            snap(day = 3, used = 1003),
+            snap(day = 4, used = 903),
+        )
+        val trend = StorageTrendCalculator.dailyTrend(snapshots).shouldNotBeNull()
+        trend.observedDays shouldBe 5
+        trend.bytesPerDay shouldBe 1L
+        trend.spreadBytes shouldBe 0L
+    }
+
+    @Test
+    fun `an install outlier at the minimum length leaves the spread at zero`() {
+        val snapshots = listOf(
+            snap(day = 0, used = 1000),
+            snap(day = 1, used = 1001),
+            snap(day = 2, used = 1002),
+            snap(day = 3, used = 1003),
+            snap(day = 4, used = 1103),
+        )
+        val trend = StorageTrendCalculator.dailyTrend(snapshots).shouldNotBeNull()
+        trend.bytesPerDay shouldBe 1L
+        trend.spreadBytes shouldBe 0L
+    }
+
+    @Test
+    fun `a genuinely erratic series has a spread larger than its rate`() {
+        val snapshots = listOf(
+            snap(day = 0, used = 1000),
+            snap(day = 1, used = 1100),
+            snap(day = 2, used = 800),
+            snap(day = 3, used = 1300),
+            snap(day = 4, used = 1100),
+        )
+        val trend = StorageTrendCalculator.dailyTrend(snapshots).shouldNotBeNull()
+        trend.bytesPerDay shouldBe -50L
+        trend.spreadBytes shouldBe 200L
+    }
+
+    @Test
+    fun `a 7 day window with a cleanup totals the honest fill`() {
+        val snapshots = series(0L..6L) { 20_000 + 100 * it - if (it >= 5) 3_000 else 0 }
+        rawFirstToLast(snapshots) shouldBe -2_400L
+        StorageTrendCalculator.windowTotal(snapshots) shouldBe 600L
+    }
+
+    @Test
+    fun `a 30 day window with a cleanup totals the honest fill`() {
+        val snapshots = series(0L..29L) { 20_000 + 100 * it - if (it >= 20) 5_000 else 0 }
+        rawFirstToLast(snapshots) shouldBe -2_100L
+        StorageTrendCalculator.windowTotal(snapshots) shouldBe 2_900L
+    }
+
+    @Test
+    fun `a 90 day window with a cleanup totals the honest fill`() {
+        val snapshots = series(0L..89L) { 20_000 + 100 * it - if (it >= 60) 8_000 else 0 }
+        rawFirstToLast(snapshots) shouldBe 900L
+        StorageTrendCalculator.windowTotal(snapshots) shouldBe 8_900L
+    }
+
+    private fun rawFirstToLast(snapshots: List<SpaceSnapshotEntity>): Long {
+        val sorted = snapshots.sortedBy { it.recordedAt }
+        return (sorted.last().spaceCapacity - sorted.last().spaceFree) -
+            (sorted.first().spaceCapacity - sorted.first().spaceFree)
+    }
+}

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/dialogs/SizeInputDialog.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/settings/dialogs/SizeInputDialog.kt
@@ -38,14 +38,19 @@ fun SizeInputDialog(
     onDismiss: () -> Unit,
     minimumSize: Long = 0,
     maximumSize: Long = 100L * 1000L * 1024L,
+    @StringRes resetLabelRes: Int = R.string.general_reset_action,
 ) {
     val context = LocalContext.current
     val sizeParser = remember(context) { SizeParser(context) }
 
-    val minKb = minimumSize / KB_MULTIPLIER
-    val maxKb = maximumSize / KB_MULTIPLIER
+    // An inverted range would throw out of coerceIn() and out of the slider's valueRange. Every
+    // current caller passes max > min, so this only guards future ones.
+    val effectiveMax = maxOf(maximumSize, minimumSize)
 
-    val initialValue = currentSize.coerceIn(minimumSize, maximumSize)
+    val minKb = minimumSize / KB_MULTIPLIER
+    val maxKb = effectiveMax / KB_MULTIPLIER
+
+    val initialValue = currentSize.coerceIn(minimumSize, effectiveMax)
 
     var sliderKb by remember { mutableStateOf(initialValue.toFloat() / KB_MULTIPLIER) }
     var textValue by remember { mutableStateOf(Formatter.formatShortFileSize(context, initialValue)) }
@@ -63,14 +68,14 @@ fun SizeInputDialog(
                         textValue = raw
                         val parsed = sizeParser.parse(raw)
                         when {
-                            parsed != null && parsed in minimumSize..maximumSize -> {
+                            parsed != null && parsed in minimumSize..effectiveMax -> {
                                 error = null
                                 sliderKb = parsed.toFloat() / KB_MULTIPLIER
                                 saveEnabled = true
                             }
                             parsed != null -> {
                                 val minLabel = Formatter.formatShortFileSize(context, minimumSize)
-                                val maxLabel = Formatter.formatShortFileSize(context, maximumSize)
+                                val maxLabel = Formatter.formatShortFileSize(context, effectiveMax)
                                 error = "$minLabel <= X <= $maxLabel"
                                 saveEnabled = false
                             }
@@ -117,7 +122,7 @@ fun SizeInputDialog(
                     onClick = onDismiss,
                 ),
                 neutral = SdmDialogAction(
-                    label = stringResource(R.string.general_reset_action),
+                    label = stringResource(resetLabelRes),
                     onClick = onReset,
                 ),
             )

--- a/app-common-ui/src/main/res/values-night/colors.xml
+++ b/app-common-ui/src/main/res/values-night/colors.xml
@@ -45,4 +45,6 @@
     <color name="md_theme_surfaceContainer">#1C211C</color>
     <color name="md_theme_surfaceContainerHigh">#262B26</color>
     <color name="md_theme_surfaceContainerHighest">#313631</color>
+
+    <color name="md_theme_storageLow">@color/md_theme_storageLow_night</color>
 </resources>

--- a/app-common-ui/src/main/res/values/colors.xml
+++ b/app-common-ui/src/main/res/values/colors.xml
@@ -46,4 +46,11 @@
     <color name="md_theme_surfaceContainer">#EBEFE8</color>
     <color name="md_theme_surfaceContainerHigh">#E5EAE2</color>
     <color name="md_theme_surfaceContainerHighest">#DFE4DC</color>
+
+    <!-- "Storage is running out" amber. Not part of the generated Material palette: it must read as
+         a warning in both themes and stay legible on the widget's background, so it is defined once
+         here and consumed by the app, the widget bars/labels and the hand-drawn storage ring. -->
+    <color name="md_theme_storageLow_day">#8A5100</color>
+    <color name="md_theme_storageLow_night">#FFB95C</color>
+    <color name="md_theme_storageLow">@color/md_theme_storageLow_day</color>
 </resources>

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/AnalyzerSettings.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/AnalyzerSettings.kt
@@ -26,7 +26,16 @@ class AnalyzerSettings @Inject constructor(
 
     val contentLayoutMode = dataStore.createValue("ui.content.layoutmode", LayoutMode.LINEAR, json)
 
+    /**
+     * When free space drops to or below this, storage counts as running out.
+     * `null` means automatic, see [eu.darken.sdmse.stats.core.LowStorage.resolveThreshold].
+     */
+    val lowStorageThresholdBytes = dataStore.createValue<Long?>("storage.low.threshold.bytes", null)
+
     companion object {
         internal val TAG = logTag("Analyzer", "Settings")
+
+        const val LOW_STORAGE_THRESHOLD_MIN = 100L * 1024 * 1024
+        const val LOW_STORAGE_THRESHOLD_MAX = 32L * 1024 * 1024 * 1024
     }
 }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/AnalyzerSettings.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/AnalyzerSettings.kt
@@ -32,6 +32,19 @@ class AnalyzerSettings @Inject constructor(
      */
     val lowStorageThresholdBytes = dataStore.createValue<Long?>("storage.low.threshold.bytes", null)
 
+    /** Pro-gated: warn before the device runs out of space. */
+    val lowSpaceNotificationEnabled = dataStore.createValue("storage.low.notification.enabled", false)
+
+    /**
+     * Transition latch: `true` means "a crossing into the warning band may notify".
+     *
+     * Runtime state, not a preference, and therefore excluded from backup
+     * (see [eu.darken.sdmse.analyzer.core.backup.AnalyzerSettingsBackupContributor]).
+     */
+    val lowSpaceNotificationArmed = dataStore.createValue("storage.low.notification.armed", true)
+
+    val hintLowSpaceDismissed = dataStore.createValue("hint.lowspace.dismissed", false)
+
     companion object {
         internal val TAG = logTag("Analyzer", "Settings")
 

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/backup/AnalyzerSettingsBackupContributor.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/backup/AnalyzerSettingsBackupContributor.kt
@@ -16,6 +16,10 @@ class AnalyzerSettingsBackupContributor @Inject constructor(
     settings: AnalyzerSettings,
 ) : DataStoreSettingsBackupContributor(settings.dataStore) {
     override val key = "analyzer"
+
+    // The armed latch is runtime state, not a preference: restoring `armed = false` onto a fresh
+    // install would suppress that device's first low-space warning indefinitely.
+    override val excludedKeys = setOf("storage.low.notification.armed")
 }
 
 @Module

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/AnalyzerNavigation.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/AnalyzerNavigation.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.analyzer.ui
 
 import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
+import eu.darken.sdmse.analyzer.ui.settings.AnalyzerSettingsScreenHost
 import eu.darken.sdmse.analyzer.ui.storage.app.AppDetailsScreenHost
 import eu.darken.sdmse.analyzer.ui.storage.apps.AppsScreenHost
 import eu.darken.sdmse.analyzer.ui.storage.content.ContentScreenHost
@@ -14,6 +15,7 @@ import javax.inject.Inject
 class AnalyzerNavigation @Inject constructor() : NavigationEntry {
 
     override fun EntryProviderScope<NavKey>.setup() {
+        entry<AnalyzerSettingsRoute> { AnalyzerSettingsScreenHost() }
         entry<DeviceStorageRoute> { DeviceStorageScreenHost() }
         entry<StorageContentRoute> { route -> StorageContentScreenHost(route = route) }
         entry<AppsRoute> { route -> AppsScreenHost(route = route) }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/AnalyzerRoutes.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/AnalyzerRoutes.kt
@@ -7,6 +7,9 @@ import eu.darken.sdmse.common.storage.StorageId
 import kotlinx.serialization.Serializable
 
 @Serializable
+data object AnalyzerSettingsRoute : NavigationDestination
+
+@Serializable
 data class StorageContentRoute(
     val storageId: StorageId,
 ) : NavigationDestination

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.twotone.NotificationImportant
 import androidx.compose.material.icons.twotone.Storage
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -26,6 +27,7 @@ import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.settings.SettingsCategoryHeader
 import eu.darken.sdmse.common.compose.settings.SettingsPreferenceItem
+import eu.darken.sdmse.common.compose.settings.SettingsSwitchItem
 import eu.darken.sdmse.common.compose.settings.dialogs.SizeInputDialog
 import eu.darken.sdmse.common.error.ErrorEventHandler
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
@@ -44,6 +46,8 @@ fun AnalyzerSettingsScreenHost(
         state = state,
         onNavigateUp = vm::navUp,
         onThresholdChanged = vm::setThreshold,
+        onNotificationChanged = vm::setNotificationEnabled,
+        onUpgradeClick = vm::onUpgradeClick,
     )
 }
 
@@ -52,6 +56,8 @@ internal fun AnalyzerSettingsScreen(
     state: AnalyzerSettingsViewModel.State = AnalyzerSettingsViewModel.State(),
     onNavigateUp: () -> Unit = {},
     onThresholdChanged: (Long?) -> Unit = {},
+    onNotificationChanged: (Boolean) -> Unit = {},
+    onUpgradeClick: () -> Unit = {},
 ) {
     var showThresholdDialog by remember { mutableStateOf(false) }
     val context = LocalContext.current
@@ -117,6 +123,18 @@ internal fun AnalyzerSettingsScreen(
                     onClick = { showThresholdDialog = true },
                 )
             }
+            item {
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.NotificationImportant,
+                    title = stringResource(R.string.analyzer_settings_lowspace_notification_title),
+                    subtitle = stringResource(R.string.analyzer_settings_lowspace_notification_desc),
+                    // Unchecked while not Pro regardless of the stored value.
+                    checked = state.isPro && state.notificationEnabled,
+                    onCheckedChange = onNotificationChanged,
+                    requiresUpgrade = !state.isPro,
+                    onUpgrade = onUpgradeClick,
+                )
+            }
         }
     }
 }
@@ -144,6 +162,22 @@ private fun AnalyzerSettingsScreenCustomPreview() {
                 customThresholdBytes = 10L * 1000 * 1000 * 1000,
                 primaryCapacityBytes = 128L * 1000 * 1000 * 1000,
                 effectiveThresholdBytes = 10L * 1000 * 1000 * 1000,
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun AnalyzerSettingsScreenProPreview() {
+    PreviewWrapper {
+        AnalyzerSettingsScreen(
+            state = AnalyzerSettingsViewModel.State(
+                customThresholdBytes = null,
+                primaryCapacityBytes = 128L * 1000 * 1000 * 1000,
+                effectiveThresholdBytes = LowStorage.AUTO_MAX_BYTES,
+                notificationEnabled = true,
+                isPro = true,
             ),
         )
     }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreen.kt
@@ -1,0 +1,150 @@
+package eu.darken.sdmse.analyzer.ui.settings
+
+import android.text.format.Formatter
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.twotone.Storage
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import eu.darken.sdmse.analyzer.R
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.common.compose.layout.SdmScaffold
+import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.compose.settings.SettingsCategoryHeader
+import eu.darken.sdmse.common.compose.settings.SettingsPreferenceItem
+import eu.darken.sdmse.common.compose.settings.dialogs.SizeInputDialog
+import eu.darken.sdmse.common.error.ErrorEventHandler
+import eu.darken.sdmse.common.navigation.NavigationEventHandler
+import eu.darken.sdmse.stats.core.LowStorage
+import eu.darken.sdmse.common.R as CommonR
+
+@Composable
+fun AnalyzerSettingsScreenHost(
+    vm: AnalyzerSettingsViewModel = hiltViewModel(),
+) {
+    ErrorEventHandler(vm)
+    NavigationEventHandler(vm)
+    val state by vm.state.collectAsStateWithLifecycle()
+
+    AnalyzerSettingsScreen(
+        state = state,
+        onNavigateUp = vm::navUp,
+        onThresholdChanged = vm::setThreshold,
+    )
+}
+
+@Composable
+internal fun AnalyzerSettingsScreen(
+    state: AnalyzerSettingsViewModel.State = AnalyzerSettingsViewModel.State(),
+    onNavigateUp: () -> Unit = {},
+    onThresholdChanged: (Long?) -> Unit = {},
+) {
+    var showThresholdDialog by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+
+    val thresholdValue = when {
+        state.customThresholdBytes != null -> Formatter.formatShortFileSize(context, state.customThresholdBytes)
+        state.effectiveThresholdBytes != null -> stringResource(
+            R.string.analyzer_settings_lowstorage_value_auto,
+            Formatter.formatShortFileSize(context, state.effectiveThresholdBytes),
+        )
+        else -> stringResource(R.string.analyzer_settings_lowstorage_value_auto_unknown)
+    }
+
+    if (showThresholdDialog) {
+        SizeInputDialog(
+            titleRes = R.string.analyzer_settings_lowstorage_title,
+            currentSize = state.customThresholdBytes
+                ?: state.effectiveThresholdBytes
+                ?: LowStorage.AUTO_MAX_BYTES,
+            minimumSize = AnalyzerSettings.LOW_STORAGE_THRESHOLD_MIN,
+            // Deliberately a fixed ceiling, not one derived from this device's capacity: a
+            // capacity-derived maximum would silently rewrite a restored custom value on Save,
+            // and on a small device it could fall below the minimum and invert the range.
+            maximumSize = AnalyzerSettings.LOW_STORAGE_THRESHOLD_MAX,
+            resetLabelRes = R.string.analyzer_settings_lowstorage_automatic_action,
+            onSave = {
+                onThresholdChanged(it)
+                showThresholdDialog = false
+            },
+            onReset = {
+                onThresholdChanged(null)
+                showThresholdDialog = false
+            },
+            onDismiss = { showThresholdDialog = false },
+        )
+    }
+
+    SdmScaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(CommonR.string.analyzer_tool_name)) },
+                navigationIcon = {
+                    SdmTooltipIconButton(
+                        icon = Icons.AutoMirrored.TwoTone.ArrowBack,
+                        label = stringResource(CommonR.string.general_navigate_up_action),
+                        onClick = onNavigateUp,
+                    )
+                },
+            )
+        },
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = paddingValues,
+        ) {
+            item { SettingsCategoryHeader(text = stringResource(R.string.analyzer_settings_storage_category_label)) }
+            item {
+                SettingsPreferenceItem(
+                    icon = Icons.TwoTone.Storage,
+                    title = stringResource(R.string.analyzer_settings_lowstorage_title),
+                    subtitle = stringResource(R.string.analyzer_settings_lowstorage_desc),
+                    value = thresholdValue,
+                    onClick = { showThresholdDialog = true },
+                )
+            }
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun AnalyzerSettingsScreenAutomaticPreview() {
+    PreviewWrapper {
+        AnalyzerSettingsScreen(
+            state = AnalyzerSettingsViewModel.State(
+                customThresholdBytes = null,
+                primaryCapacityBytes = 128L * 1000 * 1000 * 1000,
+                effectiveThresholdBytes = LowStorage.AUTO_MAX_BYTES,
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun AnalyzerSettingsScreenCustomPreview() {
+    PreviewWrapper {
+        AnalyzerSettingsScreen(
+            state = AnalyzerSettingsViewModel.State(
+                customThresholdBytes = 10L * 1000 * 1000 * 1000,
+                primaryCapacityBytes = 128L * 1000 * 1000 * 1000,
+                effectiveThresholdBytes = 10L * 1000 * 1000 * 1000,
+            ),
+        )
+    }
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModel.kt
@@ -6,12 +6,15 @@ import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
 import eu.darken.sdmse.common.uix.ViewModel4
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.stats.core.LowStorage
 import eu.darken.sdmse.stats.core.SpaceTracker
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 
@@ -20,6 +23,7 @@ class AnalyzerSettingsViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val settings: AnalyzerSettings,
     private val spaceTracker: SpaceTracker,
+    upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
 
     // A single reading is enough: capacity only informs the "currently X" hint next to Automatic.
@@ -31,11 +35,15 @@ class AnalyzerSettingsViewModel @Inject constructor(
     val state: StateFlow<State> = combine(
         settings.lowStorageThresholdBytes.flow,
         primaryCapacity,
-    ) { custom, capacity ->
+        settings.lowSpaceNotificationEnabled.flow,
+        upgradeRepo.upgradeInfo.map { it.isPro },
+    ) { custom, capacity, notificationEnabled, isPro ->
         State(
             customThresholdBytes = custom,
             primaryCapacityBytes = capacity,
             effectiveThresholdBytes = capacity?.let { LowStorage.resolveThreshold(it, custom) },
+            notificationEnabled = notificationEnabled,
+            isPro = isPro,
         )
     }.safeStateIn(
         initialValue = State(),
@@ -47,10 +55,25 @@ class AnalyzerSettingsViewModel @Inject constructor(
         settings.lowStorageThresholdBytes.value(bytes)
     }
 
+    fun setNotificationEnabled(enabled: Boolean) = launch {
+        log(TAG) { "setNotificationEnabled($enabled)" }
+        // Defence-in-depth: the row is gated behind the upgrade badge when not Pro, but refuse
+        // here too so a future caller can't bypass the gate.
+        if (!state.value.isPro) return@launch
+        settings.lowSpaceNotificationEnabled.value(enabled)
+    }
+
+    fun onUpgradeClick() {
+        log(TAG) { "onUpgradeClick()" }
+        navTo(UpgradeRoute(forced = true))
+    }
+
     data class State(
         val customThresholdBytes: Long? = null,
         val primaryCapacityBytes: Long? = null,
         val effectiveThresholdBytes: Long? = null,
+        val notificationEnabled: Boolean = false,
+        val isPro: Boolean = false,
     )
 
     companion object {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModel.kt
@@ -1,0 +1,59 @@
+package eu.darken.sdmse.analyzer.ui.settings
+
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.uix.ViewModel4
+import eu.darken.sdmse.stats.core.LowStorage
+import eu.darken.sdmse.stats.core.SpaceTracker
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+
+@HiltViewModel
+class AnalyzerSettingsViewModel @Inject constructor(
+    dispatcherProvider: DispatcherProvider,
+    private val settings: AnalyzerSettings,
+    private val spaceTracker: SpaceTracker,
+) : ViewModel4(dispatcherProvider, tag = TAG) {
+
+    // A single reading is enough: capacity only informs the "currently X" hint next to Automatic.
+    // readPrimaryStorage() can return a non-null 0/0 reading, which would render "currently 0 B".
+    private val primaryCapacity = flow {
+        emit(spaceTracker.readPrimaryStorage()?.spaceCapacity?.takeIf { it > 0L })
+    }
+
+    val state: StateFlow<State> = combine(
+        settings.lowStorageThresholdBytes.flow,
+        primaryCapacity,
+    ) { custom, capacity ->
+        State(
+            customThresholdBytes = custom,
+            primaryCapacityBytes = capacity,
+            effectiveThresholdBytes = capacity?.let { LowStorage.resolveThreshold(it, custom) },
+        )
+    }.safeStateIn(
+        initialValue = State(),
+        onError = { State() },
+    )
+
+    fun setThreshold(bytes: Long?) = launch {
+        log(TAG) { "setThreshold($bytes)" }
+        settings.lowStorageThresholdBytes.value(bytes)
+    }
+
+    data class State(
+        val customThresholdBytes: Long? = null,
+        val primaryCapacityBytes: Long? = null,
+        val effectiveThresholdBytes: Long? = null,
+    )
+
+    companion object {
+        private val TAG = logTag("Settings", "Analyzer", "ViewModel")
+    }
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageItemCard.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageItemCard.kt
@@ -37,6 +37,7 @@ import eu.darken.sdmse.common.ByteFormatter
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import eu.darken.sdmse.stats.core.forecast.StorageTrendCalculator
 import java.time.Duration
 import java.time.Instant
 import kotlin.math.absoluteValue
@@ -204,9 +205,11 @@ private fun TrendDeltaText(
     snapshots: List<SpaceSnapshotEntity>,
 ) {
     val context = LocalContext.current
-    val oldest = snapshots.first().let { it.spaceCapacity - it.spaceFree }
-    val newest = snapshots.last().let { it.spaceCapacity - it.spaceFree }
-    val delta = newest - oldest
+    val delta = StorageTrendCalculator.windowTotal(snapshots)
+    if (delta == null) {
+        Spacer(modifier = modifier)
+        return
+    }
     val absDelta = Formatter.formatShortFileSize(context, delta.absoluteValue)
     val signed = when {
         delta > 0 -> "+$absDelta"

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -61,6 +62,8 @@ fun DeviceStorageScreenHost(
         onStorageClick = vm::onStorageClick,
         onTrendClick = vm::onTrendClick,
         onRefresh = vm::refresh,
+        onLowSpaceHintDismiss = vm::dismissLowSpaceHint,
+        onLowSpaceHintUpgrade = vm::openUpgrade,
     )
 }
 
@@ -71,6 +74,8 @@ internal fun DeviceStorageScreen(
     onStorageClick: (DeviceStorageViewModel.Row) -> Unit = {},
     onTrendClick: (DeviceStorageViewModel.Row) -> Unit = {},
     onRefresh: () -> Unit = {},
+    onLowSpaceHintDismiss: () -> Unit = {},
+    onLowSpaceHintUpgrade: () -> Unit = {},
 ) {
     val state by stateSource.collectAsStateWithLifecycle()
     val context = LocalContext.current
@@ -138,6 +143,14 @@ internal fun DeviceStorageScreen(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
+                if (state.showLowSpaceHint) {
+                    item(key = "lowspace-hint", span = { GridItemSpan(maxLineSpan) }) {
+                        LowSpaceHintCard(
+                            onDismiss = onLowSpaceHintDismiss,
+                            onUpgrade = onLowSpaceHintUpgrade,
+                        )
+                    }
+                }
                 itemsIndexed(state.storages, key = { _, it -> it.storage.id.hashCode() }) { index, row ->
                     DeviceStorageItemCard(
                         modifier = if (index == 0) {
@@ -160,5 +173,15 @@ internal fun DeviceStorageScreen(
 private fun DeviceStorageScreenEmptyPreview() {
     PreviewWrapper {
         DeviceStorageScreen()
+    }
+}
+
+@Preview2
+@Composable
+private fun DeviceStorageScreenLowSpaceHintPreview() {
+    PreviewWrapper {
+        DeviceStorageScreen(
+            stateSource = MutableStateFlow(DeviceStorageViewModel.State(showLowSpaceHint = true)),
+        )
     }
 }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModel.kt
@@ -2,11 +2,13 @@ package eu.darken.sdmse.analyzer.ui.storage.device
 
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
 import eu.darken.sdmse.analyzer.core.device.DeviceStorageScanTask
 import eu.darken.sdmse.analyzer.ui.StorageContentRoute
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.intervalFlow
 import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
@@ -33,6 +35,7 @@ import kotlin.time.Duration.Companion.hours
 class DeviceStorageViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val analyzer: Analyzer,
+    private val analyzerSettings: AnalyzerSettings,
     spaceHistoryRepo: SpaceHistoryRepo,
     upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
@@ -54,7 +57,8 @@ class DeviceStorageViewModel @Inject constructor(
             spaceHistoryRepo.getAllHistory(Instant.now() - Duration.ofDays(7))
         },
         upgradeRepo.upgradeInfo.map { it.isPro },
-    ) { data, snapshots, isPro ->
+        analyzerSettings.hintLowSpaceDismissed.flow,
+    ) { data, snapshots, isPro, hintDismissed ->
         val snapshotsByStorage = snapshots.groupBy { it.storageId }
         State(
             storages = data.storages.map { storage ->
@@ -66,6 +70,7 @@ class DeviceStorageViewModel @Inject constructor(
                     isPro = isPro,
                 )
             },
+            showLowSpaceHint = !isPro && !hintDismissed,
         )
     }
 
@@ -105,9 +110,22 @@ class DeviceStorageViewModel @Inject constructor(
         val isPro: Boolean = false,
     )
 
+    // No re-arm: unlike the scheduler's battery hint there is no condition that can clear and
+    // legitimately raise this pitch again.
+    fun dismissLowSpaceHint() = launch {
+        log(TAG) { "dismissLowSpaceHint()" }
+        analyzerSettings.hintLowSpaceDismissed.value(true)
+    }
+
+    fun openUpgrade() {
+        log(TAG) { "openUpgrade()" }
+        navTo(UpgradeRoute())
+    }
+
     data class State(
         val storages: List<Row> = emptyList(),
         val progress: Progress.Data? = null,
+        val showLowSpaceHint: Boolean = false,
     )
 
     companion object {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/LowSpaceHintCard.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/LowSpaceHintCard.kt
@@ -1,0 +1,87 @@
+package eu.darken.sdmse.analyzer.ui.storage.device
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.NotificationImportant
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.analyzer.R
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.R as CommonR
+
+@Composable
+internal fun LowSpaceHintCard(
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit = {},
+    onUpgrade: () -> Unit = {},
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        ),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.TwoTone.NotificationImportant,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.analyzer_lowspace_hint_title),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+            Spacer(modifier = Modifier.padding(vertical = 4.dp))
+            Text(
+                text = stringResource(R.string.analyzer_lowspace_hint_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(modifier = Modifier.padding(vertical = 4.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(CommonR.string.general_dismiss_action))
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(onClick = onUpgrade) {
+                    Text(stringResource(CommonR.string.general_upgrade_action))
+                }
+            }
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun LowSpaceHintCardPreview() {
+    PreviewWrapper {
+        LowSpaceHintCard(modifier = Modifier.padding(16.dp))
+    }
+}

--- a/app-tool-analyzer/src/main/res/values/strings.xml
+++ b/app-tool-analyzer/src/main/res/values/strings.xml
@@ -63,6 +63,12 @@
     <string name="analyzer_settings_lowstorage_value_auto">Automatic (currently %1$s)</string>
     <string name="analyzer_settings_lowstorage_value_auto_unknown">Automatic</string>
     <string name="analyzer_settings_lowstorage_automatic_action">Automatic</string>
+    <string name="analyzer_settings_lowspace_notification_title">Low space warning</string>
+    <string name="analyzer_settings_lowspace_notification_desc">Get a notification before your storage runs out.</string>
+
+    <!-- Device storage upgrade hint -->
+    <string name="analyzer_lowspace_hint_title">Never get caught out of space</string>
+    <string name="analyzer_lowspace_hint_body">Upgrade to get a warning before your storage runs out, so you can clean up while there is still room to work with.</string>
 
     <!-- Guided tour -->
     <string name="tour_analyzer_intro_body">See what\'s actually filling up your storage. The Analyzer maps out where your space goes. Each of these cards is a storage chip on your device.</string>

--- a/app-tool-analyzer/src/main/res/values/strings.xml
+++ b/app-tool-analyzer/src/main/res/values/strings.xml
@@ -51,6 +51,10 @@
     <string name="analyzer_app_details_app_occupies_x_on_y">This app occupies %1$s on \"%2$s\".</string>
     <string name="analyzer_app_details_app_is_archived">This app has been archived.</string>
     <string name="analyzer_storage_trend_delta_in_7d">%s in 7d</string>
+    <plurals name="analyzer_storage_forecast_days">
+        <item quantity="one">About %d day of space left at this rate</item>
+        <item quantity="other">About %d days of space left at this rate</item>
+    </plurals>
 
     <!-- Guided tour -->
     <string name="tour_analyzer_intro_body">See what\'s actually filling up your storage. The Analyzer maps out where your space goes. Each of these cards is a storage chip on your device.</string>

--- a/app-tool-analyzer/src/main/res/values/strings.xml
+++ b/app-tool-analyzer/src/main/res/values/strings.xml
@@ -56,6 +56,14 @@
         <item quantity="other">About %d days of space left at this rate</item>
     </plurals>
 
+    <!-- Settings -->
+    <string name="analyzer_settings_storage_category_label">Storage</string>
+    <string name="analyzer_settings_lowstorage_title">Low storage threshold</string>
+    <string name="analyzer_settings_lowstorage_desc">When free space drops below this, SD Maid treats the storage as running out.</string>
+    <string name="analyzer_settings_lowstorage_value_auto">Automatic (currently %1$s)</string>
+    <string name="analyzer_settings_lowstorage_value_auto_unknown">Automatic</string>
+    <string name="analyzer_settings_lowstorage_automatic_action">Automatic</string>
+
     <!-- Guided tour -->
     <string name="tour_analyzer_intro_body">See what\'s actually filling up your storage. The Analyzer maps out where your space goes. Each of these cards is a storage chip on your device.</string>
     <string name="tour_analyzer_storage_body">Open a storage to break it down into apps, media and files, then keep tapping to track down the biggest culprits.</string>

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/backup/AnalyzerSettingsBackupContributorTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/backup/AnalyzerSettingsBackupContributorTest.kt
@@ -1,0 +1,74 @@
+package eu.darken.sdmse.analyzer.core.backup
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.common.backup.RestoreMode
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import java.nio.file.Path
+
+class AnalyzerSettingsBackupContributorTest : BaseTest() {
+
+    @Test
+    fun `the armed latch is excluded from a backup snapshot`(@TempDir tempDir: Path) = runTest {
+        // The latch is runtime state: restoring armed=false onto a fresh install would suppress
+        // that device's first low-space warning indefinitely.
+        val store = PreferenceDataStoreFactory.create(
+            scope = this,
+            produceFile = { tempDir.resolve("analyzer.preferences_pb").toFile() },
+        )
+        store.edit {
+            it[booleanPreferencesKey("storage.low.notification.enabled")] = true
+            it[booleanPreferencesKey("storage.low.notification.armed")] = false
+            it[booleanPreferencesKey("hint.lowspace.dismissed")] = true
+            it[longPreferencesKey("storage.low.threshold.bytes")] = 10_000_000_000L
+        }
+        val settings = mockk<AnalyzerSettings>().apply {
+            every { dataStore } returns store
+        }
+
+        val snapshot = AnalyzerSettingsBackupContributor(settings).snapshot()!!
+
+        snapshot.jsonObject.keys shouldBe setOf(
+            "storage.low.notification.enabled",
+            "hint.lowspace.dismissed",
+            "storage.low.threshold.bytes",
+        )
+    }
+
+    @Test
+    fun `restoring never overwrites the on-device latch`(@TempDir tempDir: Path) = runTest {
+        val source = PreferenceDataStoreFactory.create(
+            scope = this,
+            produceFile = { tempDir.resolve("source.preferences_pb").toFile() },
+        )
+        source.edit { it[booleanPreferencesKey("storage.low.notification.enabled")] = true }
+        val snapshot = AnalyzerSettingsBackupContributor(
+            mockk<AnalyzerSettings>().apply { every { dataStore } returns source },
+        ).snapshot()!!
+
+        val target = PreferenceDataStoreFactory.create(
+            scope = this,
+            produceFile = { tempDir.resolve("target.preferences_pb").toFile() },
+        )
+        target.edit { it[booleanPreferencesKey("storage.low.notification.armed")] = false }
+
+        AnalyzerSettingsBackupContributor(
+            mockk<AnalyzerSettings>().apply { every { dataStore } returns target },
+        ).restore(snapshot, RestoreMode.REPLACE)
+
+        val prefs = target.data.first()
+        prefs[booleanPreferencesKey("storage.low.notification.armed")] shouldBe false
+        prefs[booleanPreferencesKey("storage.low.notification.enabled")] shouldBe true
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/AnalyzerRoutesSerializationTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/AnalyzerRoutesSerializationTest.kt
@@ -38,6 +38,15 @@ class AnalyzerRoutesSerializationTest : BaseTest() {
     }
 
     @Test
+    fun `AnalyzerSettingsRoute serialization round-trip`() {
+        val serialized = json.encodeToString(AnalyzerSettingsRoute.serializer(), AnalyzerSettingsRoute)
+        serialized.toComparableKotlinxJson() shouldBe "{}".toComparableKotlinxJson()
+
+        val deserialized = json.decodeFromString(AnalyzerSettingsRoute.serializer(), serialized)
+        deserialized shouldBe AnalyzerSettingsRoute
+    }
+
+    @Test
     fun `StorageContentRoute serialization round-trip`() {
         val original = StorageContentRoute(storageId = testStorageId)
 

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreenTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreenTest.kt
@@ -1,0 +1,135 @@
+package eu.darken.sdmse.analyzer.ui.settings
+
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.stats.core.LowStorage
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class AnalyzerSettingsScreenTest : BaseComposeRobolectricTest() {
+
+    private fun ComposeContentTestRule.setSettingsScreen(
+        state: AnalyzerSettingsViewModel.State,
+        onThresholdChanged: (Long?) -> Unit = {},
+    ) {
+        setContent {
+            PreviewWrapper {
+                AnalyzerSettingsScreen(
+                    state = state,
+                    onThresholdChanged = onThresholdChanged,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `top bar shows the tool name`() {
+        composeRule.setSettingsScreen(AnalyzerSettingsViewModel.State())
+
+        composeRule.onNodeWithText("StorageAnalyzer").assertExists()
+    }
+
+    @Test
+    fun `the threshold row is visible at startup`() {
+        composeRule.setSettingsScreen(AnalyzerSettingsViewModel.State())
+
+        composeRule.onNodeWithText("Low storage threshold").assertExists()
+    }
+
+    @Test
+    fun `an unknown capacity renders a bare Automatic`() {
+        composeRule.setSettingsScreen(
+            AnalyzerSettingsViewModel.State(
+                customThresholdBytes = null,
+                primaryCapacityBytes = null,
+                effectiveThresholdBytes = null,
+            ),
+        )
+
+        composeRule.onNodeWithText("Automatic").assertExists()
+    }
+
+    @Test
+    fun `a known capacity renders the resolved automatic value`() {
+        composeRule.setSettingsScreen(
+            AnalyzerSettingsViewModel.State(
+                customThresholdBytes = null,
+                primaryCapacityBytes = 128_000_000_000L,
+                effectiveThresholdBytes = LowStorage.AUTO_MAX_BYTES,
+            ),
+        )
+
+        composeRule.onNode(hasText("Automatic (currently", substring = true)).assertExists()
+    }
+
+    @Test
+    fun `tapping the threshold row opens the size dialog`() {
+        composeRule.setSettingsScreen(
+            AnalyzerSettingsViewModel.State(
+                customThresholdBytes = 10_000_000_000L,
+                primaryCapacityBytes = 128_000_000_000L,
+                effectiveThresholdBytes = 10_000_000_000L,
+            ),
+        )
+
+        // Before the tap the dialog's buttons are not in the tree.
+        composeRule.onNodeWithText("Save").assertDoesNotExist()
+
+        composeRule.onNodeWithText("Low storage threshold").performClick()
+
+        composeRule.onNodeWithText("Save").assertExists()
+        composeRule.onNodeWithText("Cancel").assertExists()
+    }
+
+    @Test
+    fun `the dialog's neutral button resets to automatic`() {
+        // The neutral button reads "Automatic" here instead of the shared "Reset" label.
+        var captured: Long? = -1L
+        var calls = 0
+        composeRule.setSettingsScreen(
+            state = AnalyzerSettingsViewModel.State(
+                customThresholdBytes = 10_000_000_000L,
+                primaryCapacityBytes = 128_000_000_000L,
+                effectiveThresholdBytes = 10_000_000_000L,
+            ),
+            onThresholdChanged = {
+                captured = it
+                calls++
+            },
+        )
+
+        composeRule.onNodeWithText("Low storage threshold").performClick()
+        composeRule.onNodeWithText("Automatic").performClick()
+
+        calls shouldBe 1
+        captured shouldBe null
+        // The dialog closed again.
+        composeRule.onNodeWithText("Save").assertDoesNotExist()
+    }
+
+    @Test
+    fun `cancelling the dialog changes nothing`() {
+        var calls = 0
+        composeRule.setSettingsScreen(
+            state = AnalyzerSettingsViewModel.State(
+                customThresholdBytes = 10_000_000_000L,
+                primaryCapacityBytes = 128_000_000_000L,
+                effectiveThresholdBytes = 10_000_000_000L,
+            ),
+            onThresholdChanged = { calls++ },
+        )
+
+        composeRule.onNodeWithText("Low storage threshold").performClick()
+        composeRule.onNodeWithText("Cancel").performClick()
+
+        calls shouldBe 0
+        composeRule.onNodeWithText("Save").assertDoesNotExist()
+    }
+
+    private infix fun <T> T.shouldBe(expected: T) {
+        if (this != expected) throw AssertionError("Expected <$expected> but was <$this>")
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreenTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreenTest.kt
@@ -14,12 +14,16 @@ class AnalyzerSettingsScreenTest : BaseComposeRobolectricTest() {
     private fun ComposeContentTestRule.setSettingsScreen(
         state: AnalyzerSettingsViewModel.State,
         onThresholdChanged: (Long?) -> Unit = {},
+        onNotificationChanged: (Boolean) -> Unit = {},
+        onUpgradeClick: () -> Unit = {},
     ) {
         setContent {
             PreviewWrapper {
                 AnalyzerSettingsScreen(
                     state = state,
                     onThresholdChanged = onThresholdChanged,
+                    onNotificationChanged = onNotificationChanged,
+                    onUpgradeClick = onUpgradeClick,
                 )
             }
         }
@@ -127,6 +131,45 @@ class AnalyzerSettingsScreenTest : BaseComposeRobolectricTest() {
 
         calls shouldBe 0
         composeRule.onNodeWithText("Save").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the low space warning row is visible`() {
+        composeRule.setSettingsScreen(AnalyzerSettingsViewModel.State())
+
+        composeRule.onNodeWithText("Low space warning").assertExists()
+    }
+
+    @Test
+    fun `a non-Pro tap opens the upgrade flow instead of toggling`() {
+        var toggles = 0
+        var upgrades = 0
+        composeRule.setSettingsScreen(
+            state = AnalyzerSettingsViewModel.State(isPro = false, notificationEnabled = false),
+            onNotificationChanged = { toggles++ },
+            onUpgradeClick = { upgrades++ },
+        )
+
+        composeRule.onNodeWithText("Low space warning").performClick()
+
+        toggles shouldBe 0
+        upgrades shouldBe 1
+    }
+
+    @Test
+    fun `a Pro tap toggles the warning`() {
+        var captured: Boolean? = null
+        var upgrades = 0
+        composeRule.setSettingsScreen(
+            state = AnalyzerSettingsViewModel.State(isPro = true, notificationEnabled = false),
+            onNotificationChanged = { captured = it },
+            onUpgradeClick = { upgrades++ },
+        )
+
+        composeRule.onNodeWithText("Low space warning").performClick()
+
+        captured shouldBe true
+        upgrades shouldBe 0
     }
 
     private infix fun <T> T.shouldBe(expected: T) {

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModelTest.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.analyzer.ui.settings
 
 import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.stats.core.LowStorage
 import eu.darken.sdmse.stats.core.SpaceTracker
 import io.kotest.matchers.shouldBe
@@ -10,9 +11,12 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -32,29 +36,44 @@ class AnalyzerSettingsViewModelTest : BaseTest() {
     private class Harness(
         val vm: AnalyzerSettingsViewModel,
         val threshold: DataStoreValue<Long?>,
+        val notificationEnabled: DataStoreValue<Boolean>,
     )
 
-    private fun harness(
+    private fun TestScope.harness(
         customThresholdBytes: Long? = null,
         primaryStorage: SpaceTracker.StorageSnapshot? = SpaceTracker.StorageSnapshot(
             storageId = "primary",
             spaceFree = 50_000_000_000L,
             spaceCapacity = 128_000_000_000L,
         ),
+        notificationEnabled: Boolean = false,
+        isPro: Boolean = false,
     ): Harness {
         val threshold = rwDataStoreValue(customThresholdBytes)
+        val notification = rwDataStoreValue(notificationEnabled)
         val settings = mockk<AnalyzerSettings>().apply {
             every { lowStorageThresholdBytes } returns threshold
+            every { lowSpaceNotificationEnabled } returns notification
         }
         val spaceTracker = mockk<SpaceTracker>(relaxed = true).apply {
             coEvery { readPrimaryStorage() } returns primaryStorage
+        }
+        val info = mockk<UpgradeRepo.Info>().apply {
+            every { this@apply.isPro } returns isPro
+        }
+        val upgradeRepo = mockk<UpgradeRepo>().apply {
+            every { upgradeInfo } returns flowOf(info)
         }
         val vm = AnalyzerSettingsViewModel(
             dispatcherProvider = TestDispatcherProvider(),
             settings = settings,
             spaceTracker = spaceTracker,
+            upgradeRepo = upgradeRepo,
         )
-        return Harness(vm, threshold)
+        // safeStateIn is WhileSubscribed: without a live subscriber `state.value` stays at the
+        // initial State() and the Pro guard in setNotificationEnabled would never see isPro.
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        return Harness(vm, threshold, notification)
     }
 
     // ─────────────────────────── state ───────────────────────────
@@ -129,5 +148,52 @@ class AnalyzerSettingsViewModelTest : BaseTest() {
         val captured = slot<(Long?) -> Long?>()
         coVerify(exactly = 1) { h.threshold.update(capture(captured)) }
         captured.captured(10_000_000_000L) shouldBe null
+    }
+
+    // ─────────────────────────── low space warning ───────────────────────────
+
+    @Test
+    fun `the stored toggle and the Pro state surface`() = runTest2 {
+        val h = harness(notificationEnabled = true, isPro = true)
+        advanceUntilIdle()
+
+        val state = h.vm.state.first()
+        state.notificationEnabled shouldBe true
+        state.isPro shouldBe true
+    }
+
+    @Test
+    fun `a non-Pro user sees the stored value but the row renders unchecked`() = runTest2 {
+        // The screen renders `isPro && notificationEnabled`, so the stored value stays intact.
+        val h = harness(notificationEnabled = true, isPro = false)
+        advanceUntilIdle()
+
+        val state = h.vm.state.first()
+        state.notificationEnabled shouldBe true
+        state.isPro shouldBe false
+    }
+
+    @Test
+    fun `a Pro user can enable the warning`() = runTest2 {
+        val h = harness(notificationEnabled = false, isPro = true)
+        advanceUntilIdle()
+
+        h.vm.setNotificationEnabled(true)
+        advanceUntilIdle()
+
+        val captured = slot<(Boolean) -> Boolean?>()
+        coVerify(exactly = 1) { h.notificationEnabled.update(capture(captured)) }
+        captured.captured(false) shouldBe true
+    }
+
+    @Test
+    fun `a non-Pro user cannot enable the warning`() = runTest2 {
+        val h = harness(notificationEnabled = false, isPro = false)
+        advanceUntilIdle()
+
+        h.vm.setNotificationEnabled(true)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.notificationEnabled.update(any()) }
     }
 }

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModelTest.kt
@@ -1,0 +1,133 @@
+package eu.darken.sdmse.analyzer.ui.settings
+
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.stats.core.LowStorage
+import eu.darken.sdmse.stats.core.SpaceTracker
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+class AnalyzerSettingsViewModelTest : BaseTest() {
+
+    private val capacity = 128_000_000_000L
+
+    private fun <T> rwDataStoreValue(initial: T, flow: Flow<T> = flowOf(initial)): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>().apply {
+            every { this@apply.flow } returns flow
+            coEvery { update(any()) } returns DataStoreValue.Updated(old = initial, new = initial)
+        }
+
+    private class Harness(
+        val vm: AnalyzerSettingsViewModel,
+        val threshold: DataStoreValue<Long?>,
+    )
+
+    private fun harness(
+        customThresholdBytes: Long? = null,
+        primaryStorage: SpaceTracker.StorageSnapshot? = SpaceTracker.StorageSnapshot(
+            storageId = "primary",
+            spaceFree = 50_000_000_000L,
+            spaceCapacity = 128_000_000_000L,
+        ),
+    ): Harness {
+        val threshold = rwDataStoreValue(customThresholdBytes)
+        val settings = mockk<AnalyzerSettings>().apply {
+            every { lowStorageThresholdBytes } returns threshold
+        }
+        val spaceTracker = mockk<SpaceTracker>(relaxed = true).apply {
+            coEvery { readPrimaryStorage() } returns primaryStorage
+        }
+        val vm = AnalyzerSettingsViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            settings = settings,
+            spaceTracker = spaceTracker,
+        )
+        return Harness(vm, threshold)
+    }
+
+    // ─────────────────────────── state ───────────────────────────
+
+    @Test
+    fun `the default is automatic`() = runTest2 {
+        val h = harness(customThresholdBytes = null)
+
+        val state = h.vm.state.first()
+        state.customThresholdBytes shouldBe null
+        state.primaryCapacityBytes shouldBe capacity
+        state.effectiveThresholdBytes shouldBe LowStorage.resolveThreshold(capacity, null)
+    }
+
+    @Test
+    fun `a stored custom value surfaces and drives the effective threshold`() = runTest2 {
+        val h = harness(customThresholdBytes = 10_000_000_000L)
+
+        val state = h.vm.state.first()
+        state.customThresholdBytes shouldBe 10_000_000_000L
+        state.primaryCapacityBytes shouldBe capacity
+        state.effectiveThresholdBytes shouldBe 10_000_000_000L
+    }
+
+    @Test
+    fun `a zero-capacity primary reading leaves the capacity unknown`() = runTest2 {
+        // readPrimaryStorage() can return a non-null 0/0 reading; accepting it would render
+        // "Automatic (currently 0 B)".
+        val h = harness(
+            primaryStorage = SpaceTracker.StorageSnapshot(
+                storageId = "primary",
+                spaceFree = 0L,
+                spaceCapacity = 0L,
+            ),
+        )
+
+        val state = h.vm.state.first()
+        state.primaryCapacityBytes shouldBe null
+        state.effectiveThresholdBytes shouldBe null
+    }
+
+    @Test
+    fun `a missing primary reading leaves the capacity unknown`() = runTest2 {
+        val h = harness(primaryStorage = null)
+
+        val state = h.vm.state.first()
+        state.primaryCapacityBytes shouldBe null
+        state.effectiveThresholdBytes shouldBe null
+    }
+
+    // ─────────────────────────── setters ───────────────────────────
+
+    @Test
+    fun `setThreshold writes a custom value through`() = runTest2 {
+        val h = harness(customThresholdBytes = null)
+
+        h.vm.setThreshold(10_000_000_000L)
+        advanceUntilIdle()
+
+        val captured = slot<(Long?) -> Long?>()
+        coVerify(exactly = 1) { h.threshold.update(capture(captured)) }
+        captured.captured(null) shouldBe 10_000_000_000L
+    }
+
+    @Test
+    fun `setThreshold null writes automatic through`() = runTest2 {
+        val h = harness(customThresholdBytes = 10_000_000_000L)
+
+        h.vm.setThreshold(null)
+        advanceUntilIdle()
+
+        val captured = slot<(Long?) -> Long?>()
+        coVerify(exactly = 1) { h.threshold.update(capture(captured)) }
+        captured.captured(10_000_000_000L) shouldBe null
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreenTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreenTest.kt
@@ -1,0 +1,71 @@
+package eu.darken.sdmse.analyzer.ui.storage.device
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.compose.tour.GuidedTourController
+import eu.darken.sdmse.common.compose.tour.LocalGuidedTourController
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class DeviceStorageScreenTest : BaseComposeRobolectricTest() {
+
+    // Relaxed mock: shouldStart() defaults to false, so no guided tour starts.
+    private val mockTourController: GuidedTourController = mockk(relaxed = true)
+
+    private fun ComposeContentTestRule.setStorageScreen(
+        state: DeviceStorageViewModel.State,
+        onLowSpaceHintDismiss: () -> Unit = {},
+        onLowSpaceHintUpgrade: () -> Unit = {},
+    ) {
+        setContent {
+            CompositionLocalProvider(LocalGuidedTourController provides mockTourController) {
+                PreviewWrapper {
+                    DeviceStorageScreen(
+                        stateSource = MutableStateFlow(state),
+                        onLowSpaceHintDismiss = onLowSpaceHintDismiss,
+                        onLowSpaceHintUpgrade = onLowSpaceHintUpgrade,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `the low space hint renders when not Pro and not dismissed`() {
+        composeRule.setStorageScreen(DeviceStorageViewModel.State(showLowSpaceHint = true))
+
+        composeRule.onNodeWithText("Never get caught out of space").assertExists()
+    }
+
+    @Test
+    fun `the low space hint stays away when hidden`() {
+        composeRule.setStorageScreen(DeviceStorageViewModel.State(showLowSpaceHint = false))
+
+        composeRule.onNodeWithText("Never get caught out of space").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the hint's buttons are wired`() {
+        var dismissals = 0
+        var upgrades = 0
+        composeRule.setStorageScreen(
+            state = DeviceStorageViewModel.State(showLowSpaceHint = true),
+            onLowSpaceHintDismiss = { dismissals++ },
+            onLowSpaceHintUpgrade = { upgrades++ },
+        )
+
+        composeRule.onNodeWithText("Dismiss").performClick()
+        composeRule.onNodeWithText("Upgrade").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(1, dismissals)
+            assertEquals(1, upgrades)
+        }
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModelTest.kt
@@ -108,11 +108,14 @@ class DeviceStorageViewModelTest : BaseTest() {
     fun `the hint's upgrade button navigates to the upgrade screen`() = runTest2 {
         val h = harness()
         val events = mutableListOf<NavEvent>()
-        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { h.vm.navEvents.collect { events += it } }
+        // Foreground scope on purpose: advanceUntilIdle() stops as soon as no FOREGROUND event is
+        // queued, so a collector in backgroundScope would never be resumed to receive the emission.
+        val job = launch(start = CoroutineStart.UNDISPATCHED) { h.vm.navEvents.collect { events += it } }
 
         h.vm.openUpgrade()
         advanceUntilIdle()
 
         (events.single() as NavEvent.GoTo).destination shouldBe UpgradeRoute()
+        job.cancel()
     }
 }

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModelTest.kt
@@ -1,0 +1,118 @@
+package eu.darken.sdmse.analyzer.ui.storage.device
+
+import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.navigation.NavEvent
+import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.stats.core.SpaceHistoryRepo
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+class DeviceStorageViewModelTest : BaseTest() {
+
+    private fun <T> rwDataStoreValue(initial: T, flow: Flow<T> = flowOf(initial)): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>().apply {
+            every { this@apply.flow } returns flow
+            coEvery { update(any()) } returns DataStoreValue.Updated(old = initial, new = initial)
+        }
+
+    private class Harness(
+        val vm: DeviceStorageViewModel,
+        val hintDismissed: DataStoreValue<Boolean>,
+    )
+
+    private fun TestScope.harness(
+        isPro: Boolean = false,
+        hintDismissed: Boolean = false,
+    ): Harness {
+        val dismissed = rwDataStoreValue(hintDismissed)
+        val analyzer = mockk<Analyzer>(relaxed = true).apply {
+            every { data } returns MutableStateFlow(Analyzer.Data())
+            every { progress } returns MutableStateFlow(null)
+        }
+        val settings = mockk<AnalyzerSettings>().apply {
+            every { hintLowSpaceDismissed } returns dismissed
+        }
+        val info = mockk<UpgradeRepo.Info>().apply {
+            every { this@apply.isPro } returns isPro
+        }
+        val vm = DeviceStorageViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            analyzer = analyzer,
+            analyzerSettings = settings,
+            spaceHistoryRepo = mockk<SpaceHistoryRepo>().apply {
+                every { getAllHistory(any()) } returns flowOf(emptyList())
+            },
+            upgradeRepo = mockk<UpgradeRepo>().apply { every { upgradeInfo } returns flowOf(info) },
+        )
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        return Harness(vm, dismissed)
+    }
+
+    @Test
+    fun `the hint shows for a non-Pro user who has not dismissed it`() = runTest2 {
+        val h = harness(isPro = false, hintDismissed = false)
+        advanceUntilIdle()
+
+        h.vm.state.first().showLowSpaceHint shouldBe true
+    }
+
+    @Test
+    fun `the hint stays hidden for a Pro user`() = runTest2 {
+        val h = harness(isPro = true, hintDismissed = false)
+        advanceUntilIdle()
+
+        h.vm.state.first().showLowSpaceHint shouldBe false
+    }
+
+    @Test
+    fun `the hint stays hidden once dismissed`() = runTest2 {
+        val h = harness(isPro = false, hintDismissed = true)
+        advanceUntilIdle()
+
+        h.vm.state.first().showLowSpaceHint shouldBe false
+    }
+
+    @Test
+    fun `dismissing writes the flag through`() = runTest2 {
+        val h = harness()
+        advanceUntilIdle()
+
+        h.vm.dismissLowSpaceHint()
+        advanceUntilIdle()
+
+        val captured = slot<(Boolean) -> Boolean?>()
+        coVerify(exactly = 1) { h.hintDismissed.update(capture(captured)) }
+        captured.captured(false) shouldBe true
+    }
+
+    @Test
+    fun `the hint's upgrade button navigates to the upgrade screen`() = runTest2 {
+        val h = harness()
+        val events = mutableListOf<NavEvent>()
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { h.vm.navEvents.collect { events += it } }
+
+        h.vm.openUpgrade()
+        advanceUntilIdle()
+
+        (events.single() as NavEvent.GoTo).destination shouldBe UpgradeRoute()
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/App.kt
+++ b/app/src/main/java/eu/darken/sdmse/App.kt
@@ -32,6 +32,7 @@ import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.shortcuts.ShortcutManager
 import eu.darken.sdmse.main.core.taskmanager.TaskResultNotifier
+import eu.darken.sdmse.stats.core.LowSpaceMonitor
 import eu.darken.sdmse.stats.core.SpaceMonitorControl
 import eu.darken.sdmse.stats.core.TaskStatsCoordinator
 import eu.darken.sdmse.widget.WidgetRefreshCoordinator
@@ -61,6 +62,7 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var exitInfoLogger: ExitInfoLogger
     @Inject lateinit var shortcutManager: ShortcutManager
     @Inject lateinit var spaceMonitorControl: SpaceMonitorControl
+    @Inject lateinit var lowSpaceMonitor: LowSpaceMonitor
     @Inject lateinit var taskStatsCoordinator: TaskStatsCoordinator
     @Inject lateinit var taskResultNotifier: TaskResultNotifier
     @Inject lateinit var storageRescue: StorageRescue
@@ -122,6 +124,7 @@ open class App : Application(), Configuration.Provider {
         taskStatsCoordinator.start()
         taskResultNotifier.start()
         spaceMonitorControl.start()
+        lowSpaceMonitor.start(appScope)
         widgetRefreshCoordinator.start()
 
         val oldHandler = Thread.getDefaultUncaughtExceptionHandler()

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -340,10 +340,10 @@ internal fun DashboardViewModel.buildAnalyzerItem(): Flow<AnalyzerDashboardCardI
         .flatMapLatest { _ ->
             // The forecast needs a LIVE reading: sampling is six-hourly, so the newest persisted
             // row can be hours stale and a download that already crossed the floor would still
-            // read as filling. One read per tick, carried alongside the history.
-            val primary = spaceTracker.readPrimaryStorage()
+            // read as filling. Re-read per history emission, otherwise a cleanup (which forces a
+            // snapshot, and so a re-emission) would be forecast against pre-cleanup free space.
             spaceHistoryRepo.getAllHistory(Instant.now() - Duration.ofDays(7))
-                .map { AnalyzerTrendInput(snapshots = it, primaryStorage = primary) }
+                .mapLatest { AnalyzerTrendInput(snapshots = it, primaryStorage = spaceTracker.readPrimaryStorage()) }
         }
         .onStart<AnalyzerTrendInput?> { emit(null) },
 ) { data, progress, trend ->

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -44,6 +44,7 @@ import eu.darken.sdmse.squeezer.core.Squeezer
 import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
 import eu.darken.sdmse.squeezer.ui.SqueezerSetupRoute
 import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import eu.darken.sdmse.stats.core.forecast.StorageTrendCalculator
 import eu.darken.sdmse.stats.ui.ReportsRoute
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import eu.darken.sdmse.systemcleaner.core.hasData
@@ -349,17 +350,12 @@ internal fun DashboardViewModel.buildAnalyzerItem(): Flow<AnalyzerDashboardCardI
 }
 
 internal fun calculateCombinedDelta(snapshots: List<SpaceSnapshotEntity>): Long? {
-    val trendGroups = snapshots
+    val totals = snapshots
         .groupBy { it.storageId }
         .values
-        .filter { it.size >= 2 }
-    if (trendGroups.isEmpty()) return null
-    return trendGroups.sumOf { group ->
-        val sorted = group.sortedBy { it.recordedAt }
-        val firstUsed = sorted.first().let { it.spaceCapacity - it.spaceFree }
-        val lastUsed = sorted.last().let { it.spaceCapacity - it.spaceFree }
-        lastUsed - firstUsed
-    }
+        .mapNotNull { StorageTrendCalculator.windowTotal(it) }
+    if (totals.isEmpty()) return null
+    return totals.sum()
 }
 
 internal fun DashboardViewModel.buildSetupCardItem(): Flow<SetupDashboardCardItem?> = setupManager.state

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -43,7 +43,9 @@ import eu.darken.sdmse.setup.SetupRoute
 import eu.darken.sdmse.squeezer.core.Squeezer
 import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
 import eu.darken.sdmse.squeezer.ui.SqueezerSetupRoute
+import eu.darken.sdmse.stats.core.SpaceTracker
 import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import eu.darken.sdmse.stats.core.forecast.StorageForecaster
 import eu.darken.sdmse.stats.core.forecast.StorageTrendCalculator
 import eu.darken.sdmse.stats.ui.ReportsRoute
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
@@ -335,19 +337,40 @@ internal fun DashboardViewModel.buildAnalyzerItem(): Flow<AnalyzerDashboardCardI
     (analyzer.data as Flow<Analyzer.Data?>).onStart { emit(null) },
     analyzer.progress.onStart { emit(null) },
     intervalFlow(1.hours)
-        .flatMapLatest { spaceHistoryRepo.getAllHistory(Instant.now() - Duration.ofDays(7)) }
-        .onStart<List<SpaceSnapshotEntity>?> { emit(null) },
-) { data, progress, snapshots ->
+        .flatMapLatest { _ ->
+            // The forecast needs a LIVE reading: sampling is six-hourly, so the newest persisted
+            // row can be hours stale and a download that already crossed the floor would still
+            // read as filling. One read per tick, carried alongside the history.
+            val primary = spaceTracker.readPrimaryStorage()
+            spaceHistoryRepo.getAllHistory(Instant.now() - Duration.ofDays(7))
+                .map { AnalyzerTrendInput(snapshots = it, primaryStorage = primary) }
+        }
+        .onStart<AnalyzerTrendInput?> { emit(null) },
+) { data, progress, trend ->
+    val primary = trend?.primaryStorage
     AnalyzerDashboardCardItem(
         data = data,
         progress = progress,
-        combinedDelta = snapshots?.let { calculateCombinedDelta(it) },
-        isLoadingTrend = snapshots == null,
+        combinedDelta = trend?.let { calculateCombinedDelta(it.snapshots) },
+        forecast = if (trend != null && primary != null) {
+            StorageForecaster.forecast(
+                history = trend.snapshots.filter { it.storageId == primary.storageId },
+                current = primary,
+            )
+        } else {
+            null
+        },
+        isLoadingTrend = trend == null,
         onViewDetails = {
             navTo(DeviceStorageRoute)
         },
     )
 }
+
+internal data class AnalyzerTrendInput(
+    val snapshots: List<SpaceSnapshotEntity>,
+    val primaryStorage: SpaceTracker.StorageSnapshot?,
+)
 
 internal fun calculateCombinedDelta(snapshots: List<SpaceSnapshotEntity>): Long? {
     val totals = snapshots

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -43,6 +43,7 @@ import eu.darken.sdmse.setup.SetupRoute
 import eu.darken.sdmse.squeezer.core.Squeezer
 import eu.darken.sdmse.squeezer.core.tasks.SqueezerProcessTask
 import eu.darken.sdmse.squeezer.ui.SqueezerSetupRoute
+import eu.darken.sdmse.stats.core.LowStorage
 import eu.darken.sdmse.stats.core.SpaceTracker
 import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
 import eu.darken.sdmse.stats.core.forecast.StorageForecaster
@@ -346,7 +347,8 @@ internal fun DashboardViewModel.buildAnalyzerItem(): Flow<AnalyzerDashboardCardI
                 .mapLatest { AnalyzerTrendInput(snapshots = it, primaryStorage = spaceTracker.readPrimaryStorage()) }
         }
         .onStart<AnalyzerTrendInput?> { emit(null) },
-) { data, progress, trend ->
+    analyzerSettings.lowStorageThresholdBytes.flow,
+) { data, progress, trend, customThreshold ->
     val primary = trend?.primaryStorage
     AnalyzerDashboardCardItem(
         data = data,
@@ -356,6 +358,7 @@ internal fun DashboardViewModel.buildAnalyzerItem(): Flow<AnalyzerDashboardCardI
             StorageForecaster.forecast(
                 history = trend.snapshots.filter { it.storageId == primary.storageId },
                 current = primary,
+                lowStorageThresholdBytes = LowStorage.resolveThreshold(primary.spaceCapacity, customThreshold),
             )
         } else {
             null

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -104,6 +104,7 @@ import eu.darken.sdmse.squeezer.core.tasks.SqueezerScanTask
 import eu.darken.sdmse.squeezer.core.tasks.SqueezerTask
 import eu.darken.sdmse.stats.core.Report
 import eu.darken.sdmse.stats.core.SpaceHistoryRepo
+import eu.darken.sdmse.stats.core.SpaceTracker
 import eu.darken.sdmse.stats.core.StatsRepo
 import eu.darken.sdmse.stats.core.StatsSettings
 import eu.darken.sdmse.stats.ui.AffectedFilesRoute
@@ -168,6 +169,7 @@ class DashboardViewModel @Inject constructor(
     internal val statsSettings: StatsSettings,
     internal val curriculumVitae: CurriculumVitae,
     internal val spaceHistoryRepo: SpaceHistoryRepo,
+    internal val spaceTracker: SpaceTracker,
     deviceDetective: DeviceDetective,
 ) : ViewModel4(dispatcherProvider, TAG) {
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModel.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.main.ui.dashboard
 
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.common.navigation.routes.DeviceStorageRoute
 import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.appcleaner.core.hasData
@@ -151,6 +152,7 @@ class DashboardViewModel @Inject constructor(
     internal val appCleaner: AppCleaner,
     internal val appControl: AppControl,
     internal val analyzer: Analyzer,
+    internal val analyzerSettings: AnalyzerSettings,
     debugCardProvider: DebugCardProvider,
     internal val deduplicator: Deduplicator,
     internal val squeezer: Squeezer,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/AnalyzerDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/AnalyzerDashboardCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.analyzer.R as AnalyzerR
@@ -30,6 +31,7 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardActionIconSpacing
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardCard
 import eu.darken.sdmse.main.ui.dashboard.cards.common.DashboardFlatActionButton
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
 
 import kotlin.math.absoluteValue
 
@@ -37,6 +39,7 @@ data class AnalyzerDashboardCardItem(
     val data: Analyzer.Data?,
     val progress: Progress.Data?,
     val combinedDelta: Long? = null,
+    val forecast: StorageForecast? = null,
     val isLoadingTrend: Boolean = false,
     val onViewDetails: () -> Unit,
 ) : DashboardItem {
@@ -68,28 +71,47 @@ internal fun AnalyzerDashboardCard(item: AnalyzerDashboardCardItem) {
 
         // AnimatedVisibility so a resolved-but-absent trend (fresh installs) collapses smoothly
         // instead of snapping the card height after the shimmer.
-        AnimatedVisibility(visible = item.isLoadingTrend || item.combinedDelta != null) {
+        val forecast = item.forecast
+        AnimatedVisibility(
+            visible = item.isLoadingTrend || item.combinedDelta != null || forecast is StorageForecast.Filling,
+        ) {
             Column {
                 Spacer(modifier = Modifier.height(4.dp))
                 val delta = item.combinedDelta
-                if (delta == null) {
-                    ShimmerLine(height = 14.dp)
-                } else {
-                    val absDelta = Formatter.formatShortFileSize(LocalContext.current, delta.absoluteValue)
-                    val signedDelta = when {
-                        delta > 0 -> "+$absDelta"
-                        delta < 0 -> "-$absDelta"
-                        else -> absDelta
+                when {
+                    // A running-out estimate replaces the delta line, it never joins it.
+                    forecast is StorageForecast.Filling -> {
+                        val days = forecast.daysUntilFloor.toInt()
+                        Text(
+                            text = pluralStringResource(AnalyzerR.plurals.analyzer_storage_forecast_days, days, days),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = if (forecast.isUrgent) {
+                                MaterialTheme.colorScheme.error
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                        )
                     }
-                    Text(
-                        text = stringResource(AnalyzerR.string.analyzer_storage_trend_delta_in_7d, signedDelta),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = when {
-                            delta > 0 -> MaterialTheme.colorScheme.error
-                            delta < 0 -> MaterialTheme.colorScheme.primary
-                            else -> MaterialTheme.colorScheme.onSurfaceVariant
-                        },
-                    )
+
+                    delta == null -> ShimmerLine(height = 14.dp)
+
+                    else -> {
+                        val absDelta = Formatter.formatShortFileSize(LocalContext.current, delta.absoluteValue)
+                        val signedDelta = when {
+                            delta > 0 -> "+$absDelta"
+                            delta < 0 -> "-$absDelta"
+                            else -> absDelta
+                        }
+                        Text(
+                            text = stringResource(AnalyzerR.string.analyzer_storage_trend_delta_in_7d, signedDelta),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = when {
+                                delta > 0 -> MaterialTheme.colorScheme.error
+                                delta < 0 -> MaterialTheme.colorScheme.primary
+                                else -> MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                        )
+                    }
                 }
             }
         }
@@ -119,6 +141,46 @@ private fun AnalyzerDashboardCardPreview() {
                 data = null,
                 progress = null,
                 combinedDelta = 512L * 1024L * 1024L,
+                onViewDetails = {},
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun AnalyzerDashboardCardForecastUrgentPreview() {
+    PreviewWrapper {
+        AnalyzerDashboardCard(
+            item = AnalyzerDashboardCardItem(
+                data = null,
+                progress = null,
+                combinedDelta = 3L * 1024L * 1024L * 1024L,
+                forecast = StorageForecast.Filling(
+                    daysUntilFloor = 6,
+                    bytesPerDay = 512L * 1024L * 1024L,
+                    isUrgent = true,
+                ),
+                onViewDetails = {},
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun AnalyzerDashboardCardForecastCalmPreview() {
+    PreviewWrapper {
+        AnalyzerDashboardCard(
+            item = AnalyzerDashboardCardItem(
+                data = null,
+                progress = null,
+                combinedDelta = 512L * 1024L * 1024L,
+                forecast = StorageForecast.Filling(
+                    daysUntilFloor = 74,
+                    bytesPerDay = 64L * 1024L * 1024L,
+                    isUrgent = false,
+                ),
                 onViewDetails = {},
             ),
         )

--- a/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/settings/SettingsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.automirrored.twotone.ViewList
 import androidx.compose.material.icons.twotone.Apps
 import androidx.compose.material.icons.twotone.Compress
 import androidx.compose.material.icons.twotone.ContentCopy
+import androidx.compose.material.icons.twotone.DataUsage
 import androidx.compose.material.icons.twotone.Recycling
 import androidx.compose.material.icons.twotone.Swipe
 import androidx.compose.material.icons.automirrored.twotone.ContactSupport
@@ -52,6 +53,7 @@ import eu.darken.sdmse.common.compose.settings.SettingsPreferenceItem
 import eu.darken.sdmse.common.error.ErrorEventHandler
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
 import eu.darken.sdmse.common.upgrade.ui.brandTitleText
+import eu.darken.sdmse.analyzer.ui.AnalyzerSettingsRoute
 import eu.darken.sdmse.appcleaner.ui.AppCleanerSettingsRoute
 import eu.darken.sdmse.appcontrol.ui.AppControlSettingsRoute
 import eu.darken.sdmse.corpsefinder.ui.CorpseFinderSettingsRoute
@@ -119,6 +121,7 @@ fun SettingsScreenHost(
                 "AppControl" -> AppControlSettingsRoute
                 "Squeezer" -> SqueezerSettingsRoute
                 "Swiper" -> SwiperSettingsRoute
+                "Analyzer" -> AnalyzerSettingsRoute
                 else -> return@SettingsScreen
             }
             vm.navTo(route)
@@ -225,6 +228,14 @@ internal fun SettingsScreen(
                     title = stringResource(CommonR.string.swiper_tool_name),
                     subtitle = stringResource(eu.darken.sdmse.swiper.R.string.swiper_tool_description),
                     onClick = { onToolSettingsClick("Swiper") },
+                )
+            }
+            item {
+                SettingsPreferenceItem(
+                    icon = Icons.TwoTone.DataUsage,
+                    title = stringResource(CommonR.string.analyzer_tool_name),
+                    subtitle = stringResource(eu.darken.sdmse.analyzer.R.string.analyzer_explanation_short),
+                    onClick = { onToolSettingsClick("Analyzer") },
                 )
             }
 

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceAlertDecider.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceAlertDecider.kt
@@ -1,0 +1,54 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
+
+sealed interface LowSpaceAction {
+    data class Notify(val forecast: StorageForecast, val freeBytes: Long) : LowSpaceAction
+    data object Cancel : LowSpaceAction
+    data object Nothing : LowSpaceAction
+}
+
+data class LowSpaceDecision(
+    val action: LowSpaceAction,
+    /** `null` leaves the transition latch untouched. */
+    val armedAfter: Boolean?,
+)
+
+/**
+ * Whether the low-space warning should speak, go quiet, or stay out of the way.
+ *
+ * The trigger is the FORECAST, not an "is low" flag. [StorageForecast.BelowFloor] is returned the
+ * moment free space reaches the threshold, so triggering on "is low" would make the predictive copy
+ * unreachable and every warning would arrive after the fact.
+ *
+ * [LowSpaceAction.Cancel] ALWAYS re-arms. It means "no notification is standing", so the next
+ * qualifying condition has to be able to speak: an off/on of the toggle, or losing and regaining
+ * Pro, must not leave the user silently un-warned while their storage keeps filling. A successful
+ * post is the only thing that spends the latch, which is why [LowSpaceDecision.armedAfter] is left
+ * to the caller on the notify path.
+ */
+object LowSpaceAlertDecider {
+
+    fun decide(
+        enabled: Boolean,
+        isPro: Boolean,
+        armed: Boolean,
+        forecast: StorageForecast?,
+        freeBytes: Long,
+    ): LowSpaceDecision {
+        if (!enabled || !isPro) return LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+
+        val isWarning = when (forecast) {
+            is StorageForecast.Filling -> forecast.isUrgent
+            StorageForecast.BelowFloor -> true
+            else -> false
+        }
+        if (!isWarning || forecast == null) return LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+
+        // Warning state, but the latch is spent: stay quiet without clearing what is on screen.
+        if (!armed) return LowSpaceDecision(LowSpaceAction.Nothing, armedAfter = null)
+
+        // The caller sets armedAfter from the post result: false on POSTED, unchanged otherwise.
+        return LowSpaceDecision(LowSpaceAction.Notify(forecast, freeBytes), armedAfter = null)
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
@@ -43,6 +45,16 @@ class LowSpaceMonitor @Inject constructor(
 ) {
 
     private val started = AtomicBoolean(false)
+
+    /**
+     * Serializes the read-decide-post-write transaction.
+     *
+     * The worker run, the observer and a toggle-off can all land at once. Without this, two checks
+     * could both read `armed = true` and post twice, and a [cancelAndRearm] could finish before an
+     * in-flight check posts, leaving a warning on screen with the latch disarmed after the feature
+     * was switched off or Pro lapsed.
+     */
+    private val mutex = Mutex()
 
     /**
      * Reacts to the toggle and to Pro state without waiting for the next worker run.
@@ -81,7 +93,7 @@ class LowSpaceMonitor @Inject constructor(
      */
     suspend fun check() {
         try {
-            checkInternal()
+            mutex.withLock { checkInternal() }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -150,8 +162,10 @@ class LowSpaceMonitor @Inject constructor(
 
     private suspend fun cancelAndRearm() {
         try {
-            notifications.cancel()
-            setArmed(true)
+            mutex.withLock {
+                notifications.cancel()
+                setArmed(true)
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
@@ -1,0 +1,174 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.common.upgrade.isProSettled
+import eu.darken.sdmse.stats.core.forecast.StorageForecaster
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Decides whether the Pro low-space warning should be showing, and makes it so.
+ *
+ * Driven by the six-hourly [SpaceMonitorWorker] plus an observer that reacts the moment the user
+ * flips the setting or their Pro state changes. Six-hourly is inexact and Doze can defer it, which
+ * is acceptable for a gigabyte-scale advisory.
+ */
+@Singleton
+class LowSpaceMonitor @Inject constructor(
+    private val spaceTracker: SpaceTracker,
+    private val spaceHistoryRepo: SpaceHistoryRepo,
+    private val analyzerSettings: AnalyzerSettings,
+    private val upgradeRepo: UpgradeRepo,
+    private val notifications: LowSpaceNotifications,
+) {
+
+    private val started = AtomicBoolean(false)
+
+    /**
+     * Reacts to the toggle and to Pro state without waiting for the next worker run.
+     *
+     * Cancelling on the way down keeps a posted warning from lingering for up to six hours after
+     * the user switched it off, and the [check] on the way up makes enabling the setting do
+     * something observable instead of looking broken.
+     */
+    fun start(scope: CoroutineScope) {
+        if (!started.compareAndSet(false, true)) return
+        log(TAG, VERBOSE) { "start()" }
+
+        combine(
+            analyzerSettings.lowSpaceNotificationEnabled.flow,
+            // Only settled emissions: the pre-billing seed reports non-Pro even for paying users,
+            // and acting on it would cancel and re-arm on every process start, re-notifying a user
+            // who already dismissed the warning.
+            upgradeRepo.upgradeInfo.filter { it.isSettled }.map { it.isPro },
+        ) { enabled, isPro -> enabled && isPro }
+            .distinctUntilChanged()
+            .onEach { active ->
+                if (active) {
+                    log(TAG) { "Low space warning became active, checking now" }
+                    check()
+                } else {
+                    log(TAG) { "Low space warning is inactive, cancelling" }
+                    cancelAndRearm()
+                }
+            }
+            .launchIn(scope)
+    }
+
+    /**
+     * One evaluation of the primary volume. Never throws: a notification failure must not break
+     * snapshot recording or the widget refresh in [SpaceMonitorWorker].
+     */
+    suspend fun check() {
+        try {
+            checkInternal()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "check() failed: ${e.asLog()}" }
+        }
+    }
+
+    private suspend fun checkInternal() {
+        val enabled = analyzerSettings.lowSpaceNotificationEnabled.value()
+        val armed = analyzerSettings.lowSpaceNotificationArmed.value()
+
+        // recordSnapshot() returns Unit and is throttled to 30 minutes, so the worker holds no
+        // fresh reading of its own.
+        val primary = spaceTracker.readPrimaryStorage()
+        // readPrimaryStorage() can return a non-null 0/0 reading, which would otherwise classify as
+        // a warning state and post "0 B free".
+        if (primary == null || primary.spaceCapacity <= 0L || primary.spaceFree !in 0L..primary.spaceCapacity) {
+            log(TAG, WARN) { "check(): Implausible primary reading, skipping: $primary" }
+            return
+        }
+
+        // isProSettled() is the background gate; isProForUi() is for tap routing.
+        val isPro = if (enabled) upgradeRepo.isProSettled() else false
+
+        val forecast = if (enabled && isPro) {
+            // Single-storage history only: StorageTrendCalculator needs one volume's snapshots, a
+            // merged multi-volume list yields a meaningless rate.
+            val history = spaceHistoryRepo
+                .getHistory(primary.storageId, Instant.now() - HISTORY_WINDOW)
+                .first()
+            StorageForecaster.forecast(
+                history = history,
+                current = primary,
+                lowStorageThresholdBytes = LowStorage.resolveThreshold(
+                    capacityBytes = primary.spaceCapacity,
+                    customThresholdBytes = analyzerSettings.lowStorageThresholdBytes.value(),
+                ),
+            )
+        } else {
+            null
+        }
+
+        val decision = LowSpaceAlertDecider.decide(
+            enabled = enabled,
+            isPro = isPro,
+            armed = armed,
+            forecast = forecast,
+            freeBytes = primary.spaceFree,
+        )
+        log(TAG) { "check(): $decision (forecast=$forecast, armed=$armed, enabled=$enabled, isPro=$isPro)" }
+
+        var armedAfter = decision.armedAfter
+        when (val action = decision.action) {
+            is LowSpaceAction.Notify -> {
+                val result = notifications.notifyLowSpace(action.forecast, action.freeBytes)
+                // Only a successful post spends the latch.
+                if (result == LowSpaceNotifications.PostResult.POSTED) armedAfter = false
+            }
+
+            LowSpaceAction.Cancel -> notifications.cancel()
+            LowSpaceAction.Nothing -> {}
+        }
+
+        if (armedAfter != null) setArmed(armedAfter)
+    }
+
+    private suspend fun cancelAndRearm() {
+        try {
+            notifications.cancel()
+            setArmed(true)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "cancelAndRearm() failed: ${e.asLog()}" }
+        }
+    }
+
+    /** Writes only on an actual change, so a device with the feature off takes no six-hourly write. */
+    private suspend fun setArmed(value: Boolean) {
+        if (analyzerSettings.lowSpaceNotificationArmed.value() == value) return
+        log(TAG) { "setArmed($value)" }
+        analyzerSettings.lowSpaceNotificationArmed.value(value)
+    }
+
+    companion object {
+        // Same window the dashboard forecast uses.
+        private val HISTORY_WINDOW: Duration = Duration.ofDays(7)
+        private val TAG = logTag("Stats", "LowSpace", "Monitor")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -69,19 +68,34 @@ class LowSpaceMonitor @Inject constructor(
 
         combine(
             analyzerSettings.lowSpaceNotificationEnabled.flow,
-            // Only settled emissions: the pre-billing seed reports non-Pro even for paying users,
-            // and acting on it would cancel and re-arm on every process start, re-notifying a user
-            // who already dismissed the warning.
-            upgradeRepo.upgradeInfo.filter { it.isSettled }.map { it.isPro },
-        ) { enabled, isPro -> enabled && isPro }
+            // `null` means "not known yet", not "not Pro": the pre-billing seed reports non-Pro even
+            // for paying users, and acting on it would cancel and re-arm on every process start,
+            // re-notifying a user who already dismissed the warning. Mapping (instead of filtering
+            // the unsettled emissions away) keeps the toggle-off branch below reachable while
+            // billing is still settling.
+            upgradeRepo.upgradeInfo.map { if (it.isSettled) it.isPro else null },
+        ) { enabled, isPro -> enabled to isPro }
             .distinctUntilChanged()
-            .onEach { active ->
-                if (active) {
-                    log(TAG) { "Low space warning became active, checking now" }
-                    check()
-                } else {
-                    log(TAG) { "Low space warning is inactive, cancelling" }
-                    cancelAndRearm()
+            .onEach { (enabled, isPro) ->
+                when {
+                    // Switched off wins over an unknown entitlement: a warning left over from a
+                    // previous process must go away now, not once billing settles.
+                    !enabled -> {
+                        log(TAG) { "Low space warning is disabled, cancelling" }
+                        cancelAndRearm()
+                    }
+
+                    isPro == true -> {
+                        log(TAG) { "Low space warning became active, checking now" }
+                        check()
+                    }
+
+                    isPro == false -> {
+                        log(TAG) { "Low space warning is not available without Pro, cancelling" }
+                        cancelAndRearm()
+                    }
+
+                    else -> log(TAG, VERBOSE) { "Entitlement is unsettled, waiting" }
                 }
             }
             .launchIn(scope)

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceNotifications.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceNotifications.kt
@@ -78,18 +78,24 @@ class LowSpaceNotifications @Inject constructor(
         }
 
         val freeText = Formatter.formatShortFileSize(context, freeBytes)
-        val body = when (forecast) {
+        // Title and body are picked together: a trend title over an "out of space" body understates
+        // the situation the body describes.
+        val (title, body) = when (forecast) {
             is StorageForecast.Filling -> {
                 val days = forecast.daysUntilFloor.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt()
-                context.getQuantityString2(
+                val bodyText = context.getQuantityString2(
                     R.plurals.stats_lowspace_notification_forecast_body,
                     days,
                     days,
                     freeText,
                 )
+                context.getString(R.string.stats_lowspace_notification_title) to bodyText
             }
 
-            else -> context.getString(R.string.stats_lowspace_notification_low_body, freeText)
+            else -> {
+                val bodyText = context.getString(R.string.stats_lowspace_notification_low_body, freeText)
+                context.getString(R.string.stats_lowspace_notification_low_title) to bodyText
+            }
         }
 
         // Fresh builder per call: a shared builder would leak style/field state between posts.
@@ -99,7 +105,7 @@ class LowSpaceNotifications @Inject constructor(
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setSmallIcon(UiR.drawable.ic_notification_mascot_24)
             .setAutoCancel(true)
-            .setContentTitle(context.getString(R.string.stats_lowspace_notification_title))
+            .setContentTitle(title)
             .setContentText(body)
             .setStyle(BigTextStyle().bigText(body))
             .build()

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceNotifications.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceNotifications.kt
@@ -1,0 +1,162 @@
+package eu.darken.sdmse.stats.core
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.text.format.Formatter
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.BigTextStyle
+import androidx.core.app.NotificationManagerCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.BuildConfigWrap
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.getQuantityString2
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.permissions.Permission
+import eu.darken.sdmse.main.ui.MainActivity
+import eu.darken.sdmse.main.ui.shortcuts.ShortcutActivity
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
+import javax.inject.Inject
+import javax.inject.Singleton
+import eu.darken.sdmse.common.ui.R as UiR
+
+/**
+ * The tap target of the low-space warning.
+ *
+ * [Intent.filterEquals] ignores extras, and both `TaskWorkerNotifications` and
+ * `TaskResultNotifications` already hold request code `0` against a bare [MainActivity] intent.
+ * Reusing that shape with `FLAG_UPDATE_CURRENT` would overwrite THEIR extras and route their taps
+ * here, so this intent carries its own [action] and is posted under its own request code.
+ */
+internal fun lowSpaceContentIntent(context: Context): Intent = Intent(context, MainActivity::class.java).apply {
+    action = LowSpaceNotifications.ACTION_LOW_SPACE
+    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+    putExtra(ShortcutActivity.EXTRA_SHORTCUT_ACTION, ShortcutActivity.ACTION_OPEN_ANALYZER)
+}
+
+@Singleton
+class LowSpaceNotifications @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val notificationManager: NotificationManager,
+) {
+
+    private val contentPendingIntent: PendingIntent
+
+    init {
+        NotificationChannel(
+            CHANNEL_ID,
+            context.getString(R.string.stats_lowspace_notification_channel_label),
+            NotificationManager.IMPORTANCE_DEFAULT,
+        ).run { notificationManager.createNotificationChannel(this) }
+
+        contentPendingIntent = PendingIntent.getActivity(
+            context,
+            REQUEST_CODE,
+            lowSpaceContentIntent(context),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    /**
+     * Posts the warning for [forecast].
+     *
+     * Returns an explicit [PostResult] instead of swallowing the outcome: only [PostResult.POSTED]
+     * may spend the caller's transition latch, so a user who grants notification permission later
+     * still gets warned while the storage is still filling.
+     */
+    fun notifyLowSpace(forecast: StorageForecast, freeBytes: Long): PostResult {
+        if (!canPost()) {
+            log(TAG, WARN) { "notifyLowSpace(): Blocked, notifications are not deliverable" }
+            return PostResult.BLOCKED
+        }
+
+        val freeText = Formatter.formatShortFileSize(context, freeBytes)
+        val body = when (forecast) {
+            is StorageForecast.Filling -> {
+                val days = forecast.daysUntilFloor.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt()
+                context.getQuantityString2(
+                    R.plurals.stats_lowspace_notification_forecast_body,
+                    days,
+                    days,
+                    freeText,
+                )
+            }
+
+            else -> context.getString(R.string.stats_lowspace_notification_low_body, freeText)
+        }
+
+        // Fresh builder per call: a shared builder would leak style/field state between posts.
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setChannelId(CHANNEL_ID)
+            .setContentIntent(contentPendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setSmallIcon(UiR.drawable.ic_notification_mascot_24)
+            .setAutoCancel(true)
+            .setContentTitle(context.getString(R.string.stats_lowspace_notification_title))
+            .setContentText(body)
+            .setStyle(BigTextStyle().bigText(body))
+            .build()
+
+        return try {
+            notificationManager.notify(NOTIFICATION_ID, notification)
+            log(TAG) { "notifyLowSpace($forecast, $freeBytes): Posted" }
+            PostResult.POSTED
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "notifyLowSpace() failed: ${e.asLog()}" }
+            PostResult.FAILED
+        }
+    }
+
+    fun cancel() {
+        log(TAG) { "cancel()" }
+        try {
+            notificationManager.cancel(NOTIFICATION_ID)
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "cancel() failed: ${e.asLog()}" }
+        }
+    }
+
+    private fun canPost(): Boolean {
+        if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+            log(TAG, WARN) { "Notifications are disabled for the app" }
+            return false
+        }
+        if (hasApiLevel(33) && !Permission.POST_NOTIFICATIONS.isGranted(context)) {
+            log(TAG, WARN) { "POST_NOTIFICATIONS is not granted" }
+            return false
+        }
+        val channel = notificationManager.getNotificationChannel(CHANNEL_ID)
+        if (channel != null && channel.importance == NotificationManager.IMPORTANCE_NONE) {
+            log(TAG, WARN) { "Channel $CHANNEL_ID is muted (IMPORTANCE_NONE)" }
+            return false
+        }
+        return true
+    }
+
+    enum class PostResult {
+        POSTED,
+        BLOCKED,
+        FAILED,
+    }
+
+    companion object {
+        val TAG = logTag("Stats", "LowSpace", "Notifications")
+        internal val CHANNEL_ID = "${BuildConfigWrap.APPLICATION_ID}.notification.channel.stats.lowspace"
+        internal val ACTION_LOW_SPACE = "${BuildConfigWrap.APPLICATION_ID}.ACTION_NOTIFICATION_LOW_SPACE"
+
+        // Notification ID ranges in use: 1 (task worker), 75 (uninstall watcher),
+        // 1000-1100 (scheduler state), 1200-1300 (scheduler result), 2000-2007 (task results).
+        internal const val NOTIFICATION_ID = 3000
+
+        // Distinct from every other PendingIntent request code in the app (all of which are 0),
+        // so FLAG_UPDATE_CURRENT here can't rewrite another site's intent.
+        internal const val REQUEST_CODE = 3000
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/SpaceMonitorWorker.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/SpaceMonitorWorker.kt
@@ -17,6 +17,7 @@ class SpaceMonitorWorker @AssistedInject constructor(
     @Assisted private val params: WorkerParameters,
     private val spaceTracker: SpaceTracker,
     private val widgetUpdater: WidgetUpdater,
+    private val lowSpaceMonitor: LowSpaceMonitor,
 ) : CoroutineWorker(context, params) {
 
     override suspend fun doWork(): Result {
@@ -24,6 +25,8 @@ class SpaceMonitorWorker @AssistedInject constructor(
         spaceTracker.recordSnapshot()
         // Backstop refresh for placed home-screen widgets (free space may drift between cleans).
         widgetUpdater.updateAll()
+        // Never throws: a notification failure must not break snapshot recording or the widget.
+        lowSpaceMonitor.check()
         log(TAG, VERBOSE) { "doWork(): Done" }
         return Result.success()
     }

--- a/app/src/main/java/eu/darken/sdmse/widget/WidgetDataProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/WidgetDataProvider.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.widget
 
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
@@ -8,6 +9,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.shareLatest
 import eu.darken.sdmse.main.core.shortcuts.OneTapRunGuard
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.stats.core.LowStorage
 import eu.darken.sdmse.stats.core.SpaceTracker
 import eu.darken.sdmse.stats.core.StatsSettings
 import kotlinx.coroutines.CoroutineScope
@@ -27,13 +29,15 @@ import javax.inject.Singleton
  * Reads the live primary + secondary (SD card / USB) storage figures, the lifetime "space freed"
  * total and the working/cancellable task state, clamps them, and maps them to an immutable
  * [WidgetRenderState]. Freed bytes come from the [StatsSettings] DataStore value (the source of
- * truth) rather than the throttled `StatsRepo.state`.
+ * truth) rather than the throttled `StatsRepo.state`. Each volume is also flagged against the
+ * configured low-storage threshold ([AnalyzerSettings.lowStorageThresholdBytes]).
  */
 @Singleton
 class WidgetDataProvider @Inject constructor(
     @AppScope appScope: CoroutineScope,
     private val spaceTracker: SpaceTracker,
     private val statsSettings: StatsSettings,
+    private val analyzerSettings: AnalyzerSettings,
     private val taskSubmitter: TaskSubmitter,
     private val oneTapRunGuard: OneTapRunGuard,
 ) {
@@ -54,11 +58,13 @@ class WidgetDataProvider @Inject constructor(
         oneTapRunGuard.running,
         taskSubmitter.state.map { !it.isIdle to it.hasCancellable }.distinctUntilChanged(),
         statsSettings.totalSpaceFreed.flow,
-    ) { guardRunning, (busy, cancellable), freed ->
+        analyzerSettings.lowStorageThresholdBytes.flow,
+    ) { guardRunning, (busy, cancellable), freed, lowThreshold ->
         Signals(
             working = guardRunning || busy,
             cancellable = guardRunning || cancellable,
             freed = freed,
+            lowThreshold = lowThreshold,
         )
     }
         // Hold the displayed lifetime total steady while a run is in progress: the counter is
@@ -71,7 +77,14 @@ class WidgetDataProvider @Inject constructor(
         }
         .filterNotNull()
         .distinctUntilChanged()
-        .map { buildState(working = it.working, cancellable = it.cancellable, freedBytes = it.freed) }
+        .map {
+            buildState(
+                working = it.working,
+                cancellable = it.cancellable,
+                freedBytes = it.freed,
+                lowThreshold = it.lowThreshold,
+            )
+        }
         .distinctUntilChanged()
         .map { it.also { log(TAG, VERBOSE) { "renderState: $it" } } }
         // Shared so the latch lives ONCE in this singleton: a cold per-collector chain would let a
@@ -81,7 +94,13 @@ class WidgetDataProvider @Inject constructor(
         // across collectors (coordinator + one per widget session).
         .shareLatest(appScope)
 
-    private data class Signals(val working: Boolean, val cancellable: Boolean, val freed: Long)
+    private data class Signals(
+        val working: Boolean,
+        val cancellable: Boolean,
+        val freed: Long,
+        /** Custom low-storage threshold, `null` = automatic (see [LowStorage.resolveThreshold]). */
+        val lowThreshold: Long?,
+    )
 
     suspend fun snapshot(): WidgetRenderState = renderState.first()
 
@@ -89,13 +108,14 @@ class WidgetDataProvider @Inject constructor(
         working: Boolean,
         cancellable: Boolean,
         freedBytes: Long,
+        lowThreshold: Long?,
     ): WidgetRenderState {
         val entries = buildList {
             spaceTracker.readPrimaryStorage()
-                ?.let { entry(WidgetRenderState.Data.StorageEntry.Kind.INTERNAL, it) }
+                ?.let { entry(WidgetRenderState.Data.StorageEntry.Kind.INTERNAL, it, lowThreshold) }
                 ?.let { add(it) }
             spaceTracker.readSecondaryStorages()
-                .mapNotNull { entry(WidgetRenderState.Data.StorageEntry.Kind.EXTERNAL, it) }
+                .mapNotNull { entry(WidgetRenderState.Data.StorageEntry.Kind.EXTERNAL, it, lowThreshold) }
                 .let { addAll(it) }
         }.take(MAX_STORAGES)
 
@@ -115,6 +135,7 @@ class WidgetDataProvider @Inject constructor(
     private fun entry(
         kind: WidgetRenderState.Data.StorageEntry.Kind,
         snapshot: SpaceTracker.StorageSnapshot,
+        lowThreshold: Long?,
     ): WidgetRenderState.Data.StorageEntry? {
         val total = snapshot.spaceCapacity
         if (total <= 0L) return null
@@ -123,6 +144,12 @@ class WidgetDataProvider @Inject constructor(
             kind = kind,
             usedBytes = (total - free).coerceIn(0L, total),
             totalBytes = total,
+            // Per volume, against that volume's own capacity: a nearly full SD card must be able to
+            // flag while the primary is fine (and vice versa).
+            isLow = LowStorage.isLow(
+                spaceFreeBytes = free,
+                thresholdBytes = LowStorage.resolveThreshold(total, lowThreshold),
+            ),
         )
     }
 

--- a/app/src/main/java/eu/darken/sdmse/widget/WidgetRenderState.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/WidgetRenderState.kt
@@ -21,6 +21,11 @@ sealed interface WidgetRenderState {
             val kind: Kind,
             val usedBytes: Long,
             val totalBytes: Long,
+            /**
+             * Free space is at or below the configured low-storage threshold. Computed per entry, so
+             * a nearly full SD card flags while the primary volume stays normal.
+             */
+            val isLow: Boolean = false,
         ) {
             val usedRatio: Float
                 get() = if (totalBytes > 0L) {

--- a/app/src/main/java/eu/darken/sdmse/widget/ui/StorageRing.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/ui/StorageRing.kt
@@ -7,7 +7,7 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Typeface
-import android.os.Build
+import androidx.annotation.ColorInt
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.glance.GlanceModifier
@@ -15,6 +15,7 @@ import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.layout.size
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.ui.R as CommonUiR
 import kotlin.math.roundToInt
 
@@ -22,21 +23,37 @@ import kotlin.math.roundToInt
  * A determinate storage "donut" that fills to the used ratio, with the percentage in the centre.
  *
  * Glance has no determinate circular progress, so we draw a [Bitmap] at runtime and hand it to a
- * Glance [Image]. The arc uses the Material You accent on API 31+, else the app's primary; the track
- * and label follow light/dark.
+ * Glance [Image]. The arc colour comes from [storageArcColor]; the track and label follow light/dark.
+ *
+ * [isLow] means free space is at or below the configured low-storage threshold — the ring is the
+ * only storage indicator in the narrow single-row layout, so it has to carry that signal itself.
  */
 @Composable
-internal fun StorageRing(ratio: Float, diameter: Dp) {
+internal fun StorageRing(ratio: Float, diameter: Dp, isLow: Boolean = false) {
     val context = LocalContext.current
     val px = (diameter.value * context.resources.displayMetrics.density).roundToInt().coerceAtLeast(1)
     Image(
-        provider = ImageProvider(storageRingBitmap(context, ratio, px)),
+        provider = ImageProvider(storageRingBitmap(context, ratio, px, isLow)),
         contentDescription = null,
         modifier = GlanceModifier.size(diameter),
     )
 }
 
-private fun storageRingBitmap(context: Context, ratio: Float, sizePx: Int): Bitmap {
+/**
+ * Arc colour for the ring. Extracted and pure so it can be unit-tested — the bitmap itself can't be
+ * (Robolectric's Canvas doesn't rasterise).
+ *
+ * The low-storage branch deliberately comes FIRST: a Material You wallpaper accent must never
+ * override the warning colour, otherwise a device with an amber-ish accent shows no difference at all.
+ */
+@ColorInt
+internal fun storageArcColor(context: Context, isLow: Boolean): Int = when {
+    isLow -> context.getColor(CommonUiR.color.md_theme_storageLow)
+    hasApiLevel(31) -> context.getColor(android.R.color.system_accent1_500)
+    else -> context.getColor(CommonUiR.color.md_theme_primary)
+}
+
+private fun storageRingBitmap(context: Context, ratio: Float, sizePx: Int, isLow: Boolean): Bitmap {
     val night = (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
         Configuration.UI_MODE_NIGHT_YES
 
@@ -49,11 +66,7 @@ private fun storageRingBitmap(context: Context, ratio: Float, sizePx: Int): Bitm
     val pad = stroke / 2f
     val bounds = RectF(pad, pad, sizePx - pad, sizePx - pad)
 
-    val arcColor = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        context.getColor(android.R.color.system_accent1_500)
-    } else {
-        context.getColor(CommonUiR.color.md_theme_primary)
-    }
+    val arcColor = storageArcColor(context, isLow)
     val trackColor = if (night) 0x33FFFFFF else 0x1F000000
     val textColor = if (night) 0xFFECECEC.toInt() else 0xFF1B1B1B.toInt()
 

--- a/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContent.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContent.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.text.format.Formatter
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -37,10 +38,12 @@ import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
 import eu.darken.sdmse.R
 import eu.darken.sdmse.main.ui.MainActivity
 import eu.darken.sdmse.main.ui.shortcuts.ShortcutActivity
 import eu.darken.sdmse.widget.WidgetRenderState
+import androidx.glance.color.ColorProvider as dayNightColorProvider
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.ui.R as CommonUiR
 
@@ -173,9 +176,13 @@ private fun WidgetChrome(content: @Composable () -> Unit) {
     }
 }
 
-/** Tall (2+ rows): branding + storage (tap → app) at the top, Clean button pinned to the bottom. */
+/**
+ * Tall (2+ rows): branding + storage (tap → app) at the top, Clean button pinned to the bottom.
+ *
+ * Internal (not private) so WidgetContentLowStateTest can compose it in isolation.
+ */
 @Composable
-private fun StackedLayout(data: WidgetRenderState.Data) {
+internal fun StackedLayout(data: WidgetRenderState.Data) {
     Column(modifier = GlanceModifier.fillMaxSize()) {
         BrandingHeader(data.freedBytes, GlanceModifier.fillMaxWidth().clickable(openApp()))
         Spacer(GlanceModifier.height(12.dp))
@@ -194,9 +201,11 @@ private fun StackedLayout(data: WidgetRenderState.Data) {
 /**
  * 1 row, medium/wide: mascot + primary storage (tap → app) + Clean button. The button label only
  * shows at the widest sizes; at ~3 columns it's icon-only so the value isn't truncated.
+ *
+ * Internal (not private) so WidgetContentLowStateTest can compose it in isolation.
  */
 @Composable
-private fun ValueRowLayout(data: WidgetRenderState.Data, showButtonLabel: Boolean, showFreedText: Boolean) {
+internal fun ValueRowLayout(data: WidgetRenderState.Data, showButtonLabel: Boolean, showFreedText: Boolean) {
     val context = LocalContext.current
     Row(
         modifier = GlanceModifier.fillMaxSize(),
@@ -208,11 +217,15 @@ private fun ValueRowLayout(data: WidgetRenderState.Data, showButtonLabel: Boolea
             data.storages.firstOrNull()?.let { entry ->
                 Text(
                     text = usedOfTotal(context, entry),
-                    style = TextStyle(color = GlanceTheme.colors.onBackground, fontSize = 14.sp, fontWeight = FontWeight.Bold),
+                    style = TextStyle(
+                        color = storageValueColor(entry.isLow),
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                    ),
                     maxLines = 1,
                 )
                 Spacer(GlanceModifier.height(3.dp))
-                StorageBar(entry.usedRatio)
+                StorageBar(entry.usedRatio, entry.isLow)
                 if (showFreedText) {
                     Spacer(GlanceModifier.height(3.dp))
                     Text(
@@ -241,7 +254,7 @@ private fun RingRowLayout(data: WidgetRenderState.Data) {
         Mascot(NARROW_ELEMENT_SIZE, GlanceModifier.clickable(openApp()))
         Spacer(GlanceModifier.defaultWeight())
         Box(modifier = GlanceModifier.size(NARROW_ELEMENT_SIZE).clickable(openAnalyzer())) {
-            data.storages.firstOrNull()?.let { StorageRing(it.usedRatio, NARROW_ELEMENT_SIZE) }
+            data.storages.firstOrNull()?.let { StorageRing(it.usedRatio, NARROW_ELEMENT_SIZE, it.isLow) }
         }
         Spacer(GlanceModifier.defaultWeight())
         CleanCircle(NARROW_ELEMENT_SIZE, mode = data.cleanMode)
@@ -279,6 +292,29 @@ private fun Mascot(size: Dp, modifier: GlanceModifier = GlanceModifier) {
     )
 }
 
+/**
+ * The shared "storage is running out" amber, resolved from the day/night colour resources so the
+ * widget bars, the widget labels and the ring bitmap can't drift apart.
+ *
+ * Internal so WidgetContentLowStateTest can assert against the exact same value.
+ */
+internal fun lowStorageColorProvider(context: Context): ColorProvider = dayNightColorProvider(
+    day = Color(context.getColor(CommonUiR.color.md_theme_storageLow_day)),
+    night = Color(context.getColor(CommonUiR.color.md_theme_storageLow_night)),
+)
+
+/**
+ * Colour for the "used / total" storage figure. Amber when that volume is low.
+ *
+ * This label is NOT decoration: see the note on [StorageBar] — below API 31 it is the ONLY
+ * low-storage signal the widget can render.
+ */
+@Composable
+private fun storageValueColor(isLow: Boolean): ColorProvider = when {
+    isLow -> lowStorageColorProvider(LocalContext.current)
+    else -> GlanceTheme.colors.onBackground
+}
+
 @Composable
 private fun StorageRow(entry: WidgetRenderState.Data.StorageEntry) {
     val context = LocalContext.current
@@ -297,21 +333,32 @@ private fun StorageRow(entry: WidgetRenderState.Data.StorageEntry) {
             Spacer(GlanceModifier.defaultWeight())
             Text(
                 text = usedOfTotal(context, entry),
-                style = TextStyle(color = GlanceTheme.colors.onBackground, fontSize = 13.sp, fontWeight = FontWeight.Bold),
+                style = TextStyle(
+                    color = storageValueColor(entry.isLow),
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                ),
                 maxLines = 1,
             )
         }
         Spacer(GlanceModifier.height(5.dp))
-        StorageBar(entry.usedRatio)
+        StorageBar(entry.usedRatio, entry.isLow)
     }
 }
 
 @Composable
-private fun StorageBar(ratio: Float) {
+private fun StorageBar(ratio: Float, isLow: Boolean = false) {
+    val context = LocalContext.current
     LinearProgressIndicator(
         progress = ratio,
         modifier = GlanceModifier.fillMaxWidth().height(8.dp).cornerRadius(4.dp),
-        color = GlanceTheme.colors.primary,
+        // IMPORTANT: Glance (1.2.0-rc01) only applies a custom LinearProgressIndicator tint on
+        // API 31+ — below that this argument compiles and is then silently ignored, so the bar stays
+        // the default colour. minSdk is 26, which means on Android 8-11 the amber BAR never renders
+        // and the amber storage TEXT LABEL (storageValueColor) is the only low-storage signal there.
+        // That label colouring is therefore NOT redundant with this one; deleting it blinds those
+        // versions entirely. WidgetContentLowStateTest guards it.
+        color = if (isLow) lowStorageColorProvider(context) else GlanceTheme.colors.primary,
         backgroundColor = GlanceTheme.colors.secondaryContainer,
     )
 }
@@ -427,7 +474,7 @@ private fun UnavailableContent() {
     }
 }
 
-private fun usedOfTotal(context: Context, entry: WidgetRenderState.Data.StorageEntry): String =
+internal fun usedOfTotal(context: Context, entry: WidgetRenderState.Data.StorageEntry): String =
     "${formatSize(context, entry.usedBytes)} / ${formatSize(context, entry.totalBytes)}"
 
 private fun storageLabelRes(kind: WidgetRenderState.Data.StorageEntry.Kind): Int = when (kind) {

--- a/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContentPreviews.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContentPreviews.kt
@@ -19,6 +19,12 @@ private fun internal(usedGb: Long, totalGb: Long) =
 private fun external(usedGb: Long, totalGb: Long) =
     StorageEntry(StorageEntry.Kind.EXTERNAL, usedGb * GB, totalGb * GB)
 
+private fun internalLow(usedGb: Long, totalGb: Long) =
+    StorageEntry(StorageEntry.Kind.INTERNAL, usedGb * GB, totalGb * GB, isLow = true)
+
+private fun externalLow(usedGb: Long, totalGb: Long) =
+    StorageEntry(StorageEntry.Kind.EXTERNAL, usedGb * GB, totalGb * GB, isLow = true)
+
 @Preview(widthDp = 200, heightDp = 140)
 @Composable
 private fun WidgetContentNormalPreview() {
@@ -117,6 +123,41 @@ private fun WidgetContentLargePreview() {
     WidgetContent(
         WidgetRenderState.Data(
             storages = listOf(internal(45, 128), external(20, 64)),
+            freedBytes = 12 * GB,
+        )
+    )
+}
+
+// --- Low storage ---------------------------------------------------------------------------------
+// Free space at or below the configured threshold. All three layouts must signal it: bar + label in
+// the stacked and value-row layouts, ring arc in the narrow one. Note the amber bar only renders on
+// API 31+ (Glance limitation), which is why the label is coloured too — check both here.
+
+@Preview(widthDp = 200, heightDp = 140)
+@Composable
+private fun WidgetContentLowStackedPreview() {
+    WidgetContent(WidgetRenderState.Data(listOf(internalLow(126, 128)), freedBytes = 3 * GB))
+}
+
+@Preview(widthDp = 300, heightDp = 80)
+@Composable
+private fun WidgetContentLowValueRowPreview() {
+    WidgetContent(WidgetRenderState.Data(listOf(internalLow(126, 128)), freedBytes = 3 * GB))
+}
+
+@Preview(widthDp = 150, heightDp = 80)
+@Composable
+private fun WidgetContentLowRingPreview() {
+    WidgetContent(WidgetRenderState.Data(listOf(internalLow(126, 128)), freedBytes = 3 * GB))
+}
+
+// Per-volume: the SD card is low while the primary is fine, so only the second row goes amber.
+@Preview(widthDp = 220, heightDp = 170)
+@Composable
+private fun WidgetContentLowSecondaryOnlyPreview() {
+    WidgetContent(
+        WidgetRenderState.Data(
+            storages = listOf(internal(45, 128), externalLow(63, 64)),
             freedBytes = 12 * GB,
         )
     )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -448,4 +448,13 @@
     <string name="backup_restore_warn_history_body">This backup\'s history data (statistics, compression history, swipe sessions) is from a different app version and can\'t be restored. Everything else will be restored.</string>
     <string name="backup_restore_ack_understand">I understand and want to continue</string>
     <string name="backup_restore_action_restore">Restore</string>
+
+    <!-- Low space warning -->
+    <string name="stats_lowspace_notification_channel_label">Storage warnings</string>
+    <string name="stats_lowspace_notification_title">Storage is filling up</string>
+    <string name="stats_lowspace_notification_low_body">%1$s free. Storage is running out.</string>
+    <plurals name="stats_lowspace_notification_forecast_body">
+        <item quantity="one">About %1$d day of space left at this rate. %2$s free.</item>
+        <item quantity="other">About %1$d days of space left at this rate. %2$s free.</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,6 +452,7 @@
     <!-- Low space warning -->
     <string name="stats_lowspace_notification_channel_label">Storage warnings</string>
     <string name="stats_lowspace_notification_title">Storage is filling up</string>
+    <string name="stats_lowspace_notification_low_title">Storage is almost full</string>
     <string name="stats_lowspace_notification_low_body">%1$s free. Storage is running out.</string>
     <plurals name="stats_lowspace_notification_forecast_body">
         <item quantity="one">About %1$d day of space left at this rate. %2$s free.</item>

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/CombinedDeltaCalculationTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/CombinedDeltaCalculationTest.kt
@@ -5,6 +5,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.time.Duration
 import java.time.Instant
 
 internal class CombinedDeltaCalculationTest : BaseTest() {
@@ -92,5 +93,21 @@ internal class CombinedDeltaCalculationTest : BaseTest() {
                 snapshot("a", t1, used = 700),
             )
         ) shouldBe 200L
+    }
+
+    @Test
+    fun `a cleanup inside the window cannot report a filling device as emptying`() {
+        // A task forces a snapshot, so a window that ends right after a cleanup shows sharply more
+        // free space. First-to-last read that as -50, i.e. "usage shrinking", on a device that had
+        // gained 100 per day all week.
+        val filling = (0L..6L).map { day ->
+            snapshot(
+                storageId = "a",
+                recordedAt = t0.plus(Duration.ofDays(day)),
+                used = if (day == 6L) 19_950L else 20_000L + 100L * day,
+                capacity = 100_000L,
+            )
+        }
+        calculateCombinedDelta(filling) shouldBe 600L
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardAnalyzerForecastTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardAnalyzerForecastTest.kt
@@ -1,0 +1,241 @@
+package eu.darken.sdmse.main.ui.dashboard
+
+import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.appcleaner.core.AppCleaner
+import eu.darken.sdmse.appcontrol.core.AppControl
+import eu.darken.sdmse.common.WebpageTool
+import eu.darken.sdmse.common.areas.DataAreaManager
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.debug.DebugCardProvider
+import eu.darken.sdmse.common.debug.recorder.core.DebugLogSessionManager
+import eu.darken.sdmse.common.review.ReviewTool
+import eu.darken.sdmse.common.updater.UpdateService
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.corpsefinder.core.CorpseFinder
+import eu.darken.sdmse.deduplicator.core.Deduplicator
+import eu.darken.sdmse.main.core.CurriculumVitae
+import eu.darken.sdmse.main.core.DashboardCardConfig
+import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.main.core.motd.MotdRepo
+import eu.darken.sdmse.main.core.release.ReleaseManager
+import eu.darken.sdmse.main.core.taskmanager.TaskManager
+import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.main.ui.dashboard.cards.AnalyzerDashboardCardItem
+import eu.darken.sdmse.scheduler.core.SchedulerManager
+import eu.darken.sdmse.setup.SetupManager
+import eu.darken.sdmse.squeezer.core.Squeezer
+import eu.darken.sdmse.stats.core.SpaceHistoryRepo
+import eu.darken.sdmse.stats.core.SpaceTracker
+import eu.darken.sdmse.stats.core.StatsRepo
+import eu.darken.sdmse.stats.core.StatsSettings
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
+import eu.darken.sdmse.swiper.core.Swiper
+import eu.darken.sdmse.systemcleaner.core.SystemCleaner
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+/**
+ * The Analyzer card's free-space forecast: derived from the primary volume alone and from a live
+ * capacity/free reading, while the delta line keeps summing every storage.
+ */
+internal class DashboardAnalyzerForecastTest : BaseTest() {
+
+    private val base = LocalDate.parse("2026-06-01")
+    private val primaryId = "primary"
+    private val secondaryId = "sd-card"
+    private val primaryCapacity = 100_000_000_000L
+    private val secondaryCapacity = 64_000_000_000L
+    private val floor = 2_147_483_648L
+
+    private fun snapshot(
+        storageId: String,
+        day: Long,
+        used: Long,
+        capacity: Long,
+        hour: Long,
+    ) = SpaceSnapshotEntity(
+        storageId = storageId,
+        recordedAt = base.plusDays(day).atStartOfDay(ZoneOffset.UTC).toInstant().plus(Duration.ofHours(hour)),
+        spaceFree = capacity - used,
+        spaceCapacity = capacity,
+    )
+
+    /** Seven days of primary growth at [ratePerDay], plus a flat secondary volume recorded later each day. */
+    private fun mixedHistory(ratePerDay: Long): List<SpaceSnapshotEntity> = (0L..6L).flatMap { day ->
+        listOf(
+            snapshot(
+                storageId = primaryId,
+                day = day,
+                used = 10_000_000_000L + ratePerDay * day,
+                capacity = primaryCapacity,
+                hour = 12,
+            ),
+            // Later in the day and on a different capacity: if these leaked into the primary
+            // forecast they would own every day bucket and flatten the rate to zero.
+            snapshot(
+                storageId = secondaryId,
+                day = day,
+                used = 60_000_000_000L,
+                capacity = secondaryCapacity,
+                hour = 18,
+            ),
+        )
+    }
+
+    private fun primaryReading(free: Long) = SpaceTracker.StorageSnapshot(
+        storageId = primaryId,
+        spaceFree = free,
+        spaceCapacity = primaryCapacity,
+    )
+
+    private fun TestScope.harness(
+        history: List<SpaceSnapshotEntity>,
+        primary: SpaceTracker.StorageSnapshot?,
+    ): DashboardViewModel {
+        val statsSettings = mockk<StatsSettings>(relaxed = true).apply {
+            every { retentionReports } returns mockDuration()
+            every { retentionPaths } returns mockDuration()
+            every { retentionSnapshots } returns mockDuration()
+        }
+        val generalSettings = mockk<GeneralSettings>(relaxed = true).apply {
+            every { dashboardCardConfig } returns mockk(relaxed = true) {
+                every { flow } returns flowOf(DashboardCardConfig())
+            }
+            every { enableDashboardOneClick } returns mockk(relaxed = true) {
+                every { flow } returns MutableStateFlow(false)
+            }
+            every { dashboardHeroAutoShow } returns mockk(relaxed = true) {
+                every { flow } returns MutableStateFlow(true)
+            }
+        }
+
+        val vm = DashboardViewModel(
+            context = mockk(relaxed = true),
+            dispatcherProvider = TestDispatcherProvider(),
+            areaManager = mockk<DataAreaManager>(relaxed = true).apply { every { latestState } returns emptyFlow() },
+            taskManager = mockk<TaskManager>(relaxed = true).apply {
+                every { state } returns MutableStateFlow(TaskSubmitter.State())
+            },
+            setupManager = mockk<SetupManager>(relaxed = true).apply { every { state } returns emptyFlow() },
+            corpseFinder = mockk<CorpseFinder>(relaxed = true).apply { every { state } returns emptyFlow() },
+            systemCleaner = mockk<SystemCleaner>(relaxed = true).apply { every { state } returns emptyFlow() },
+            appCleaner = mockk<AppCleaner>(relaxed = true).apply { every { state } returns emptyFlow() },
+            appControl = mockk<AppControl>(relaxed = true).apply { every { state } returns emptyFlow() },
+            analyzer = mockk<Analyzer>(relaxed = true).apply {
+                every { data } returns emptyFlow()
+                every { progress } returns emptyFlow()
+            },
+            debugCardProvider = mockk<DebugCardProvider>(relaxed = true).apply {
+                every { create(any(), any(), any(), any()) } returns emptyFlow()
+            },
+            deduplicator = mockk<Deduplicator>(relaxed = true).apply { every { state } returns emptyFlow() },
+            squeezer = mockk<Squeezer>(relaxed = true).apply { every { state } returns emptyFlow() },
+            swiper = mockk<Swiper>(relaxed = true).apply {
+                every { getSessionsWithStats() } returns emptyFlow()
+                every { progress } returns emptyFlow()
+            },
+            upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply { every { upgradeInfo } returns emptyFlow() },
+            generalSettings = generalSettings,
+            webpageTool = mockk<WebpageTool>(relaxed = true),
+            schedulerManager = mockk<SchedulerManager>(relaxed = true).apply { every { state } returns emptyFlow() },
+            updateService = mockk<UpdateService>(relaxed = true).apply { every { availableUpdate } returns emptyFlow() },
+            sessionManager = mockk<DebugLogSessionManager>(relaxed = true).apply { every { sessions } returns emptyFlow() },
+            motdRepo = mockk<MotdRepo>(relaxed = true).apply { every { motd } returns emptyFlow() },
+            releaseManager = mockk<ReleaseManager>(relaxed = true),
+            reviewTool = mockk<ReviewTool>(relaxed = true).apply { every { state } returns emptyFlow() },
+            anniversaryProvider = mockk<AnniversaryProvider>(relaxed = true).apply { every { item } returns emptyFlow() },
+            statsRepo = mockk<StatsRepo>(relaxed = true).apply { every { state } returns emptyFlow() },
+            statsSettings = statsSettings,
+            curriculumVitae = mockk<CurriculumVitae>(relaxed = true).apply { every { installedAt } returns emptyFlow() },
+            spaceHistoryRepo = mockk<SpaceHistoryRepo>(relaxed = true).apply {
+                every { getAllHistory(any()) } returns flowOf(history)
+            },
+            spaceTracker = mockk<SpaceTracker>(relaxed = true).apply {
+                coEvery { readPrimaryStorage() } returns primary
+            },
+            deviceDetective = mockk(relaxed = true),
+        )
+
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.listState.collect { } }
+        return vm
+    }
+
+    private fun mockDuration(): DataStoreValue<Duration> = mockk(relaxed = true) {
+        every { flow } returns MutableStateFlow(Duration.ZERO)
+    }
+
+    private suspend fun DashboardViewModel.analyzerCard(): AnalyzerDashboardCardItem = listState
+        .mapNotNull { it?.items?.filterIsInstance<AnalyzerDashboardCardItem>()?.singleOrNull() }
+        .first { !it.isLoadingTrend }
+
+    @Test
+    fun `the forecast comes from the primary volume alone`() = runTest2 {
+        val vm = harness(
+            history = mixedHistory(ratePerDay = 1_000_000_000L),
+            primary = primaryReading(free = 20_000_000_000L),
+        )
+
+        vm.analyzerCard().forecast shouldBe StorageForecast.Filling(
+            daysUntilFloor = 18,
+            bytesPerDay = 1_000_000_000L,
+            isUrgent = false,
+        )
+    }
+
+    @Test
+    fun `an urgent forecast reaches the card`() = runTest2 {
+        val vm = harness(
+            history = mixedHistory(ratePerDay = 1_000_000_000L),
+            primary = primaryReading(free = floor + 5_500_000_000L),
+        )
+
+        vm.analyzerCard().forecast shouldBe StorageForecast.Filling(
+            daysUntilFloor = 6,
+            bytesPerDay = 1_000_000_000L,
+            isUrgent = true,
+        )
+    }
+
+    @Test
+    fun `without a live reading there is no forecast and the delta line survives`() = runTest2 {
+        val vm = harness(
+            history = mixedHistory(ratePerDay = 1_000_000_000L),
+            primary = null,
+        )
+
+        val card = vm.analyzerCard()
+        card.forecast.shouldBeNull()
+        card.combinedDelta shouldBe 6_000_000_000L
+    }
+
+    @Test
+    fun `a non-filling forecast leaves the delta line in place`() = runTest2 {
+        val vm = harness(
+            history = mixedHistory(ratePerDay = 0L),
+            primary = primaryReading(free = 20_000_000_000L),
+        )
+
+        val card = vm.analyzerCard()
+        card.forecast shouldBe StorageForecast.Stable
+        card.combinedDelta shouldBe 0L
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardAnalyzerForecastTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardAnalyzerForecastTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.main.ui.dashboard
 
 import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.appcontrol.core.AppControl
 import eu.darken.sdmse.common.WebpageTool
@@ -112,11 +113,17 @@ internal class DashboardAnalyzerForecastTest : BaseTest() {
     private fun TestScope.harness(
         history: List<SpaceSnapshotEntity>,
         primary: SpaceTracker.StorageSnapshot?,
-    ): DashboardViewModel = harness(historySource = flowOf(history), primarySource = { primary })
+        thresholdSource: Flow<Long?> = flowOf(null),
+    ): DashboardViewModel = harness(
+        historySource = flowOf(history),
+        primarySource = { primary },
+        thresholdSource = thresholdSource,
+    )
 
     private fun TestScope.harness(
         historySource: Flow<List<SpaceSnapshotEntity>>,
         primarySource: suspend () -> SpaceTracker.StorageSnapshot?,
+        thresholdSource: Flow<Long?> = flowOf(null),
     ): DashboardViewModel {
         val statsSettings = mockk<StatsSettings>(relaxed = true).apply {
             every { retentionReports } returns mockDuration()
@@ -132,6 +139,12 @@ internal class DashboardAnalyzerForecastTest : BaseTest() {
             }
             every { dashboardHeroAutoShow } returns mockk(relaxed = true) {
                 every { flow } returns MutableStateFlow(true)
+            }
+        }
+        // A relaxed mock's flow never emits, which would stall the Analyzer card's combine.
+        val analyzerSettings = mockk<AnalyzerSettings>(relaxed = true).apply {
+            every { lowStorageThresholdBytes } returns mockk(relaxed = true) {
+                every { flow } returns thresholdSource
             }
         }
 
@@ -151,6 +164,7 @@ internal class DashboardAnalyzerForecastTest : BaseTest() {
                 every { data } returns emptyFlow()
                 every { progress } returns emptyFlow()
             },
+            analyzerSettings = analyzerSettings,
             debugCardProvider = mockk<DebugCardProvider>(relaxed = true).apply {
                 every { create(any(), any(), any(), any()) } returns emptyFlow()
             },
@@ -272,5 +286,43 @@ internal class DashboardAnalyzerForecastTest : BaseTest() {
         val card = vm.analyzerCard()
         card.forecast shouldBe StorageForecast.Stable
         card.combinedDelta shouldBe 0L
+    }
+
+    @Test
+    fun `a custom threshold recomputes the forecast`() = runTest2 {
+        // Same history and the same live reading: only the configured floor moves, and the card
+        // has to follow it.
+        val threshold = MutableStateFlow<Long?>(null)
+        val vm = harness(
+            history = mixedHistory(ratePerDay = 1_000_000_000L),
+            primary = primaryReading(free = 20_000_000_000L),
+            thresholdSource = threshold,
+        )
+
+        val automatic = vm.analyzerCard().forecast
+        automatic shouldBe StorageForecast.Filling(
+            daysUntilFloor = 18,
+            bytesPerDay = 1_000_000_000L,
+            isUrgent = false,
+        )
+
+        threshold.value = 10_000_000_000L
+
+        vm.analyzerCard { it.forecast != automatic }.forecast shouldBe StorageForecast.Filling(
+            daysUntilFloor = 10,
+            bytesPerDay = 1_000_000_000L,
+            isUrgent = true,
+        )
+    }
+
+    @Test
+    fun `a custom threshold above the free space puts the card below the floor`() = runTest2 {
+        val vm = harness(
+            history = mixedHistory(ratePerDay = 1_000_000_000L),
+            primary = primaryReading(free = 20_000_000_000L),
+            thresholdSource = flowOf(25_000_000_000L),
+        )
+
+        vm.analyzerCard().forecast shouldBe StorageForecast.BelowFloor
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardAnalyzerForecastTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardAnalyzerForecastTest.kt
@@ -38,6 +38,8 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
@@ -110,6 +112,11 @@ internal class DashboardAnalyzerForecastTest : BaseTest() {
     private fun TestScope.harness(
         history: List<SpaceSnapshotEntity>,
         primary: SpaceTracker.StorageSnapshot?,
+    ): DashboardViewModel = harness(historySource = flowOf(history), primarySource = { primary })
+
+    private fun TestScope.harness(
+        historySource: Flow<List<SpaceSnapshotEntity>>,
+        primarySource: suspend () -> SpaceTracker.StorageSnapshot?,
     ): DashboardViewModel {
         val statsSettings = mockk<StatsSettings>(relaxed = true).apply {
             every { retentionReports } returns mockDuration()
@@ -167,10 +174,10 @@ internal class DashboardAnalyzerForecastTest : BaseTest() {
             statsSettings = statsSettings,
             curriculumVitae = mockk<CurriculumVitae>(relaxed = true).apply { every { installedAt } returns emptyFlow() },
             spaceHistoryRepo = mockk<SpaceHistoryRepo>(relaxed = true).apply {
-                every { getAllHistory(any()) } returns flowOf(history)
+                every { getAllHistory(any()) } returns historySource
             },
             spaceTracker = mockk<SpaceTracker>(relaxed = true).apply {
-                coEvery { readPrimaryStorage() } returns primary
+                coEvery { readPrimaryStorage() } coAnswers { primarySource() }
             },
             deviceDetective = mockk(relaxed = true),
         )
@@ -183,9 +190,11 @@ internal class DashboardAnalyzerForecastTest : BaseTest() {
         every { flow } returns MutableStateFlow(Duration.ZERO)
     }
 
-    private suspend fun DashboardViewModel.analyzerCard(): AnalyzerDashboardCardItem = listState
+    private suspend fun DashboardViewModel.analyzerCard(
+        predicate: (AnalyzerDashboardCardItem) -> Boolean = { true },
+    ): AnalyzerDashboardCardItem = listState
         .mapNotNull { it?.items?.filterIsInstance<AnalyzerDashboardCardItem>()?.singleOrNull() }
-        .first { !it.isLoadingTrend }
+        .first { !it.isLoadingTrend && predicate(it) }
 
     @Test
     fun `the forecast comes from the primary volume alone`() = runTest2 {
@@ -225,6 +234,32 @@ internal class DashboardAnalyzerForecastTest : BaseTest() {
         val card = vm.analyzerCard()
         card.forecast.shouldBeNull()
         card.combinedDelta shouldBe 6_000_000_000L
+    }
+
+    @Test
+    fun `every history emission is forecast against a fresh live reading`() = runTest2 {
+        // A cleanup forces a snapshot, so the history re-emits within the hourly refresh window.
+        // Reusing the reading taken at the last tick would keep an obsolete forecast on screen.
+        val historySource = MutableSharedFlow<List<SpaceSnapshotEntity>>(replay = 1)
+        var reading = primaryReading(free = 20_000_000_000L)
+        val vm = harness(historySource = historySource, primarySource = { reading })
+
+        historySource.emit(mixedHistory(ratePerDay = 1_000_000_000L))
+        val stale = vm.analyzerCard().forecast
+        stale shouldBe StorageForecast.Filling(
+            daysUntilFloor = 18,
+            bytesPerDay = 1_000_000_000L,
+            isUrgent = false,
+        )
+
+        reading = primaryReading(free = 50_000_000_000L)
+        historySource.emit(mixedHistory(ratePerDay = 1_000_000_000L))
+
+        vm.analyzerCard { it.forecast != stale }.forecast shouldBe StorageForecast.Filling(
+            daysUntilFloor = 48,
+            bytesPerDay = 1_000_000_000L,
+            isUrgent = false,
+        )
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
@@ -24,6 +24,7 @@ import eu.darken.sdmse.scheduler.core.SchedulerManager
 import eu.darken.sdmse.setup.SetupManager
 import eu.darken.sdmse.squeezer.core.Squeezer
 import eu.darken.sdmse.stats.core.SpaceHistoryRepo
+import eu.darken.sdmse.stats.core.SpaceTracker
 import eu.darken.sdmse.stats.core.StatsRepo
 import eu.darken.sdmse.stats.core.StatsSettings
 import eu.darken.sdmse.swiper.core.Swiper
@@ -115,6 +116,7 @@ internal class DashboardDiscardTest : BaseTest() {
             spaceHistoryRepo = mockk<SpaceHistoryRepo>(relaxed = true).apply {
                 every { getAllHistory(any()) } returns emptyFlow()
             },
+            spaceTracker = mockk<SpaceTracker>(relaxed = true),
             deviceDetective = mockk(relaxed = true),
         )
         return Harness(vm, taskManager, corpseFinder, systemCleaner, appCleaner, deduplicator)

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.main.ui.dashboard
 
 import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.appcontrol.core.AppControl
 import eu.darken.sdmse.common.WebpageTool
@@ -72,6 +73,12 @@ internal class DashboardDiscardTest : BaseTest() {
             every { data } returns emptyFlow()
             every { progress } returns emptyFlow()
         }
+        // A relaxed mock's flow never emits, which would stall the Analyzer card's combine.
+        val analyzerSettings = mockk<AnalyzerSettings>(relaxed = true).apply {
+            every { lowStorageThresholdBytes } returns mockk(relaxed = true) {
+                every { flow } returns flowOf<Long?>(null)
+            }
+        }
         val statsSettings = mockk<StatsSettings>(relaxed = true).apply {
             every { retentionReports } returns mockDuration()
             every { retentionPaths } returns mockDuration()
@@ -89,6 +96,7 @@ internal class DashboardDiscardTest : BaseTest() {
             appCleaner = appCleaner,
             appControl = appControl,
             analyzer = analyzer,
+            analyzerSettings = analyzerSettings,
             debugCardProvider = mockk<DebugCardProvider>(relaxed = true).apply {
                 every { create(any(), any(), any(), any()) } returns emptyFlow()
             },

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroToolRoutingTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroToolRoutingTest.kt
@@ -27,6 +27,7 @@ import eu.darken.sdmse.setup.SetupManager
 import eu.darken.sdmse.squeezer.core.Squeezer
 import eu.darken.sdmse.stats.core.Report
 import eu.darken.sdmse.stats.core.SpaceHistoryRepo
+import eu.darken.sdmse.stats.core.SpaceTracker
 import eu.darken.sdmse.stats.core.StatsRepo
 import eu.darken.sdmse.stats.core.StatsSettings
 import eu.darken.sdmse.stats.ui.AffectedFilesRoute
@@ -144,6 +145,7 @@ internal class DashboardHeroToolRoutingTest : BaseTest() {
             statsSettings = statsSettings,
             curriculumVitae = curriculumVitae,
             spaceHistoryRepo = spaceHistoryRepo,
+            spaceTracker = mockk<SpaceTracker>(relaxed = true),
             deviceDetective = mockk(relaxed = true),
         )
     }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroToolRoutingTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardHeroToolRoutingTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.main.ui.dashboard
 
 import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.appcontrol.core.AppControl
 import eu.darken.sdmse.common.WebpageTool
@@ -75,6 +76,12 @@ internal class DashboardHeroToolRoutingTest : BaseTest() {
             every { data } returns emptyFlow()
             every { progress } returns emptyFlow()
         }
+        // A relaxed mock's flow never emits, which would stall the Analyzer card's combine.
+        val analyzerSettings = mockk<AnalyzerSettings>(relaxed = true).apply {
+            every { lowStorageThresholdBytes } returns mockk(relaxed = true) {
+                every { flow } returns flowOf<Long?>(null)
+            }
+        }
         val schedulerManager = mockk<SchedulerManager>(relaxed = true).apply { every { state } returns emptyFlow() }
         val setupManager = mockk<SetupManager>(relaxed = true).apply { every { state } returns emptyFlow() }
         val areaManager = mockk<DataAreaManager>(relaxed = true).apply { every { latestState } returns emptyFlow() }
@@ -127,6 +134,7 @@ internal class DashboardHeroToolRoutingTest : BaseTest() {
             appCleaner = appCleaner,
             appControl = appControl,
             analyzer = analyzer,
+            analyzerSettings = analyzerSettings,
             debugCardProvider = debugCardProvider,
             deduplicator = deduplicator,
             squeezer = squeezer,

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.main.ui.dashboard
 
 import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.appcleaner.core.AppJunk
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
@@ -126,6 +127,12 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
             every { data } returns srcOr("analyzer", emptyFlow())
             every { progress } returns emptyFlow()
         }
+        // A relaxed mock's flow never emits, which would stall the Analyzer card's combine.
+        val analyzerSettings = mockk<AnalyzerSettings>(relaxed = true).apply {
+            every { lowStorageThresholdBytes } returns mockk(relaxed = true) {
+                every { flow } returns flowOf<Long?>(null)
+            }
+        }
         val schedulerManager = mockk<SchedulerManager>(relaxed = true).apply { every { state } returns emptyFlow() }
         val setupManager = mockk<SetupManager>(relaxed = true).apply { every { state } returns srcOr("setup", emptyFlow()) }
         val areaManager = mockk<DataAreaManager>(relaxed = true).apply { every { latestState } returns srcOr("dataArea", emptyFlow()) }
@@ -181,6 +188,7 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
             appCleaner = appCleaner,
             appControl = appControl,
             analyzer = analyzer,
+            analyzerSettings = analyzerSettings,
             debugCardProvider = debugCardProvider,
             deduplicator = deduplicator,
             squeezer = squeezer,

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardViewModelResilienceTest.kt
@@ -34,6 +34,7 @@ import eu.darken.sdmse.main.ui.dashboard.cards.StatsDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.SwiperDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.ToolDashboardCardItem
 import eu.darken.sdmse.stats.core.SpaceHistoryRepo
+import eu.darken.sdmse.stats.core.SpaceTracker
 import eu.darken.sdmse.stats.core.StatsRepo
 import eu.darken.sdmse.stats.core.StatsSettings
 import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
@@ -198,6 +199,7 @@ internal class DashboardViewModelResilienceTest : BaseTest() {
             statsSettings = statsSettings,
             curriculumVitae = curriculumVitae,
             spaceHistoryRepo = spaceHistoryRepo,
+            spaceTracker = mockk<SpaceTracker>(relaxed = true),
             deviceDetective = mockk(relaxed = true),
         )
 

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceAlertDeciderTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceAlertDeciderTest.kt
@@ -1,0 +1,138 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class LowSpaceAlertDeciderTest : BaseTest() {
+
+    private val free = 1_000_000_000L
+    private val urgent = StorageForecast.Filling(daysUntilFloor = 3, bytesPerDay = 1_000_000_000L, isUrgent = true)
+    private val calm = StorageForecast.Filling(daysUntilFloor = 90, bytesPerDay = 1_000_000L, isUrgent = false)
+
+    private fun decide(
+        enabled: Boolean = true,
+        isPro: Boolean = true,
+        armed: Boolean = true,
+        forecast: StorageForecast? = urgent,
+    ) = LowSpaceAlertDecider.decide(
+        enabled = enabled,
+        isPro = isPro,
+        armed = armed,
+        forecast = forecast,
+        freeBytes = free,
+    )
+
+    // ─────────────────────────── notify ───────────────────────────
+
+    @Test
+    fun `an urgent Filling forecast notifies with that forecast`() {
+        // Regression guard: forecast() returns BelowFloor the moment free space reaches the
+        // threshold, so a trigger on "is low" would make this branch unreachable.
+        val decision = decide(forecast = urgent)
+
+        val notify = decision.action.shouldBeInstanceOf<LowSpaceAction.Notify>()
+        notify.forecast shouldBe urgent
+        notify.freeBytes shouldBe free
+        // The caller sets the latch from the post result.
+        decision.armedAfter shouldBe null
+    }
+
+    @Test
+    fun `BelowFloor notifies`() {
+        val decision = decide(forecast = StorageForecast.BelowFloor)
+
+        val notify = decision.action.shouldBeInstanceOf<LowSpaceAction.Notify>()
+        notify.forecast shouldBe StorageForecast.BelowFloor
+        decision.armedAfter shouldBe null
+    }
+
+    // ─────────────────────────── nothing to say ───────────────────────────
+
+    @Test
+    fun `a non-urgent Filling forecast cancels and re-arms`() {
+        decide(forecast = calm) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `Stable cancels and re-arms`() {
+        decide(forecast = StorageForecast.Stable) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `Erratic cancels and re-arms`() {
+        decide(forecast = StorageForecast.Erratic) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `InsufficientData cancels and re-arms`() {
+        decide(forecast = StorageForecast.InsufficientData) shouldBe
+                LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `a missing forecast cancels and re-arms`() {
+        decide(forecast = null) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    // ─────────────────────────── gates ───────────────────────────
+
+    @Test
+    fun `a disabled toggle cancels and re-arms even in the warning band`() {
+        decide(enabled = false) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `a non-Pro user cancels and re-arms even in the warning band`() {
+        decide(isPro = false) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `recovery while the toggle is off re-arms`() {
+        // Latch already spent, feature switched off, storage recovered: the next crossing must
+        // still be able to speak.
+        decide(enabled = false, armed = false, forecast = StorageForecast.Stable) shouldBe
+                LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `recovery while non-Pro re-arms`() {
+        decide(isPro = false, armed = false, forecast = StorageForecast.Stable) shouldBe
+                LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    // ─────────────────────────── latch ───────────────────────────
+
+    @Test
+    fun `a spent latch stays quiet without clearing the standing notification`() {
+        decide(armed = false) shouldBe LowSpaceDecision(LowSpaceAction.Nothing, armedAfter = null)
+    }
+
+    @Test
+    fun `re-enabling while still in the warning band does not re-notify a spent latch`() {
+        // Off: cancel + re-arm... but the latch was already spent and the OFF pass re-armed it,
+        // so this models the case where the user toggles off and on again in one warning episode.
+        val off = decide(enabled = false, armed = false)
+        off.armedAfter shouldBe true
+
+        // Simulate the caller NOT having written the re-arm yet (e.g. the DataStore write lost a
+        // race): the latch is still spent, so nothing is posted.
+        decide(enabled = true, armed = false) shouldBe LowSpaceDecision(LowSpaceAction.Nothing, armedAfter = null)
+    }
+
+    @Test
+    fun `Pro loss then regain lets the warning speak again`() {
+        // Warned once, latch spent.
+        decide(armed = true).action.shouldBeInstanceOf<LowSpaceAction.Notify>()
+
+        // Pro lapses: cancel + re-arm.
+        val lost = decide(isPro = false, armed = false)
+        lost.action shouldBe LowSpaceAction.Cancel
+        lost.armedAfter shouldBe true
+
+        // Pro returns with the storage still in the warning band.
+        decide(isPro = true, armed = true).action.shouldBeInstanceOf<LowSpaceAction.Notify>()
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
@@ -12,8 +12,11 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -77,6 +80,8 @@ class LowSpaceMonitorTest : BaseTest() {
         enabled: Boolean = true,
         isPro: Boolean = true,
         armed: Boolean = true,
+        /** Virtual-time suspension inside the reading, so two checks can genuinely overlap. */
+        readDelayMs: Long = 0L,
         primary: SpaceTracker.StorageSnapshot? = SpaceTracker.StorageSnapshot(
             storageId = primaryId,
             spaceFree = floor + 2_500_000_000L,
@@ -95,7 +100,10 @@ class LowSpaceMonitorTest : BaseTest() {
             every { lowStorageThresholdBytes } returns statefulValue<Long?>(null)
         }
         val spaceTracker = mockk<SpaceTracker>().apply {
-            coEvery { readPrimaryStorage() } returns primary
+            coEvery { readPrimaryStorage() } coAnswers {
+                if (readDelayMs > 0L) delay(readDelayMs)
+                primary
+            }
         }
         val historyIds = mutableListOf<String>()
         val spaceHistoryRepo = mockk<SpaceHistoryRepo>().apply {
@@ -174,6 +182,20 @@ class LowSpaceMonitorTest : BaseTest() {
         h.monitor.check()
 
         verify(exactly = 1) { h.notifications.notifyLowSpace(StorageForecast.BelowFloor, floor - 1) }
+        h.armed.value() shouldBe false
+    }
+
+    @Test
+    fun `two concurrent checks notify exactly once`() = runTest2 {
+        // The six-hourly worker can overlap the observer. Both would read armed=true and post
+        // unless the read-decide-post-write transaction is serialized.
+        val h = harness(primary = reading(), readDelayMs = 1_000L)
+
+        launch { h.monitor.check() }
+        launch { h.monitor.check() }
+        advanceUntilIdle()
+
+        verify(exactly = 1) { h.notifications.notifyLowSpace(any(), any()) }
         h.armed.value() shouldBe false
     }
 

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
@@ -1,0 +1,310 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class LowSpaceMonitorTest : BaseTest() {
+
+    private val primaryId = "primary"
+    private val secondaryId = "secondary"
+    private val capacity = 100_000_000_000L
+
+    /** The automatic threshold for [capacity]: the smaller of 5% and 2 GiB. */
+    private val floor = LowStorage.resolveThreshold(capacity, null)
+
+    private val base = LocalDate.parse("2026-06-01")
+
+    private fun snap(storageId: String, day: Long, used: Long) = SpaceSnapshotEntity(
+        storageId = storageId,
+        recordedAt = base.plusDays(day).atStartOfDay(ZoneOffset.UTC).toInstant().plus(Duration.ofHours(12)),
+        spaceFree = capacity - used,
+        spaceCapacity = capacity,
+    )
+
+    /** Seven days of a steady 1 GB/day fill, which yields a [StorageForecast.Filling]. */
+    private fun fillingHistory(storageId: String) = (0 until 7).map {
+        snap(storageId, it.toLong(), 10_000_000_000L + 1_000_000_000L * it)
+    }
+
+    /** Stateful, so the armed latch behaves like the real DataStore across repeated checks. */
+    private fun <T> statefulValue(initial: T): DataStoreValue<T> {
+        val state = MutableStateFlow(initial)
+        return mockk<DataStoreValue<T>>().apply {
+            every { this@apply.flow } returns state
+            coEvery { update(any()) } answers {
+                val mutation = firstArg<(T) -> T?>()
+                val old = state.value
+                @Suppress("UNCHECKED_CAST")
+                val new = mutation(old) as T
+                state.value = new
+                DataStoreValue.Updated(old = old, new = new)
+            }
+        }
+    }
+
+    private class Harness(
+        val monitor: LowSpaceMonitor,
+        val notifications: LowSpaceNotifications,
+        val armed: DataStoreValue<Boolean>,
+        val historyIds: MutableList<String>,
+    )
+
+    private fun reading(free: Long = floor - 1) = SpaceTracker.StorageSnapshot(
+        storageId = primaryId,
+        spaceFree = free,
+        spaceCapacity = capacity,
+    )
+
+    private fun harness(
+        enabled: Boolean = true,
+        isPro: Boolean = true,
+        armed: Boolean = true,
+        primary: SpaceTracker.StorageSnapshot? = SpaceTracker.StorageSnapshot(
+            storageId = primaryId,
+            spaceFree = floor + 2_500_000_000L,
+            spaceCapacity = capacity,
+        ),
+        history: Map<String, List<SpaceSnapshotEntity>> = mapOf(
+            primaryId to fillingHistory(primaryId),
+            secondaryId to fillingHistory(secondaryId),
+        ),
+        postResult: LowSpaceNotifications.PostResult = LowSpaceNotifications.PostResult.POSTED,
+    ): Harness {
+        val armedValue = statefulValue(armed)
+        val settings = mockk<AnalyzerSettings>().apply {
+            every { lowSpaceNotificationEnabled } returns statefulValue(enabled)
+            every { lowSpaceNotificationArmed } returns armedValue
+            every { lowStorageThresholdBytes } returns statefulValue<Long?>(null)
+        }
+        val spaceTracker = mockk<SpaceTracker>().apply {
+            coEvery { readPrimaryStorage() } returns primary
+        }
+        val historyIds = mutableListOf<String>()
+        val spaceHistoryRepo = mockk<SpaceHistoryRepo>().apply {
+            every { getHistory(any(), any()) } answers {
+                val id = firstArg<String>()
+                historyIds += id
+                flowOf(history[id].orEmpty())
+            }
+        }
+        val info = mockk<UpgradeRepo.Info>().apply {
+            every { this@apply.isPro } returns isPro
+            every { isSettled } returns true
+            every { error } returns null
+        }
+        val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
+            // A StateFlow (which never completes) so a non-Pro isProSettled() takes its documented
+            // timeout path instead of throwing on an exhausted flow.
+            every { upgradeInfo } returns MutableStateFlow(info)
+        }
+        val notifications = mockk<LowSpaceNotifications>(relaxed = true).apply {
+            every { notifyLowSpace(any(), any()) } returns postResult
+        }
+
+        return Harness(
+            monitor = LowSpaceMonitor(
+                spaceTracker = spaceTracker,
+                spaceHistoryRepo = spaceHistoryRepo,
+                analyzerSettings = settings,
+                upgradeRepo = upgradeRepo,
+                notifications = notifications,
+            ),
+            notifications = notifications,
+            armed = armedValue,
+            historyIds = historyIds,
+        )
+    }
+
+    // ─────────────────────────── the predictive branch ───────────────────────────
+
+    @Test
+    fun `an urgent Filling forecast notifies with that forecast`() = runTest2 {
+        // Regression guard: BelowFloor is returned the moment free space reaches the threshold, so
+        // a trigger on "is low" would make the predictive copy unreachable.
+        val h = harness()
+
+        h.monitor.check()
+
+        val forecast = slot<StorageForecast>()
+        val free = slot<Long>()
+        verify(exactly = 1) { h.notifications.notifyLowSpace(capture(forecast), capture(free)) }
+        val filling = forecast.captured as StorageForecast.Filling
+        filling.isUrgent shouldBe true
+        filling.daysUntilFloor shouldBe 3L
+        free.captured shouldBe floor + 2_500_000_000L
+    }
+
+    @Test
+    fun `history is read for the primary storage only`() = runTest2 {
+        // StorageTrendCalculator needs single-volume snapshots; a merged list yields a
+        // meaningless rate.
+        val h = harness()
+
+        h.monitor.check()
+
+        h.historyIds shouldBe listOf(primaryId)
+    }
+
+    // ─────────────────────────── the latch ───────────────────────────
+
+    @Test
+    fun `a persistently low volume notifies exactly once`() = runTest2 {
+        val h = harness(primary = reading())
+
+        h.monitor.check()
+        h.monitor.check()
+        h.monitor.check()
+
+        verify(exactly = 1) { h.notifications.notifyLowSpace(StorageForecast.BelowFloor, floor - 1) }
+        h.armed.value() shouldBe false
+    }
+
+    @Test
+    fun `a blocked post leaves the latch armed`() = runTest2 {
+        val h = harness(
+            primary = reading(),
+            postResult = LowSpaceNotifications.PostResult.BLOCKED,
+        )
+
+        h.monitor.check()
+        h.armed.value() shouldBe true
+
+        // Still armed, so a later run (e.g. after the user grants the permission) tries again.
+        h.monitor.check()
+        verify(exactly = 2) { h.notifications.notifyLowSpace(any(), any()) }
+    }
+
+    @Test
+    fun `a failed post leaves the latch armed`() = runTest2 {
+        val h = harness(
+            primary = reading(),
+            postResult = LowSpaceNotifications.PostResult.FAILED,
+        )
+
+        h.monitor.check()
+
+        h.armed.value() shouldBe true
+    }
+
+    @Test
+    fun `a disabled toggle cancels and re-arms`() = runTest2 {
+        val h = harness(enabled = false, armed = false, primary = reading())
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+        verify(exactly = 1) { h.notifications.cancel() }
+        h.armed.value() shouldBe true
+    }
+
+    @Test
+    fun `a non-Pro user cancels and re-arms`() = runTest2 {
+        val h = harness(isPro = false, armed = false, primary = reading())
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+        verify(exactly = 1) { h.notifications.cancel() }
+        h.armed.value() shouldBe true
+    }
+
+    @Test
+    fun `a calm forecast cancels and re-arms`() = runTest2 {
+        val h = harness(
+            armed = false,
+            // Far above the floor, so the 1 GB/day trend is not urgent.
+            primary = reading(free = 60_000_000_000L),
+        )
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+        verify(exactly = 1) { h.notifications.cancel() }
+        h.armed.value() shouldBe true
+    }
+
+    // ─────────────────────────── implausible readings ───────────────────────────
+
+    @Test
+    fun `a zero-capacity reading is rejected`() = runTest2 {
+        // readPrimaryStorage() can return a non-null 0/0, which would otherwise post "0 B free".
+        val h = harness(
+            primary = SpaceTracker.StorageSnapshot(storageId = primaryId, spaceFree = 0L, spaceCapacity = 0L),
+        )
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+        verify(exactly = 0) { h.notifications.cancel() }
+    }
+
+    @Test
+    fun `a negative free value is rejected`() = runTest2 {
+        val h = harness(primary = reading(free = -1L))
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+    }
+
+    @Test
+    fun `free space larger than capacity is rejected`() = runTest2 {
+        val h = harness(primary = reading(free = capacity + 1))
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+    }
+
+    @Test
+    fun `a missing reading is rejected`() = runTest2 {
+        val h = harness(primary = null)
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+    }
+
+    // ─────────────────────────── resilience ───────────────────────────
+
+    @Test
+    fun `check swallows failures so the worker keeps going`() = runTest2 {
+        val settings = mockk<AnalyzerSettings>().apply {
+            every { lowSpaceNotificationEnabled } returns statefulValue(true)
+            every { lowSpaceNotificationArmed } returns statefulValue(true)
+            every { lowStorageThresholdBytes } returns statefulValue<Long?>(null)
+        }
+        val notifications = mockk<LowSpaceNotifications>(relaxed = true)
+        val monitor = LowSpaceMonitor(
+            spaceTracker = mockk<SpaceTracker>().apply {
+                coEvery { readPrimaryStorage() } throws IllegalStateException("boom")
+            },
+            spaceHistoryRepo = mockk(relaxed = true),
+            analyzerSettings = settings,
+            upgradeRepo = mockk(relaxed = true),
+            notifications = notifications,
+        )
+
+        monitor.check()
+
+        verify(exactly = 0) { notifications.notifyLowSpace(any(), any()) }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
@@ -12,10 +12,14 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -68,7 +72,14 @@ class LowSpaceMonitorTest : BaseTest() {
         val notifications: LowSpaceNotifications,
         val armed: DataStoreValue<Boolean>,
         val historyIds: MutableList<String>,
+        val upgradeInfo: MutableStateFlow<UpgradeRepo.Info>,
     )
+
+    private fun upgradeInfo(isPro: Boolean, isSettled: Boolean) = mockk<UpgradeRepo.Info>().apply {
+        every { this@apply.isPro } returns isPro
+        every { this@apply.isSettled } returns isSettled
+        every { error } returns null
+    }
 
     private fun reading(free: Long = floor - 1) = SpaceTracker.StorageSnapshot(
         storageId = primaryId,
@@ -79,6 +90,7 @@ class LowSpaceMonitorTest : BaseTest() {
     private fun harness(
         enabled: Boolean = true,
         isPro: Boolean = true,
+        isSettled: Boolean = true,
         armed: Boolean = true,
         /** Virtual-time suspension inside the reading, so two checks can genuinely overlap. */
         readDelayMs: Long = 0L,
@@ -113,15 +125,11 @@ class LowSpaceMonitorTest : BaseTest() {
                 flowOf(history[id].orEmpty())
             }
         }
-        val info = mockk<UpgradeRepo.Info>().apply {
-            every { this@apply.isPro } returns isPro
-            every { isSettled } returns true
-            every { error } returns null
-        }
+        // A StateFlow (which never completes) so a non-Pro isProSettled() takes its documented
+        // timeout path instead of throwing on an exhausted flow.
+        val infoFlow = MutableStateFlow(upgradeInfo(isPro = isPro, isSettled = isSettled))
         val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
-            // A StateFlow (which never completes) so a non-Pro isProSettled() takes its documented
-            // timeout path instead of throwing on an exhausted flow.
-            every { upgradeInfo } returns MutableStateFlow(info)
+            every { upgradeInfo } returns infoFlow
         }
         val notifications = mockk<LowSpaceNotifications>(relaxed = true).apply {
             every { notifyLowSpace(any(), any()) } returns postResult
@@ -138,6 +146,7 @@ class LowSpaceMonitorTest : BaseTest() {
             notifications = notifications,
             armed = armedValue,
             historyIds = historyIds,
+            upgradeInfo = infoFlow,
         )
     }
 
@@ -261,6 +270,46 @@ class LowSpaceMonitorTest : BaseTest() {
         verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
         verify(exactly = 1) { h.notifications.cancel() }
         h.armed.value() shouldBe true
+    }
+
+    // ─────────────────────────── the observer ───────────────────────────
+
+    @Test
+    fun `an unsettled entitlement is not treated as non-Pro, and acts once it settles`() = runTest2 {
+        // The GPlay pre-billing seed reports non-Pro even for paying users, so cancelling on it
+        // would re-arm and re-notify on every process start.
+        val h = harness(primary = reading(), isPro = false, isSettled = false)
+        val scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+
+        h.monitor.start(scope)
+        advanceUntilIdle()
+
+        verify(exactly = 0) { h.notifications.cancel() }
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+
+        h.upgradeInfo.value = upgradeInfo(isPro = true, isSettled = true)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { h.notifications.notifyLowSpace(any(), any()) }
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a disabled toggle cancels even while the entitlement is unsettled`() = runTest2 {
+        // A warning surviving from a previous process has to go now, not once billing settles -
+        // the process may exit before that ever happens.
+        val h = harness(enabled = false, armed = false, isPro = false, isSettled = false)
+        val scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+
+        h.monitor.start(scope)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { h.notifications.cancel() }
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+        h.armed.value() shouldBe true
+
+        scope.cancel()
     }
 
     // ─────────────────────────── implausible readings ───────────────────────────

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceNotificationsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceNotificationsTest.kt
@@ -1,0 +1,94 @@
+package eu.darken.sdmse.stats.core
+
+import android.Manifest
+import android.app.Application
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.main.ui.MainActivity
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class LowSpaceNotificationsTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val notificationManager: NotificationManager
+        get() = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    private fun notifications(granted: Boolean = true): LowSpaceNotifications {
+        val app = Shadows.shadowOf(ApplicationProvider.getApplicationContext<Application>())
+        if (granted) {
+            app.grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            app.denyPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        }
+        return LowSpaceNotifications(context = context, notificationManager = notificationManager)
+    }
+
+    private fun lastPosted(): Notification = Shadows
+        .shadowOf(notificationManager)
+        .getNotification(LowSpaceNotifications.NOTIFICATION_ID)
+
+    @Test
+    fun `the content intent does not collapse into the task manager PendingIntents`() {
+        // filterEquals ignores extras, and TaskWorkerNotifications / TaskResultNotifications both
+        // hold request code 0 against this bare intent. Sharing the shape would let
+        // FLAG_UPDATE_CURRENT rewrite THEIR extras and send their taps to the Analyzer.
+        val taskManagerIntent = Intent(context, MainActivity::class.java)
+
+        lowSpaceContentIntent(context).filterEquals(taskManagerIntent) shouldBe false
+        LowSpaceNotifications.REQUEST_CODE shouldBe 3000
+    }
+
+    @Test
+    fun `the content intent routes to the Analyzer`() {
+        val intent = lowSpaceContentIntent(context)
+
+        intent.component?.className shouldBe MainActivity::class.java.name
+        intent.action shouldBe LowSpaceNotifications.ACTION_LOW_SPACE
+    }
+
+    @Test
+    fun `the predictive body renders the day count`() {
+        notifications().notifyLowSpace(
+            forecast = StorageForecast.Filling(daysUntilFloor = 3, bytesPerDay = 1_000_000_000L, isUrgent = true),
+            freeBytes = 3_000_000_000L,
+        ) shouldBe LowSpaceNotifications.PostResult.POSTED
+
+        lastPosted().extras.getCharSequence(Notification.EXTRA_TEXT).toString() shouldContain "3 days"
+    }
+
+    @Test
+    fun `the below-floor body says the storage is running out`() {
+        notifications().notifyLowSpace(
+            forecast = StorageForecast.BelowFloor,
+            freeBytes = 1_000_000_000L,
+        ) shouldBe LowSpaceNotifications.PostResult.POSTED
+
+        lastPosted().extras.getCharSequence(Notification.EXTRA_TEXT).toString() shouldContain "running out"
+    }
+
+    @Test
+    fun `a missing POST_NOTIFICATIONS permission blocks instead of failing`() {
+        // API 33+ without the runtime permission must report BLOCKED so the caller keeps its latch
+        // armed for a later grant.
+        notifications(granted = false).notifyLowSpace(
+            forecast = StorageForecast.BelowFloor,
+            freeBytes = 1_000_000_000L,
+        ) shouldBe LowSpaceNotifications.PostResult.BLOCKED
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceNotificationsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceNotificationsTest.kt
@@ -43,6 +43,10 @@ class LowSpaceNotificationsTest : BaseTest() {
         .shadowOf(notificationManager)
         .getNotification(LowSpaceNotifications.NOTIFICATION_ID)
 
+    private fun Notification.title(): String = extras.getCharSequence(Notification.EXTRA_TITLE).toString()
+
+    private fun Notification.body(): String = extras.getCharSequence(Notification.EXTRA_TEXT).toString()
+
     @Test
     fun `the content intent does not collapse into the task manager PendingIntents`() {
         // filterEquals ignores extras, and TaskWorkerNotifications / TaskResultNotifications both
@@ -63,23 +67,28 @@ class LowSpaceNotificationsTest : BaseTest() {
     }
 
     @Test
-    fun `the predictive body renders the day count`() {
+    fun `the predictive variant warns about filling up and renders the day count`() {
         notifications().notifyLowSpace(
             forecast = StorageForecast.Filling(daysUntilFloor = 3, bytesPerDay = 1_000_000_000L, isUrgent = true),
             freeBytes = 3_000_000_000L,
         ) shouldBe LowSpaceNotifications.PostResult.POSTED
 
-        lastPosted().extras.getCharSequence(Notification.EXTRA_TEXT).toString() shouldContain "3 days"
+        val posted = lastPosted()
+        posted.title() shouldBe "Storage is filling up"
+        posted.body() shouldContain "3 days"
     }
 
     @Test
-    fun `the below-floor body says the storage is running out`() {
+    fun `the below-floor variant warns that storage is almost full and says it is running out`() {
+        // A trend title ("filling up") over a "running out" body understates the emergency.
         notifications().notifyLowSpace(
             forecast = StorageForecast.BelowFloor,
             freeBytes = 1_000_000_000L,
         ) shouldBe LowSpaceNotifications.PostResult.POSTED
 
-        lastPosted().extras.getCharSequence(Notification.EXTRA_TEXT).toString() shouldContain "running out"
+        val posted = lastPosted()
+        posted.title() shouldBe "Storage is almost full"
+        posted.body() shouldContain "running out"
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/widget/WidgetDataProviderTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/widget/WidgetDataProviderTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.widget
 
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.shortcuts.OneTapRunGuard
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
@@ -26,6 +27,7 @@ class WidgetDataProviderTest : BaseTest() {
 
     private val spaceTracker = mockk<SpaceTracker>()
     private val statsSettings = mockk<StatsSettings>()
+    private val analyzerSettings = mockk<AnalyzerSettings>()
     private val taskSubmitter = mockk<TaskSubmitter>()
     private val oneTapRunGuard = OneTapRunGuard()
 
@@ -34,7 +36,7 @@ class WidgetDataProviderTest : BaseTest() {
     // constructing the provider uses runTest2(autoCancel = true): the sharing coroutine never
     // completes on its own.
     private fun TestScope.provider() =
-        WidgetDataProvider(this, spaceTracker, statsSettings, taskSubmitter, oneTapRunGuard)
+        WidgetDataProvider(this, spaceTracker, statsSettings, analyzerSettings, taskSubmitter, oneTapRunGuard)
 
     private fun snapshot(free: Long, capacity: Long) = SpaceTracker.StorageSnapshot(
         storageId = "s",
@@ -70,10 +72,14 @@ class WidgetDataProviderTest : BaseTest() {
         secondary: List<SpaceTracker.StorageSnapshot> = emptyList(),
         freed: Long = 0L,
         taskState: TaskSubmitter.State = TaskSubmitter.State(),
+        lowThreshold: Long? = null,
     ) {
         coEvery { spaceTracker.readPrimaryStorage() } returns primary
         coEvery { spaceTracker.readSecondaryStorages() } returns secondary
         every { statsSettings.totalSpaceFreed } returns mockDataStoreValue(freed)
+        // Must actually emit: a relaxed mock hands back a Flow that never does, which stalls the
+        // renderState combine forever.
+        every { analyzerSettings.lowStorageThresholdBytes } returns mockDataStoreValue(lowThreshold)
         every { taskSubmitter.state } returns MutableStateFlow(taskState)
     }
 
@@ -157,6 +163,75 @@ class WidgetDataProviderTest : BaseTest() {
     }
 
     @Test
+    fun `automatic threshold - free above 5 percent is not low`() = runTest2(autoCancel = true) {
+        // capacity 500 → automatic threshold is 5% = 25 (the 2 GiB cap doesn't bite here).
+        stub(primary = snapshot(free = 26, capacity = 500), lowThreshold = null)
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages.single().isLow shouldBe false
+    }
+
+    @Test
+    fun `automatic threshold - free exactly at the threshold is low`() = runTest2(autoCancel = true) {
+        stub(primary = snapshot(free = 25, capacity = 500), lowThreshold = null)
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages.single().isLow shouldBe true
+    }
+
+    @Test
+    fun `automatic threshold - free below the threshold is low`() = runTest2(autoCancel = true) {
+        stub(primary = snapshot(free = 1, capacity = 500), lowThreshold = null)
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages.single().isLow shouldBe true
+    }
+
+    @Test
+    fun `a custom threshold overrides the automatic one`() = runTest2(autoCancel = true) {
+        // free = 100 is far above the automatic 25, but below the configured 200.
+        stub(primary = snapshot(free = 100, capacity = 500), lowThreshold = 200L)
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages.single().isLow shouldBe true
+    }
+
+    @Test
+    fun `a custom threshold below the automatic one keeps a volume normal`() = runTest2(autoCancel = true) {
+        // free = 20 would be low automatically (threshold 25), but the user configured 10.
+        stub(primary = snapshot(free = 20, capacity = 500), lowThreshold = 10L)
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages.single().isLow shouldBe false
+    }
+
+    @Test
+    fun `isLow is per volume - a low SD card does not flag the primary`() = runTest2(autoCancel = true) {
+        // Automatic thresholds: primary 5% of 500 = 25, secondary 5% of 200 = 10.
+        stub(
+            primary = snapshot(free = 400, capacity = 500),
+            secondary = listOf(snapshot(free = 5, capacity = 200)),
+            lowThreshold = null,
+        )
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages[0].isLow shouldBe false
+        state.storages[1].isLow shouldBe true
+    }
+
+    @Test
     fun `usedRatio is a clamped fraction`() {
         WidgetRenderState.Data.StorageEntry(Kind.INTERNAL, usedBytes = 250, totalBytes = 1000).usedRatio shouldBe 0.25f
         WidgetRenderState.Data.StorageEntry(Kind.INTERNAL, usedBytes = 0, totalBytes = 0).usedRatio shouldBe 0f
@@ -216,6 +291,7 @@ class WidgetDataProviderTest : BaseTest() {
         coEvery { spaceTracker.readPrimaryStorage() } returns snapshot(free = 100, capacity = 500)
         coEvery { spaceTracker.readSecondaryStorages() } returns emptyList()
         every { statsSettings.totalSpaceFreed } returns mockk { every { flow } returns freedFlow }
+        every { analyzerSettings.lowStorageThresholdBytes } returns mockDataStoreValue(null)
         every { taskSubmitter.state } returns taskFlow
 
         val provider = provider()

--- a/app/src/test/java/eu/darken/sdmse/widget/ui/StorageRingColorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/widget/ui/StorageRingColorTest.kt
@@ -1,0 +1,53 @@
+package eu.darken.sdmse.widget.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import eu.darken.sdmse.common.ui.R as CommonUiR
+
+/**
+ * Colour selection for the widget's storage ring. The ring is drawn into a [android.graphics.Bitmap],
+ * and Robolectric's Canvas is a stub that rasterises nothing — asserting pixels there would prove
+ * nothing, so the pure selection function is what gets tested.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestApplication::class)
+class StorageRingColorTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    @Config(sdk = [30])
+    fun `normal storage below API 31 uses the app primary`() {
+        storageArcColor(context, isLow = false) shouldBe context.getColor(CommonUiR.color.md_theme_primary)
+    }
+
+    @Test
+    @Config(sdk = [33])
+    fun `normal storage on API 31+ uses the Material You accent`() {
+        storageArcColor(context, isLow = false) shouldBe context.getColor(android.R.color.system_accent1_500)
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `low storage below API 31 is amber`() {
+        storageArcColor(context, isLow = true) shouldBe context.getColor(CommonUiR.color.md_theme_storageLow)
+    }
+
+    @Test
+    @Config(sdk = [33])
+    fun `low storage wins over the Material You accent`() {
+        // The whole point of ordering the low branch first: on a device whose wallpaper accent
+        // happens to look like a warning, or like anything else, the warning must still win.
+        storageArcColor(context, isLow = true) shouldBe context.getColor(CommonUiR.color.md_theme_storageLow)
+        storageArcColor(context, isLow = true) shouldNotBe context.getColor(android.R.color.system_accent1_500)
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/widget/ui/WidgetContentLowStateTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/widget/ui/WidgetContentLowStateTest.kt
@@ -1,0 +1,141 @@
+package eu.darken.sdmse.widget.ui
+
+import android.content.Context
+import androidx.glance.EmittableWithText
+import androidx.glance.appwidget.EmittableLinearProgressIndicator
+import androidx.glance.appwidget.testing.unit.runGlanceAppWidgetUnitTest
+import androidx.glance.testing.GlanceNodeMatcher
+import androidx.glance.testing.unit.MappedNode
+import androidx.glance.testing.unit.hasTextEqualTo
+import androidx.glance.unit.ColorProvider
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.widget.WidgetRenderState
+import eu.darken.sdmse.widget.WidgetRenderState.Data.StorageEntry
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * Guards the low-storage signal in the two bar-based widget layouts.
+ *
+ * The label assertions are the important ones: Glance 1.2.0-rc01 only applies a custom
+ * [androidx.glance.appwidget.LinearProgressIndicator] tint on API 31+ and silently drops it below
+ * that, so on Android 8-11 (minSdk is 26) the amber TEXT LABEL is the only low-storage signal the
+ * widget can render. If a refactor drops the label colouring as "redundant with the bar", those
+ * versions lose the warning entirely and nothing else in the suite notices.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class WidgetContentLowStateTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun entry(isLow: Boolean) = StorageEntry(
+        kind = StorageEntry.Kind.INTERNAL,
+        usedBytes = 126_000_000_000L,
+        totalBytes = 128_000_000_000L,
+        isLow = isLow,
+    )
+
+    private fun data(isLow: Boolean) = WidgetRenderState.Data(
+        storages = listOf(entry(isLow)),
+        freedBytes = 3_000_000_000L,
+    )
+
+    // Glance ships no colour matcher, so these reach into the emitted node. The Emittable types are
+    // @RestrictTo(LIBRARY_GROUP) — public bytecode, lint-only, and lint doesn't scan unit-test
+    // sources here.
+    private fun hasTextColor(expected: ColorProvider) = GlanceNodeMatcher<MappedNode>(
+        description = "text colour is $expected",
+    ) { node ->
+        val emittable = node.value.emittable
+        emittable is EmittableWithText && emittable.style?.color == expected
+    }
+
+    private fun isProgressBarWithColor(expected: ColorProvider) = GlanceNodeMatcher<MappedNode>(
+        description = "linear progress indicator with colour $expected",
+    ) { node ->
+        val emittable = node.value.emittable
+        emittable is EmittableLinearProgressIndicator && emittable.color == expected
+    }
+
+    @Test
+    fun `stacked layout - a low volume colours the storage label amber`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable { StackedLayout(data(isLow = true)) }
+
+        onNode(
+            hasTextEqualTo(usedOfTotal(context, entry(isLow = true)))
+                and hasTextColor(lowStorageColorProvider(context))
+        ).assertExists()
+    }
+
+    @Test
+    fun `stacked layout - a normal volume leaves the storage label alone`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable { StackedLayout(data(isLow = false)) }
+
+        // Positive first, so a changed label format can't make the negative assertion vacuous.
+        onNode(hasTextEqualTo(usedOfTotal(context, entry(isLow = false)))).assertExists()
+        onNode(
+            hasTextEqualTo(usedOfTotal(context, entry(isLow = false)))
+                and hasTextColor(lowStorageColorProvider(context))
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `value row layout - a low volume colours the storage label amber`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable {
+            ValueRowLayout(data(isLow = true), showButtonLabel = true, showFreedText = true)
+        }
+
+        onNode(
+            hasTextEqualTo(usedOfTotal(context, entry(isLow = true)))
+                and hasTextColor(lowStorageColorProvider(context))
+        ).assertExists()
+    }
+
+    @Test
+    fun `value row layout - a normal volume leaves the storage label alone`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable {
+            ValueRowLayout(data(isLow = false), showButtonLabel = true, showFreedText = true)
+        }
+
+        // Positive first, so a changed label format can't make the negative assertion vacuous.
+        onNode(hasTextEqualTo(usedOfTotal(context, entry(isLow = false)))).assertExists()
+        onNode(
+            hasTextEqualTo(usedOfTotal(context, entry(isLow = false)))
+                and hasTextColor(lowStorageColorProvider(context))
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `stacked layout - a low volume also colours the bar`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable { StackedLayout(data(isLow = true)) }
+
+        onNode(isProgressBarWithColor(lowStorageColorProvider(context))).assertExists()
+    }
+
+    @Test
+    fun `value row layout - a low volume also colours the bar`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable {
+            ValueRowLayout(data(isLow = true), showButtonLabel = true, showFreedText = true)
+        }
+
+        onNode(isProgressBarWithColor(lowStorageColorProvider(context))).assertExists()
+    }
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -205,6 +205,11 @@ fun DependencyHandlerScope.addGlance() {
     // @Preview annotation (kept on the main classpath); renderer stays debug-only.
     implementation("androidx.glance:glance-preview:${Versions.AndroidX.Glance.core}")
     debugImplementation("androidx.glance:glance-appwidget-preview:${Versions.AndroidX.Glance.core}")
+
+    // runGlanceAppWidgetUnitTest: composes Glance content on the JVM and asserts on the emitted
+    // node tree. Glance content can't be driven by the normal Compose test rule (own Applier), so
+    // this is the only way to unit-test what a widget layout actually emits.
+    testImplementation("androidx.glance:glance-appwidget-testing:${Versions.AndroidX.Glance.core}")
 }
 
 fun DependencyHandlerScope.addNavigation3() {


### PR DESCRIPTION
## What changed

Four related changes to how SD Maid understands and reports storage running low. They were developed and reviewed as a stack of four pull requests (#2700, #2701, #2703) and folded into this one so CI validates them together before they reach main.

**The storage trend figure was wrong.** On the dashboard, the Device Storage screen and the Storage Trend screen it was worked out by comparing just the first and the last reading in the window. SD Maid records a storage snapshot after every cleaning task, so running any cleanup inside that window made the figure report that you had *gained* free space, drawn in the "usage is shrinking" colour, while the device was actually filling up. All three places now use one shared calculation that is not thrown off by a single unusual day, whether that is a cleanup, a large install, or a gap in recording.

**The dashboard estimates how long you have.** The Storage Analyzer card now shows something like "About 17 days of space left at this rate" when storage is filling steadily. It stays quiet when there is no clear trend, when the estimate is far out, and when free space is already below the low storage mark, so a device that is permanently near full never carries a permanent warning.

**The Storage Analyzer has a settings screen**, reachable from Settings under Tools, holding the low storage threshold: the point at which SD Maid treats a storage device as running out. The default is "Automatic", which is whichever is smaller of 5% of capacity or 2 GB, exactly as before, and it shows what that works out to on your device. You can replace it with an exact figure, used as given with no adjustment for device size.

**The widget shows it.** The home screen widget turns its storage indicator amber when a storage device drops to or below that threshold. All three widget sizes signal it, and each storage device is judged on its own, so a nearly full SD card turns amber while internal storage stays normal.

**SD Maid can warn you before you run out.** Off by default, switched on in the new settings screen, and a Pro feature. It watches the fill rate and notifies when your storage is heading for the threshold, saying roughly how many days you have left at the current rate, or how much is left if you are already below it. Tapping it opens the storage overview. It warns once rather than repeating, and clears itself when you free up space, switch it off, or if Pro lapses.

Refs #1903, which this now covers in full: both the detection and the optional prompt it asked for.

## Technical Context

- Root cause of the trend defect was a first-to-last delta over a window that `TaskStatsCoordinator` perturbs by design, since it force-records a snapshot after every task. It is replaced by a median of per-day rates, which survives one cleanup, one large install, or one sampling gap.
- The definition of "low on space" lives in one shared `LowStorage` object because the forecast, the widget and the notification must all agree. `StorageForecaster.forecast()` takes the resolved threshold as a required parameter with no default argument: a default would have let a mis-wired call site silently keep the old hardcoded behaviour.
- The notification triggers on the forecast, not on a "storage is low" flag. That distinction is load-bearing: `forecast()` returns `BelowFloor` the instant free space reaches the threshold, so keying off "is low" would have made the days-remaining wording unreachable and turned the feature into an after-the-fact alert.
- The warn-once behaviour is a stored latch. Only a successful post clears it, so a post Android blocked still arrives once the user fixes the cause; every cancel re-arms it, so toggling the feature off and on cannot leave someone silently un-warned; and it is excluded from settings backup, since restoring it onto a new phone would otherwise suppress that phone's first warning forever.
- The six-hourly worker and the settings observer run the same read-decide-post-write sequence, serialized behind a mutex so a cancel cannot lose to an in-flight post and strand a notification after the feature was switched off. Entitlement is read as "unknown until settled" rather than filtered, because Google Play emits an unsettled non-Pro value at every process start.
- Glance only tints its progress bar on Android 12 and above, silently ignoring the colour below that, so the widget's used-of-total label is coloured too and carries the signal on Android 8 through 11. The call site says so, because that label looks redundant next to the bar and is otherwise an obvious thing to delete.
- Known and deliberate: an in-progress edit in the threshold picker is lost if the activity is recreated. That matches every other settings dialog in the app; fixing it properly means changing the shared `SizeInputDialog` for all five screens that use it.
- Manual verification covered what CI cannot: the notification posting on a device, its wording, tapping through to the storage overview, and cancel-and-rearm on toggling. The widget rendering amber is not covered by any test, since placing a widget needs a drag-and-drop no automation can perform.
