### PR TITLE
General: Turn the widget storage indicator amber when space runs low

### DIFF
--- a/app-common-ui/src/main/res/values-night/colors.xml
+++ b/app-common-ui/src/main/res/values-night/colors.xml
@@ -45,4 +45,6 @@
     <color name="md_theme_surfaceContainer">#1C211C</color>
     <color name="md_theme_surfaceContainerHigh">#262B26</color>
     <color name="md_theme_surfaceContainerHighest">#313631</color>
+
+    <color name="md_theme_storageLow">@color/md_theme_storageLow_night</color>
 </resources>

--- a/app-common-ui/src/main/res/values/colors.xml
+++ b/app-common-ui/src/main/res/values/colors.xml
@@ -46,4 +46,11 @@
     <color name="md_theme_surfaceContainer">#EBEFE8</color>
     <color name="md_theme_surfaceContainerHigh">#E5EAE2</color>
     <color name="md_theme_surfaceContainerHighest">#DFE4DC</color>
+
+    <!-- "Storage is running out" amber. Not part of the generated Material palette: it must read as
+         a warning in both themes and stay legible on the widget's background, so it is defined once
+         here and consumed by the app, the widget bars/labels and the hand-drawn storage ring. -->
+    <color name="md_theme_storageLow_day">#8A5100</color>
+    <color name="md_theme_storageLow_night">#FFB95C</color>
+    <color name="md_theme_storageLow">@color/md_theme_storageLow_day</color>
 </resources>

--- a/app/src/main/java/eu/darken/sdmse/widget/WidgetDataProvider.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/WidgetDataProvider.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.widget
 
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
@@ -8,6 +9,7 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.shareLatest
 import eu.darken.sdmse.main.core.shortcuts.OneTapRunGuard
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.stats.core.LowStorage
 import eu.darken.sdmse.stats.core.SpaceTracker
 import eu.darken.sdmse.stats.core.StatsSettings
 import kotlinx.coroutines.CoroutineScope
