### PR TITLE
General: Clearer setup cards for root access and the app list

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/SetupLimitationBox.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupLimitationBox.kt
@@ -26,7 +26,8 @@ import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 /**
  * Highlighted hint for setup states the user can't (fully) fix themselves, e.g. OS restrictions or device
  * limitations. Actions stack vertically; long button labels must not wrap. Callers with several short-labeled
- * actions can place their own Row inside the slot.
+ * actions can place their own Row inside the slot. The action slot is optional: pass no actions for states
+ * that only need explaining.
  */
 @Composable
 internal fun SetupLimitationBox(
@@ -34,7 +35,7 @@ internal fun SetupLimitationBox(
     body: String,
     modifier: Modifier = Modifier,
     body2: String? = null,
-    actions: @Composable ColumnScope.() -> Unit,
+    actions: (@Composable ColumnScope.() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier
@@ -71,13 +72,17 @@ internal fun SetupLimitationBox(
                 color = Color.Unspecified,
             )
         }
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            actions()
+        // Skipped entirely when there are no actions: the Column's top padding would otherwise
+        // leave a gap below the body.
+        actions?.let {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                it()
+            }
         }
     }
 }

--- a/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCard.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Apps
 import androidx.compose.material.icons.twotone.CheckCircle
-import androidx.compose.material.icons.twotone.ErrorOutline
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -55,8 +54,10 @@ internal fun InventorySetupCard(
                 .padding(horizontal = 16.dp),
         )
 
-        if (item.state.missingPermission.isEmpty()) {
-            val isError = item.state.isAccessFaked
+        // Faked access is left to the limitation box below: it already carries a warning icon, its own
+        // title and a body that explains the state, so this row was a second error header with strictly
+        // less information.
+        if (item.state.missingPermission.isEmpty() && !item.state.isAccessFaked) {
             Row(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
@@ -65,18 +66,15 @@ internal fun InventorySetupCard(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Icon(
-                    imageVector = if (isError) Icons.TwoTone.ErrorOutline else Icons.TwoTone.CheckCircle,
+                    imageVector = Icons.TwoTone.CheckCircle,
                     contentDescription = null,
-                    tint = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                    tint = MaterialTheme.colorScheme.primary,
                     modifier = Modifier.size(20.dp),
                 )
                 Text(
-                    text = stringResource(
-                        if (isError) R.string.setup_inventory_invalid_label
-                        else R.string.setup_permission_granted_label,
-                    ),
+                    text = stringResource(R.string.setup_permission_granted_label),
                     style = MaterialTheme.typography.labelLarge,
-                    color = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.primary,
+                    color = MaterialTheme.colorScheme.primary,
                 )
             }
         }

--- a/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupCard.kt
@@ -24,6 +24,7 @@ import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.setup.SetupCardContainer
 import eu.darken.sdmse.setup.SetupCardItem
+import eu.darken.sdmse.setup.SetupLimitationBox
 
 data class RootSetupCardItem(
     override val state: RootSetupModule.Result,
@@ -51,27 +52,42 @@ internal fun RootSetupCard(
         )
         if (item.state.useRoot == true) {
             val ready = item.state.ourService
-            // The probe has settled by the time we render a Result (Loading shows a spinner card
-            // instead), so ourService == false is a definitive "not available" — not "waiting".
-            // We never claim the device isn't rooted: root detection is unreliable, so we only
-            // report our own probe outcome.
-            val stateText = stringResource(
-                if (ready) R.string.setup_root_state_ready_label
-                else R.string.setup_root_state_waiting_label,
-            )
-            Text(
-                text = stateText,
-                style = MaterialTheme.typography.labelMedium,
-                color = if (ready) {
-                    MaterialTheme.colorScheme.onSurfaceVariant
-                } else {
-                    MaterialTheme.colorScheme.error
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp),
-                textAlign = TextAlign.Center,
-            )
+            // A known root manager is installed but our service never came up: SD Maid asked for root
+            // and didn't get it, which is worth explaining. Without a root manager (isInstalled == false)
+            // there is nothing the user can act on here, so that case keeps the plain one-liner.
+            val failed = item.state.isInstalled && !item.state.ourService
+
+            if (!failed) {
+                // The probe has settled by the time we render a Result (Loading shows a spinner card
+                // instead), so ourService == false is a definitive "not available" — not "waiting".
+                // We never claim the device isn't rooted: root detection is unreliable, so we only
+                // report our own probe outcome.
+                val stateText = stringResource(
+                    if (ready) R.string.setup_root_state_ready_label
+                    else R.string.setup_root_state_waiting_label,
+                )
+                Text(
+                    text = stateText,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = if (ready) {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    } else {
+                        MaterialTheme.colorScheme.error
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp),
+                    textAlign = TextAlign.Center,
+                )
+            } else {
+                // Start aligned, multi-line explanation instead of the centred one-liner, matching how
+                // the Shizuku card presents its settled failure. No actions: retrying is the root
+                // manager's job, and the card header already carries the help icon.
+                SetupLimitationBox(
+                    title = stringResource(R.string.setup_root_state_failed_title),
+                    body = stringResource(R.string.setup_root_state_failed_body),
+                )
+            }
         }
         Column(
             modifier = Modifier
@@ -139,6 +155,24 @@ private fun RootSetupCardPreview() {
                     useRoot = true,
                     isInstalled = true,
                     ourService = true,
+                ),
+                onToggleUseRoot = {},
+                onHelp = {},
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun RootSetupCardFailedPreview() {
+    PreviewWrapper {
+        RootSetupCard(
+            item = RootSetupCardItem(
+                state = RootSetupModule.Result(
+                    useRoot = true,
+                    isInstalled = true,
+                    ourService = false,
                 ),
                 onToggleUseRoot = {},
                 onHelp = {},

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -265,6 +265,8 @@
     <string name="setup_root_card_body">Should SD Maid use root access if it is available? Root access can be used to check additional system folders and private application data.</string>
     <string name="setup_root_state_ready_label">Root access is ready.</string>
     <string name="setup_root_state_waiting_label">Root access is not available.</string>
+    <string name="setup_root_state_failed_title">Root access failed</string>
+    <string name="setup_root_state_failed_body">SD Maid asked for root access and didn\'t get it. If your device is rooted, open your root manager (Magisk, KernelSU or similar) and check whether the request from SD Maid was denied or is still waiting.</string>
     <string name="setup_root_enable_root_use_label">Try to use root access</string>
     <string name="setup_root_disable_root_use_label">I didn\'t root my device</string>
     <string name="setup_root_card_body2">Only available on rooted devices. If you didn\'t make this modification, then your device is not rooted and this setting has no effect.</string>

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
@@ -116,7 +116,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
     }
 
     @Test
-    fun `inventory card with fake access shows error label, limitation box and open settings button`() {
+    fun `inventory card with fake access shows limitation box and open settings button`() {
         composeRule.setSetupContent {
             SetupScreen(
                 uiState = SetupUiState.Cards(
@@ -134,7 +134,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                 ),
             )
         }
-        composeRule.onAllNodesWithText(context.getString(R.string.setup_inventory_invalid_label)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_permission_granted_label)).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.setup_inventory_limitation_title)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.setup_inventory_limitation_body)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.setup_inventory_limitation_body2)).assertCountEquals(1)
@@ -194,7 +194,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
         }
         composeRule.onAllNodesWithText(context.getString(CommonR.string.general_grant_access_action)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.setup_inventory_limitation_title)).assertCountEquals(0)
-        composeRule.onAllNodesWithText(context.getString(R.string.setup_inventory_invalid_label)).assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_permission_granted_label)).assertCountEquals(0)
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
@@ -244,6 +244,55 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
     }
 
     @Test
+    fun `root card with installed root manager and failed service shows limitation box`() {
+        composeRule.setSetupContent {
+            SetupScreen(
+                uiState = SetupUiState.Cards(
+                    items = listOf(
+                        RootSetupCardItem(
+                            state = RootSetupModule.Result(
+                                useRoot = true,
+                                isInstalled = true,
+                                ourService = false,
+                            ),
+                            onToggleUseRoot = {},
+                            onHelp = {},
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_root_state_failed_title)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_root_state_failed_body)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_root_state_waiting_label)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `root card with working root service shows ready label and no limitation box`() {
+        composeRule.setSetupContent {
+            SetupScreen(
+                uiState = SetupUiState.Cards(
+                    items = listOf(
+                        RootSetupCardItem(
+                            state = RootSetupModule.Result(
+                                useRoot = true,
+                                isInstalled = true,
+                                ourService = true,
+                            ),
+                            onToggleUseRoot = {},
+                            onHelp = {},
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_root_state_ready_label)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_root_state_failed_title)).assertCountEquals(0)
+    }
+
+    @Test
     fun `automation card with full consent shows enabled + running states and disallow action`() {
         composeRule.setSetupContent {
             SetupScreen(


### PR DESCRIPTION
## What changed

Two improvements to the setup screen.

When you allow SD Maid to use root access but the request never comes through, the setup card used to show a single red line, "Root access is not available.", and nothing else. It now explains what happened and what to check: if your device is rooted, open your root manager (Magisk, KernelSU or similar) and look for a request from SD Maid that was denied or is still waiting. Devices with no root manager installed at all are unchanged, since there is nothing to act on there.

The app inventory card used to stack two warnings on top of each other when a device returns an incomplete app list: a red "Invalid app list" line, and directly beneath it the box that actually explains the problem and offers a way forward. The red line is gone, the explanation stays.

## Technical Context

- The root card now separates two states the old one-liner collapsed together. `isInstalled && !ourService` means a known root manager is present and the probe still failed, which is worth explaining. `!isInstalled` means no known root manager, setup already counts as complete, and nothing is actionable, so that case keeps its plain one-liner.
- Both failure states now go through `SetupLimitationBox`, the component the Automation, Inventory and Shizuku cards already use, so the setup screen reads as one design instead of several treatments of the same kind of state.
- `SetupLimitationBox`'s action slot became optional. Its action `Column` carries `padding(top = 8.dp)`, so a caller with no buttons would otherwise render an empty gap under the body text. Additive change, the three existing callers are untouched.
- There is deliberately no Retry button on the root card. `RootSetupModule.refresh()` only restarts that module's own probe, while app-wide root state lives in `RootManager.cachedState`, which is invalidated only when the useRoot setting changes. On the exact journey a retry is for (denied, then granted in the root manager, then back to SD Maid) the card would flip to "ready" while `isRooted()`, `useRoot`, `accessState` and every root-gated tool kept the cached `false`. Giving `RootManager` a real invalidation path is separate work.
- `setup_inventory_invalid_label` is intentionally left in `strings.xml` with no references. `ExtraTranslation` is fatal in release lint and 73 locale files carry a translation of it, so deleting the base string alone fails `lintVitalFossRelease`, and deleting all 74 fights the Crowdin sync.