@@ -27,13 +29,15 @@ import javax.inject.Singleton
  * Reads the live primary + secondary (SD card / USB) storage figures, the lifetime "space freed"
  * total and the working/cancellable task state, clamps them, and maps them to an immutable
  * [WidgetRenderState]. Freed bytes come from the [StatsSettings] DataStore value (the source of
- * truth) rather than the throttled `StatsRepo.state`.
+ * truth) rather than the throttled `StatsRepo.state`. Each volume is also flagged against the
+ * configured low-storage threshold ([AnalyzerSettings.lowStorageThresholdBytes]).
  */
 @Singleton
 class WidgetDataProvider @Inject constructor(
     @AppScope appScope: CoroutineScope,
     private val spaceTracker: SpaceTracker,
     private val statsSettings: StatsSettings,
+    private val analyzerSettings: AnalyzerSettings,
     private val taskSubmitter: TaskSubmitter,
     private val oneTapRunGuard: OneTapRunGuard,
 ) {
@@ -54,11 +58,13 @@ class WidgetDataProvider @Inject constructor(
         oneTapRunGuard.running,
         taskSubmitter.state.map { !it.isIdle to it.hasCancellable }.distinctUntilChanged(),
         statsSettings.totalSpaceFreed.flow,
-    ) { guardRunning, (busy, cancellable), freed ->
+        analyzerSettings.lowStorageThresholdBytes.flow,
+    ) { guardRunning, (busy, cancellable), freed, lowThreshold ->
         Signals(
             working = guardRunning || busy,
             cancellable = guardRunning || cancellable,
             freed = freed,
+            lowThreshold = lowThreshold,
         )
     }
         // Hold the displayed lifetime total steady while a run is in progress: the counter is
@@ -71,7 +77,14 @@ class WidgetDataProvider @Inject constructor(
         }
         .filterNotNull()
         .distinctUntilChanged()
-        .map { buildState(working = it.working, cancellable = it.cancellable, freedBytes = it.freed) }
+        .map {
+            buildState(
+                working = it.working,
+                cancellable = it.cancellable,
+                freedBytes = it.freed,
+                lowThreshold = it.lowThreshold,
+            )
+        }
         .distinctUntilChanged()
         .map { it.also { log(TAG, VERBOSE) { "renderState: $it" } } }
         // Shared so the latch lives ONCE in this singleton: a cold per-collector chain would let a
@@ -81,7 +94,13 @@ class WidgetDataProvider @Inject constructor(
         // across collectors (coordinator + one per widget session).
         .shareLatest(appScope)
 
-    private data class Signals(val working: Boolean, val cancellable: Boolean, val freed: Long)
+    private data class Signals(
+        val working: Boolean,
+        val cancellable: Boolean,
+        val freed: Long,
+        /** Custom low-storage threshold, `null` = automatic (see [LowStorage.resolveThreshold]). */
+        val lowThreshold: Long?,
+    )
 
     suspend fun snapshot(): WidgetRenderState = renderState.first()
 
@@ -89,13 +108,14 @@ class WidgetDataProvider @Inject constructor(
         working: Boolean,
         cancellable: Boolean,
         freedBytes: Long,
+        lowThreshold: Long?,
     ): WidgetRenderState {
         val entries = buildList {
             spaceTracker.readPrimaryStorage()
-                ?.let { entry(WidgetRenderState.Data.StorageEntry.Kind.INTERNAL, it) }
+                ?.let { entry(WidgetRenderState.Data.StorageEntry.Kind.INTERNAL, it, lowThreshold) }
                 ?.let { add(it) }
             spaceTracker.readSecondaryStorages()
-                .mapNotNull { entry(WidgetRenderState.Data.StorageEntry.Kind.EXTERNAL, it) }
+                .mapNotNull { entry(WidgetRenderState.Data.StorageEntry.Kind.EXTERNAL, it, lowThreshold) }
                 .let { addAll(it) }
         }.take(MAX_STORAGES)
 
@@ -115,6 +135,7 @@ class WidgetDataProvider @Inject constructor(
     private fun entry(
         kind: WidgetRenderState.Data.StorageEntry.Kind,
         snapshot: SpaceTracker.StorageSnapshot,
+        lowThreshold: Long?,
     ): WidgetRenderState.Data.StorageEntry? {
         val total = snapshot.spaceCapacity
         if (total <= 0L) return null
@@ -123,6 +144,12 @@ class WidgetDataProvider @Inject constructor(
             kind = kind,
             usedBytes = (total - free).coerceIn(0L, total),
             totalBytes = total,
+            // Per volume, against that volume's own capacity: a nearly full SD card must be able to
+            // flag while the primary is fine (and vice versa).
+            isLow = LowStorage.isLow(
+                spaceFreeBytes = free,
+                thresholdBytes = LowStorage.resolveThreshold(total, lowThreshold),
+            ),
         )
     }
 

--- a/app/src/main/java/eu/darken/sdmse/widget/WidgetRenderState.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/WidgetRenderState.kt
@@ -21,6 +21,11 @@ sealed interface WidgetRenderState {
             val kind: Kind,
             val usedBytes: Long,
             val totalBytes: Long,
+            /**
+             * Free space is at or below the configured low-storage threshold. Computed per entry, so
+             * a nearly full SD card flags while the primary volume stays normal.
+             */
+            val isLow: Boolean = false,
         ) {
             val usedRatio: Float
                 get() = if (totalBytes > 0L) {

--- a/app/src/main/java/eu/darken/sdmse/widget/ui/StorageRing.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/ui/StorageRing.kt
@@ -7,7 +7,7 @@ import android.graphics.Canvas
 import android.graphics.Paint
 import android.graphics.RectF
 import android.graphics.Typeface
-import android.os.Build
+import androidx.annotation.ColorInt
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.Dp
 import androidx.glance.GlanceModifier
@@ -15,6 +15,7 @@ import androidx.glance.Image
 import androidx.glance.ImageProvider
 import androidx.glance.LocalContext
 import androidx.glance.layout.size
+import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.ui.R as CommonUiR
 import kotlin.math.roundToInt
 
@@ -22,21 +23,37 @@ import kotlin.math.roundToInt
  * A determinate storage "donut" that fills to the used ratio, with the percentage in the centre.
  *
  * Glance has no determinate circular progress, so we draw a [Bitmap] at runtime and hand it to a
- * Glance [Image]. The arc uses the Material You accent on API 31+, else the app's primary; the track
- * and label follow light/dark.
+ * Glance [Image]. The arc colour comes from [storageArcColor]; the track and label follow light/dark.
+ *
+ * [isLow] means free space is at or below the configured low-storage threshold — the ring is the
+ * only storage indicator in the narrow single-row layout, so it has to carry that signal itself.
  */
 @Composable
-internal fun StorageRing(ratio: Float, diameter: Dp) {
+internal fun StorageRing(ratio: Float, diameter: Dp, isLow: Boolean = false) {
     val context = LocalContext.current
     val px = (diameter.value * context.resources.displayMetrics.density).roundToInt().coerceAtLeast(1)
     Image(
-        provider = ImageProvider(storageRingBitmap(context, ratio, px)),
+        provider = ImageProvider(storageRingBitmap(context, ratio, px, isLow)),
         contentDescription = null,
         modifier = GlanceModifier.size(diameter),
     )
 }
 
-private fun storageRingBitmap(context: Context, ratio: Float, sizePx: Int): Bitmap {
+/**
+ * Arc colour for the ring. Extracted and pure so it can be unit-tested — the bitmap itself can't be
+ * (Robolectric's Canvas doesn't rasterise).
+ *
+ * The low-storage branch deliberately comes FIRST: a Material You wallpaper accent must never
+ * override the warning colour, otherwise a device with an amber-ish accent shows no difference at all.
+ */
+@ColorInt
+internal fun storageArcColor(context: Context, isLow: Boolean): Int = when {
+    isLow -> context.getColor(CommonUiR.color.md_theme_storageLow)
+    hasApiLevel(31) -> context.getColor(android.R.color.system_accent1_500)
+    else -> context.getColor(CommonUiR.color.md_theme_primary)
+}
+
+private fun storageRingBitmap(context: Context, ratio: Float, sizePx: Int, isLow: Boolean): Bitmap {
     val night = (context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK) ==
         Configuration.UI_MODE_NIGHT_YES
 
@@ -49,11 +66,7 @@ private fun storageRingBitmap(context: Context, ratio: Float, sizePx: Int): Bitm
     val pad = stroke / 2f
     val bounds = RectF(pad, pad, sizePx - pad, sizePx - pad)
 
-    val arcColor = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        context.getColor(android.R.color.system_accent1_500)
-    } else {
-        context.getColor(CommonUiR.color.md_theme_primary)
-    }
+    val arcColor = storageArcColor(context, isLow)
     val trackColor = if (night) 0x33FFFFFF else 0x1F000000
     val textColor = if (night) 0xFFECECEC.toInt() else 0xFF1B1B1B.toInt()
 

--- a/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContent.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContent.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.text.format.Formatter
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -37,10 +38,12 @@ import androidx.glance.layout.width
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import androidx.glance.unit.ColorProvider
 import eu.darken.sdmse.R
 import eu.darken.sdmse.main.ui.MainActivity
 import eu.darken.sdmse.main.ui.shortcuts.ShortcutActivity
 import eu.darken.sdmse.widget.WidgetRenderState
+import androidx.glance.color.ColorProvider as dayNightColorProvider
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.ui.R as CommonUiR
 
@@ -173,9 +176,13 @@ private fun WidgetChrome(content: @Composable () -> Unit) {
     }
 }
 
-/** Tall (2+ rows): branding + storage (tap → app) at the top, Clean button pinned to the bottom. */
+/**
+ * Tall (2+ rows): branding + storage (tap → app) at the top, Clean button pinned to the bottom.
+ *
+ * Internal (not private) so WidgetContentLowStateTest can compose it in isolation.
+ */
 @Composable
-private fun StackedLayout(data: WidgetRenderState.Data) {
+internal fun StackedLayout(data: WidgetRenderState.Data) {
     Column(modifier = GlanceModifier.fillMaxSize()) {
         BrandingHeader(data.freedBytes, GlanceModifier.fillMaxWidth().clickable(openApp()))
         Spacer(GlanceModifier.height(12.dp))
@@ -194,9 +201,11 @@ private fun StackedLayout(data: WidgetRenderState.Data) {
 /**
  * 1 row, medium/wide: mascot + primary storage (tap → app) + Clean button. The button label only
  * shows at the widest sizes; at ~3 columns it's icon-only so the value isn't truncated.
+ *
+ * Internal (not private) so WidgetContentLowStateTest can compose it in isolation.
  */
 @Composable
-private fun ValueRowLayout(data: WidgetRenderState.Data, showButtonLabel: Boolean, showFreedText: Boolean) {
+internal fun ValueRowLayout(data: WidgetRenderState.Data, showButtonLabel: Boolean, showFreedText: Boolean) {
     val context = LocalContext.current
     Row(
         modifier = GlanceModifier.fillMaxSize(),
@@ -208,11 +217,15 @@ private fun ValueRowLayout(data: WidgetRenderState.Data, showButtonLabel: Boolea
             data.storages.firstOrNull()?.let { entry ->
                 Text(
                     text = usedOfTotal(context, entry),
-                    style = TextStyle(color = GlanceTheme.colors.onBackground, fontSize = 14.sp, fontWeight = FontWeight.Bold),
+                    style = TextStyle(
+                        color = storageValueColor(entry.isLow),
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                    ),
                     maxLines = 1,
                 )
                 Spacer(GlanceModifier.height(3.dp))
-                StorageBar(entry.usedRatio)
+                StorageBar(entry.usedRatio, entry.isLow)
                 if (showFreedText) {
                     Spacer(GlanceModifier.height(3.dp))
                     Text(
@@ -241,7 +254,7 @@ private fun RingRowLayout(data: WidgetRenderState.Data) {
         Mascot(NARROW_ELEMENT_SIZE, GlanceModifier.clickable(openApp()))
         Spacer(GlanceModifier.defaultWeight())
         Box(modifier = GlanceModifier.size(NARROW_ELEMENT_SIZE).clickable(openAnalyzer())) {
-            data.storages.firstOrNull()?.let { StorageRing(it.usedRatio, NARROW_ELEMENT_SIZE) }
+            data.storages.firstOrNull()?.let { StorageRing(it.usedRatio, NARROW_ELEMENT_SIZE, it.isLow) }
         }
         Spacer(GlanceModifier.defaultWeight())
         CleanCircle(NARROW_ELEMENT_SIZE, mode = data.cleanMode)
@@ -279,6 +292,29 @@ private fun Mascot(size: Dp, modifier: GlanceModifier = GlanceModifier) {
     )
 }
 
+/**
+ * The shared "storage is running out" amber, resolved from the day/night colour resources so the
+ * widget bars, the widget labels and the ring bitmap can't drift apart.
+ *
+ * Internal so WidgetContentLowStateTest can assert against the exact same value.
+ */
+internal fun lowStorageColorProvider(context: Context): ColorProvider = dayNightColorProvider(
+    day = Color(context.getColor(CommonUiR.color.md_theme_storageLow_day)),
+    night = Color(context.getColor(CommonUiR.color.md_theme_storageLow_night)),
+)
+
+/**
+ * Colour for the "used / total" storage figure. Amber when that volume is low.
+ *
+ * This label is NOT decoration: see the note on [StorageBar] — below API 31 it is the ONLY
+ * low-storage signal the widget can render.
+ */
+@Composable
+private fun storageValueColor(isLow: Boolean): ColorProvider = when {
+    isLow -> lowStorageColorProvider(LocalContext.current)
+    else -> GlanceTheme.colors.onBackground
+}
+
 @Composable
 private fun StorageRow(entry: WidgetRenderState.Data.StorageEntry) {
     val context = LocalContext.current
@@ -297,21 +333,32 @@ private fun StorageRow(entry: WidgetRenderState.Data.StorageEntry) {
             Spacer(GlanceModifier.defaultWeight())
             Text(
                 text = usedOfTotal(context, entry),
-                style = TextStyle(color = GlanceTheme.colors.onBackground, fontSize = 13.sp, fontWeight = FontWeight.Bold),
+                style = TextStyle(
+                    color = storageValueColor(entry.isLow),
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                ),
                 maxLines = 1,
             )
         }
         Spacer(GlanceModifier.height(5.dp))
-        StorageBar(entry.usedRatio)
+        StorageBar(entry.usedRatio, entry.isLow)
     }
 }
 
 @Composable
-private fun StorageBar(ratio: Float) {
+private fun StorageBar(ratio: Float, isLow: Boolean = false) {
+    val context = LocalContext.current
     LinearProgressIndicator(
         progress = ratio,
         modifier = GlanceModifier.fillMaxWidth().height(8.dp).cornerRadius(4.dp),
-        color = GlanceTheme.colors.primary,
+        // IMPORTANT: Glance (1.2.0-rc01) only applies a custom LinearProgressIndicator tint on
+        // API 31+ — below that this argument compiles and is then silently ignored, so the bar stays
+        // the default colour. minSdk is 26, which means on Android 8-11 the amber BAR never renders
+        // and the amber storage TEXT LABEL (storageValueColor) is the only low-storage signal there.
+        // That label colouring is therefore NOT redundant with this one; deleting it blinds those
+        // versions entirely. WidgetContentLowStateTest guards it.
+        color = if (isLow) lowStorageColorProvider(context) else GlanceTheme.colors.primary,
         backgroundColor = GlanceTheme.colors.secondaryContainer,
     )
 }
@@ -427,7 +474,7 @@ private fun UnavailableContent() {
     }
 }
 
-private fun usedOfTotal(context: Context, entry: WidgetRenderState.Data.StorageEntry): String =
+internal fun usedOfTotal(context: Context, entry: WidgetRenderState.Data.StorageEntry): String =
     "${formatSize(context, entry.usedBytes)} / ${formatSize(context, entry.totalBytes)}"
 
 private fun storageLabelRes(kind: WidgetRenderState.Data.StorageEntry.Kind): Int = when (kind) {

--- a/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContentPreviews.kt
+++ b/app/src/main/java/eu/darken/sdmse/widget/ui/WidgetContentPreviews.kt
@@ -19,6 +19,12 @@ private fun internal(usedGb: Long, totalGb: Long) =
 private fun external(usedGb: Long, totalGb: Long) =
     StorageEntry(StorageEntry.Kind.EXTERNAL, usedGb * GB, totalGb * GB)
 
+private fun internalLow(usedGb: Long, totalGb: Long) =
+    StorageEntry(StorageEntry.Kind.INTERNAL, usedGb * GB, totalGb * GB, isLow = true)
+
+private fun externalLow(usedGb: Long, totalGb: Long) =
+    StorageEntry(StorageEntry.Kind.EXTERNAL, usedGb * GB, totalGb * GB, isLow = true)
+
 @Preview(widthDp = 200, heightDp = 140)
 @Composable
 private fun WidgetContentNormalPreview() {
@@ -117,6 +123,41 @@ private fun WidgetContentLargePreview() {
     WidgetContent(
         WidgetRenderState.Data(
             storages = listOf(internal(45, 128), external(20, 64)),
+            freedBytes = 12 * GB,
+        )
+    )
+}
+
+// --- Low storage ---------------------------------------------------------------------------------
+// Free space at or below the configured threshold. All three layouts must signal it: bar + label in
+// the stacked and value-row layouts, ring arc in the narrow one. Note the amber bar only renders on
+// API 31+ (Glance limitation), which is why the label is coloured too — check both here.
+
+@Preview(widthDp = 200, heightDp = 140)
+@Composable
+private fun WidgetContentLowStackedPreview() {
+    WidgetContent(WidgetRenderState.Data(listOf(internalLow(126, 128)), freedBytes = 3 * GB))
+}
+
+@Preview(widthDp = 300, heightDp = 80)
+@Composable
+private fun WidgetContentLowValueRowPreview() {
+    WidgetContent(WidgetRenderState.Data(listOf(internalLow(126, 128)), freedBytes = 3 * GB))
+}
+
+@Preview(widthDp = 150, heightDp = 80)
+@Composable
+private fun WidgetContentLowRingPreview() {
+    WidgetContent(WidgetRenderState.Data(listOf(internalLow(126, 128)), freedBytes = 3 * GB))
+}
+
+// Per-volume: the SD card is low while the primary is fine, so only the second row goes amber.
+@Preview(widthDp = 220, heightDp = 170)
+@Composable
+private fun WidgetContentLowSecondaryOnlyPreview() {
+    WidgetContent(
+        WidgetRenderState.Data(
+            storages = listOf(internal(45, 128), externalLow(63, 64)),
             freedBytes = 12 * GB,
         )
     )

--- a/app/src/test/java/eu/darken/sdmse/widget/WidgetDataProviderTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/widget/WidgetDataProviderTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.widget
 
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.shortcuts.OneTapRunGuard
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
@@ -26,6 +27,7 @@ class WidgetDataProviderTest : BaseTest() {
 
     private val spaceTracker = mockk<SpaceTracker>()
     private val statsSettings = mockk<StatsSettings>()
+    private val analyzerSettings = mockk<AnalyzerSettings>()
     private val taskSubmitter = mockk<TaskSubmitter>()
     private val oneTapRunGuard = OneTapRunGuard()
 
@@ -34,7 +36,7 @@ class WidgetDataProviderTest : BaseTest() {
     // constructing the provider uses runTest2(autoCancel = true): the sharing coroutine never
     // completes on its own.
     private fun TestScope.provider() =
-        WidgetDataProvider(this, spaceTracker, statsSettings, taskSubmitter, oneTapRunGuard)
+        WidgetDataProvider(this, spaceTracker, statsSettings, analyzerSettings, taskSubmitter, oneTapRunGuard)
 
     private fun snapshot(free: Long, capacity: Long) = SpaceTracker.StorageSnapshot(
         storageId = "s",
@@ -70,10 +72,14 @@ class WidgetDataProviderTest : BaseTest() {
         secondary: List<SpaceTracker.StorageSnapshot> = emptyList(),
         freed: Long = 0L,
         taskState: TaskSubmitter.State = TaskSubmitter.State(),
+        lowThreshold: Long? = null,
     ) {
         coEvery { spaceTracker.readPrimaryStorage() } returns primary
         coEvery { spaceTracker.readSecondaryStorages() } returns secondary
         every { statsSettings.totalSpaceFreed } returns mockDataStoreValue(freed)
+        // Must actually emit: a relaxed mock hands back a Flow that never does, which stalls the
+        // renderState combine forever.
+        every { analyzerSettings.lowStorageThresholdBytes } returns mockDataStoreValue(lowThreshold)
         every { taskSubmitter.state } returns MutableStateFlow(taskState)
     }
 
@@ -157,6 +163,75 @@ class WidgetDataProviderTest : BaseTest() {
     }
 
     @Test
+    fun `automatic threshold - free above 5 percent is not low`() = runTest2(autoCancel = true) {
+        // capacity 500 → automatic threshold is 5% = 25 (the 2 GiB cap doesn't bite here).
+        stub(primary = snapshot(free = 26, capacity = 500), lowThreshold = null)
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages.single().isLow shouldBe false
+    }
+
+    @Test
+    fun `automatic threshold - free exactly at the threshold is low`() = runTest2(autoCancel = true) {
+        stub(primary = snapshot(free = 25, capacity = 500), lowThreshold = null)
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages.single().isLow shouldBe true
+    }
+
+    @Test
+    fun `automatic threshold - free below the threshold is low`() = runTest2(autoCancel = true) {
+        stub(primary = snapshot(free = 1, capacity = 500), lowThreshold = null)
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages.single().isLow shouldBe true
+    }
+
+    @Test
+    fun `a custom threshold overrides the automatic one`() = runTest2(autoCancel = true) {
+        // free = 100 is far above the automatic 25, but below the configured 200.
+        stub(primary = snapshot(free = 100, capacity = 500), lowThreshold = 200L)
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages.single().isLow shouldBe true
+    }
+
+    @Test
+    fun `a custom threshold below the automatic one keeps a volume normal`() = runTest2(autoCancel = true) {
+        // free = 20 would be low automatically (threshold 25), but the user configured 10.
+        stub(primary = snapshot(free = 20, capacity = 500), lowThreshold = 10L)
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages.single().isLow shouldBe false
+    }
+
+    @Test
+    fun `isLow is per volume - a low SD card does not flag the primary`() = runTest2(autoCancel = true) {
+        // Automatic thresholds: primary 5% of 500 = 25, secondary 5% of 200 = 10.
+        stub(
+            primary = snapshot(free = 400, capacity = 500),
+            secondary = listOf(snapshot(free = 5, capacity = 200)),
+            lowThreshold = null,
+        )
+
+        val state = provider().snapshot()
+
+        state.shouldBeInstanceOf<WidgetRenderState.Data>()
+        state.storages[0].isLow shouldBe false
+        state.storages[1].isLow shouldBe true
+    }
+
+    @Test
     fun `usedRatio is a clamped fraction`() {
         WidgetRenderState.Data.StorageEntry(Kind.INTERNAL, usedBytes = 250, totalBytes = 1000).usedRatio shouldBe 0.25f
         WidgetRenderState.Data.StorageEntry(Kind.INTERNAL, usedBytes = 0, totalBytes = 0).usedRatio shouldBe 0f
@@ -216,6 +291,7 @@ class WidgetDataProviderTest : BaseTest() {
         coEvery { spaceTracker.readPrimaryStorage() } returns snapshot(free = 100, capacity = 500)
         coEvery { spaceTracker.readSecondaryStorages() } returns emptyList()
         every { statsSettings.totalSpaceFreed } returns mockk { every { flow } returns freedFlow }
+        every { analyzerSettings.lowStorageThresholdBytes } returns mockDataStoreValue(null)
         every { taskSubmitter.state } returns taskFlow
 
         val provider = provider()

--- a/app/src/test/java/eu/darken/sdmse/widget/ui/StorageRingColorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/widget/ui/StorageRingColorTest.kt
@@ -1,0 +1,53 @@
+package eu.darken.sdmse.widget.ui
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import eu.darken.sdmse.common.ui.R as CommonUiR
+
+/**
+ * Colour selection for the widget's storage ring. The ring is drawn into a [android.graphics.Bitmap],
+ * and Robolectric's Canvas is a stub that rasterises nothing — asserting pixels there would prove
+ * nothing, so the pure selection function is what gets tested.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = TestApplication::class)
+class StorageRingColorTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    @Config(sdk = [30])
+    fun `normal storage below API 31 uses the app primary`() {
+        storageArcColor(context, isLow = false) shouldBe context.getColor(CommonUiR.color.md_theme_primary)
+    }
+
+    @Test
+    @Config(sdk = [33])
+    fun `normal storage on API 31+ uses the Material You accent`() {
+        storageArcColor(context, isLow = false) shouldBe context.getColor(android.R.color.system_accent1_500)
+    }
+
+    @Test
+    @Config(sdk = [30])
+    fun `low storage below API 31 is amber`() {
+        storageArcColor(context, isLow = true) shouldBe context.getColor(CommonUiR.color.md_theme_storageLow)
+    }
+
+    @Test
+    @Config(sdk = [33])
+    fun `low storage wins over the Material You accent`() {
+        // The whole point of ordering the low branch first: on a device whose wallpaper accent
+        // happens to look like a warning, or like anything else, the warning must still win.
+        storageArcColor(context, isLow = true) shouldBe context.getColor(CommonUiR.color.md_theme_storageLow)
+        storageArcColor(context, isLow = true) shouldNotBe context.getColor(android.R.color.system_accent1_500)
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/widget/ui/WidgetContentLowStateTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/widget/ui/WidgetContentLowStateTest.kt
@@ -1,0 +1,141 @@
+package eu.darken.sdmse.widget.ui
+
+import android.content.Context
+import androidx.glance.EmittableWithText
+import androidx.glance.appwidget.EmittableLinearProgressIndicator
+import androidx.glance.appwidget.testing.unit.runGlanceAppWidgetUnitTest
+import androidx.glance.testing.GlanceNodeMatcher
+import androidx.glance.testing.unit.MappedNode
+import androidx.glance.testing.unit.hasTextEqualTo
+import androidx.glance.unit.ColorProvider
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.widget.WidgetRenderState
+import eu.darken.sdmse.widget.WidgetRenderState.Data.StorageEntry
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * Guards the low-storage signal in the two bar-based widget layouts.
+ *
+ * The label assertions are the important ones: Glance 1.2.0-rc01 only applies a custom
+ * [androidx.glance.appwidget.LinearProgressIndicator] tint on API 31+ and silently drops it below
+ * that, so on Android 8-11 (minSdk is 26) the amber TEXT LABEL is the only low-storage signal the
+ * widget can render. If a refactor drops the label colouring as "redundant with the bar", those
+ * versions lose the warning entirely and nothing else in the suite notices.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class WidgetContentLowStateTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun entry(isLow: Boolean) = StorageEntry(
+        kind = StorageEntry.Kind.INTERNAL,
+        usedBytes = 126_000_000_000L,
+        totalBytes = 128_000_000_000L,
+        isLow = isLow,
+    )
+
+    private fun data(isLow: Boolean) = WidgetRenderState.Data(
+        storages = listOf(entry(isLow)),
+        freedBytes = 3_000_000_000L,
+    )
+
+    // Glance ships no colour matcher, so these reach into the emitted node. The Emittable types are
+    // @RestrictTo(LIBRARY_GROUP) — public bytecode, lint-only, and lint doesn't scan unit-test
+    // sources here.
+    private fun hasTextColor(expected: ColorProvider) = GlanceNodeMatcher<MappedNode>(
+        description = "text colour is $expected",
+    ) { node ->
+        val emittable = node.value.emittable
+        emittable is EmittableWithText && emittable.style?.color == expected
+    }
+
+    private fun isProgressBarWithColor(expected: ColorProvider) = GlanceNodeMatcher<MappedNode>(
+        description = "linear progress indicator with colour $expected",
+    ) { node ->
+        val emittable = node.value.emittable
+        emittable is EmittableLinearProgressIndicator && emittable.color == expected
+    }
+
+    @Test
+    fun `stacked layout - a low volume colours the storage label amber`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable { StackedLayout(data(isLow = true)) }
+
+        onNode(
+            hasTextEqualTo(usedOfTotal(context, entry(isLow = true)))
+                and hasTextColor(lowStorageColorProvider(context))
+        ).assertExists()
+    }
+
+    @Test
+    fun `stacked layout - a normal volume leaves the storage label alone`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable { StackedLayout(data(isLow = false)) }
+
+        // Positive first, so a changed label format can't make the negative assertion vacuous.
+        onNode(hasTextEqualTo(usedOfTotal(context, entry(isLow = false)))).assertExists()
+        onNode(
+            hasTextEqualTo(usedOfTotal(context, entry(isLow = false)))
+                and hasTextColor(lowStorageColorProvider(context))
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `value row layout - a low volume colours the storage label amber`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable {
+            ValueRowLayout(data(isLow = true), showButtonLabel = true, showFreedText = true)
+        }
+
+        onNode(
+            hasTextEqualTo(usedOfTotal(context, entry(isLow = true)))
+                and hasTextColor(lowStorageColorProvider(context))
+        ).assertExists()
+    }
+
+    @Test
+    fun `value row layout - a normal volume leaves the storage label alone`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable {
+            ValueRowLayout(data(isLow = false), showButtonLabel = true, showFreedText = true)
+        }
+
+        // Positive first, so a changed label format can't make the negative assertion vacuous.
+        onNode(hasTextEqualTo(usedOfTotal(context, entry(isLow = false)))).assertExists()
+        onNode(
+            hasTextEqualTo(usedOfTotal(context, entry(isLow = false)))
+                and hasTextColor(lowStorageColorProvider(context))
+        ).assertDoesNotExist()
+    }
+
+    @Test
+    fun `stacked layout - a low volume also colours the bar`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable { StackedLayout(data(isLow = true)) }
+
+        onNode(isProgressBarWithColor(lowStorageColorProvider(context))).assertExists()
+    }
+
+    @Test
+    fun `value row layout - a low volume also colours the bar`() = runGlanceAppWidgetUnitTest {
+        setContext(context)
+
+        provideComposable {
+            ValueRowLayout(data(isLow = true), showButtonLabel = true, showFreedText = true)
+        }
+
+        onNode(isProgressBarWithColor(lowStorageColorProvider(context))).assertExists()
+    }
+}

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -205,6 +205,11 @@ fun DependencyHandlerScope.addGlance() {
     // @Preview annotation (kept on the main classpath); renderer stays debug-only.
     implementation("androidx.glance:glance-preview:${Versions.AndroidX.Glance.core}")
     debugImplementation("androidx.glance:glance-appwidget-preview:${Versions.AndroidX.Glance.core}")
+
+    // runGlanceAppWidgetUnitTest: composes Glance content on the JVM and asserts on the emitted
+    // node tree. Glance content can't be driven by the normal Compose test rule (own Applier), so
+    // this is the only way to unit-test what a widget layout actually emits.
+    testImplementation("androidx.glance:glance-appwidget-testing:${Versions.AndroidX.Glance.core}")
 }
 
 fun DependencyHandlerScope.addNavigation3() {


### PR DESCRIPTION
## What changed

The home screen widget now turns its storage indicator amber when a storage device drops to or below the low storage threshold, instead of showing the same colour whether you have plenty of room or almost none.

All three widget sizes signal it. The small size colours its ring, and the medium and large sizes colour their bar and the used-of-total figure beside it. Each storage device is judged on its own, so an SD card that is nearly full turns amber while internal storage stays normal.

The threshold is the one configured in the Storage Analyzer settings, so setting it there changes when the widget reacts.

Stacked on #2700, which adds that setting. Refs #1903.

## Technical Context

- Glance only applies a custom tint to its progress bar on Android 12 and above; below that the colour is accepted and silently ignored. Since the app supports Android 8, the used-of-total label is coloured too, and on Android 8 through 11 that label is the only thing carrying the signal. The call site has a comment saying so, because the label colouring looks redundant next to the bar and is otherwise an obvious thing to delete.
- The ring is a hand-drawn bitmap rather than a Glance component, so its colour is chosen separately. That choice is extracted into `storageArcColor`, where the low-storage branch deliberately precedes the Android 12 dynamic-colour branch: a wallpaper accent must never outrank a warning.
- The widget-picker preview on Android 15 is pinned to the normal state. It is configuration content shown before the widget is placed, so an amber preview would imply a warning about a device it has not looked at.
- `WidgetContentLowStateTest` is the guard on the Android 8 through 11 fallback and needs `androidx.glance:glance-appwidget-testing`, since Glance composes through its own Applier and the ordinary Compose test rule cannot drive it. That is why the test dependency is new, and why three composables in `WidgetContent` are now `internal`.
- Not covered by any test: that the chosen colour reaches the screen as amber pixels. Placing a widget needs a drag-and-drop that test automation cannot perform, and Robolectric's Canvas is a stub, so a bitmap assertion there would prove nothing. Colour selection, per-volume derivation and the label wiring are all covered.
