### PR TITLE
Fix: Stop task counts from vanishing at the bottom of the screen

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
@@ -14,6 +14,8 @@ import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.indication
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
@@ -29,8 +31,10 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.TextAutoSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.Stars
@@ -58,11 +62,14 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlin.math.floor
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.ByteFormatter
 import eu.darken.sdmse.common.R as CommonR
@@ -334,11 +341,26 @@ private fun BarContent(
     val context = LocalContext.current
     // The surface extends behind the nav inset; keep the controls in the visible bar band by
     // padding the bottom up by that inset.
-    Box(
+    BoxWithConstraints(
         modifier = modifier
             .fillMaxSize()
             .padding(top = 8.dp, bottom = 8.dp + contentBottomPadding),
     ) {
+        // Everything left of the cradled FAB, measured off the FAB's actual touch box rather than a
+        // fixed fraction of the bar: the text below is long in several locales, and the fraction was
+        // leaving usable dp unused right next to it.
+        val infoSlot = Modifier
+            .align(Alignment.CenterStart)
+            .padding(start = BAR_INFO_START_PADDING)
+            .width(
+                ((maxWidth - DASHBOARD_FAB_TOUCH_SIZE) / 2 - BAR_INFO_START_PADDING - BAR_INFO_FAB_GAP)
+                    .coerceAtLeast(0.dp)
+            )
+        // Half the visible bar band, floored to a whole pixel: a line box is rounded *up* to the
+        // pixel grid, so splitting an odd band evenly would round the pair one pixel past the band
+        // and clip the second counter again.
+        val infoLineSlot = with(LocalDensity.current) { floor(maxHeight.toPx() / 2f).toDp() }
+
         when {
             state != null && (state.activeTasks > 0 || state.queuedTasks > 0) -> {
                 val active = pluralStringResource(
@@ -351,15 +373,12 @@ private fun BarContent(
                     state.queuedTasks,
                     state.queuedTasks,
                 )
-                Text(
-                    text = "$active\n$queued",
-                    style = MaterialTheme.typography.bodySmall,
-                    maxLines = 2,
-                    modifier = Modifier
-                        .fillMaxWidth(0.4f)
-                        .align(Alignment.CenterStart)
-                        .padding(horizontal = 16.dp),
-                )
+                // One TalkBack stop, as when this was a single two-line Text — the split is a
+                // layout concern and shouldn't cost the user an extra swipe.
+                Column(modifier = infoSlot.semantics(mergeDescendants = true) { }) {
+                    BarInfoLine(text = active, lineSlot = infoLineSlot)
+                    BarInfoLine(text = queued, lineSlot = infoLineSlot)
+                }
             }
 
             compactSummary != null -> {
@@ -395,10 +414,9 @@ private fun BarContent(
                     text = stringResource(easterEggProgressMsg),
                     style = MaterialTheme.typography.bodySmall,
                     maxLines = 2,
-                    modifier = Modifier
-                        .fillMaxWidth(0.4f)
-                        .align(Alignment.CenterStart)
-                        .padding(horizontal = 16.dp),
+                    // Clip would drop an overlong message's tail with nothing to show for it.
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = infoSlot,
                 )
             }
         }
@@ -428,6 +446,76 @@ private fun BarContent(
             )
         }
     }
+}
+
+/** Inset of the bar's info slot from the start edge. */
+private val BAR_INFO_START_PADDING = 16.dp
+
+/** Breathing room between the info slot and the cradled FAB's touch box. */
+private val BAR_INFO_FAB_GAP = 8.dp
+
+/** Floor for [BarInfoLine]'s auto-sizing. Below this the counts stop being readable at a glance. */
+private val BAR_INFO_MIN_FONT_SIZE = 9.sp
+
+/** Used only if the theme's `bodySmall` ever loses its explicit size/line height. */
+private val BAR_INFO_FALLBACK_FONT_SIZE = 12.sp
+private const val BAR_INFO_FALLBACK_LINE_RATIO = 4f / 3f
+
+/**
+ * One line of the bar's info slot, sized to fit [lineSlot] tall and its slot wide.
+ *
+ * Each count gets its own single-line [Text]. Rendering both as one `"$a\n$b"` string capped at two
+ * lines meant a wrap in the first line consumed the second line's budget and the queued count
+ * vanished outright (issue #2698).
+ *
+ * The line shrinks rather than wraps, and only ellipsizes in the *middle* once it hits
+ * [BAR_INFO_MIN_FONT_SIZE]: several locales put the number last ("Задач в очереди: %d"), so a tail
+ * truncation would cut exactly the count the line exists to show.
+ *
+ * Auto-size alone can't keep the pair inside the bar: with an ellipsizing overflow its fit test is
+ * "was this line ellipsized", which is a width question, and the bar band is a fixed dp height that
+ * a 200% font scale overruns. Hence the explicit ceiling — the largest font whose line box still
+ * fits [lineSlot].
+ */
+@Composable
+private fun BarInfoLine(
+    text: String,
+    lineSlot: Dp,
+    modifier: Modifier = Modifier,
+) {
+    val style = MaterialTheme.typography.bodySmall
+    val baseSize = if (style.fontSize.isSp) style.fontSize else BAR_INFO_FALLBACK_FONT_SIZE
+    val density = LocalDensity.current
+
+    // All of this is computed in dp, not sp. Android's font scaling is non-linear above 100%, so
+    // an sp ratio is not the rendered ratio (at 200%, 12sp and 16sp do not render 3:4) and doing the
+    // arithmetic in sp shrinks the text further than it has to.
+    val baseSizeDp = with(density) { baseSize.toDp() }
+    val baseLineDp = when {
+        style.lineHeight.isSp -> with(density) { style.lineHeight.toDp() }
+        else -> baseSizeDp * BAR_INFO_FALLBACK_LINE_RATIO
+    }
+    val lineRatio = if (baseSizeDp.value > 0f) baseLineDp / baseSizeDp else BAR_INFO_FALLBACK_LINE_RATIO
+
+    // The style's line height is absolute, so shrinking the font on its own leaves the line *box* as
+    // tall as ever and the second counter keeps hanging out of the bar. Cap the box at the slot
+    // (never above the theme's own value, so ordinary text scales look untouched), then cap the font
+    // at what fits that box.
+    val lineCapDp = minOf(baseLineDp, lineSlot)
+    val ceiling = with(density) { (lineCapDp / lineRatio).toSp() }.value.coerceIn(1f, baseSize.value)
+
+    Text(
+        modifier = modifier,
+        text = text,
+        style = style.copy(lineHeight = with(density) { lineCapDp.toSp() }),
+        autoSize = TextAutoSize.StepBased(
+            minFontSize = BAR_INFO_MIN_FONT_SIZE.value.coerceAtMost(ceiling).sp,
+            maxFontSize = ceiling.sp,
+            stepSize = 0.5.sp,
+        ),
+        maxLines = 1,
+        overflow = TextOverflow.MiddleEllipsis,
+    )
 }
 
 /**

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBarTaskCountsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBarTaskCountsTest.kt
@@ -1,0 +1,80 @@
+package eu.darken.sdmse.main.ui.dashboard.bottom
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.getQuantityString2
+import eu.darken.sdmse.main.ui.dashboard.BottomBarState
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * The bar's task counters used to be one `"$active\n$queued"` string capped at two lines: whenever
+ * the first line wrapped it ate the second line's budget and the queued count disappeared, and in
+ * locales that put the number last ("Задач в очереди: %d") a wrap dropped the digit alone
+ * (issue #2698).
+ *
+ * Robolectric's text metrics are stubs (roughly 1dp per character, never wrapping), so this can't
+ * assert the wrap itself, and semantics keep the full string even when its glyphs are clipped — a
+ * passing run here is not evidence that the digit is on screen. What it does pin down is the
+ * structural property the fix rests on: each count is its own node, so neither can consume the
+ * other's line budget. Re-joining them into a single string fails both assertions, because that
+ * node's text is the concatenation and matches neither count exactly.
+ *
+ * Read against the unmerged tree: the counters merge into one TalkBack stop on purpose, and the
+ * merged node would match both counts and prove nothing about them being separate.
+ */
+class DashboardBarTaskCountsTest : BaseComposeRobolectricTest() {
+
+    private val context: Context get() = ApplicationProvider.getApplicationContext()
+
+    private fun setDock(activeTasks: Int, queuedTasks: Int) {
+        composeRule.setContent {
+            PreviewWrapper {
+                BottomBar(
+                    state = BottomBarState(
+                        isReady = true,
+                        actionState = BottomBarState.Action.WORKING,
+                        activeTasks = activeTasks,
+                        queuedTasks = queuedTasks,
+                        heroSummary = null,
+                        upgradeInfo = null,
+                    ),
+                    isVisible = true,
+                    heroVisible = false,
+                    onMainAction = {},
+                    onSettings = {},
+                    onUpgrade = {},
+                    onDismissHero = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `each task count is its own node`() {
+        setDock(activeTasks = 2, queuedTasks = 1)
+
+        val active = context.getQuantityString2(R.plurals.tasks_activity_active_notification_message, 2)
+        val queued = context.getQuantityString2(R.plurals.tasks_activity_queued_notification_message, 1)
+
+        composeRule.onNodeWithText(active, useUnmergedTree = true).assertIsDisplayed()
+        composeRule.onNodeWithText(queued, useUnmergedTree = true).assertIsDisplayed()
+    }
+
+    /**
+     * The queued line renders even at zero: the bar shows up as soon as *either* counter is
+     * non-zero, and "no tasks waiting" is exactly the state the missing line was mistaken for.
+     */
+    @Test
+    fun `the queued count renders while only active tasks run`() {
+        setDock(activeTasks = 1, queuedTasks = 0)
+
+        val queued = context.getQuantityString2(R.plurals.tasks_activity_queued_notification_message, 0)
+
+        composeRule.onNodeWithText(queued, useUnmergedTree = true).assertIsDisplayed()
+    }
+}


### PR DESCRIPTION
## What changed

The main screen shows how many cleaning tasks are running and how many are waiting, in the bottom left of the bar. In some languages the waiting count lost its number, so the line read as an empty field, and at larger text or display sizes the whole line could disappear. Both counts now stay on screen and shrink to fit rather than being cut off.

## Technical Context

- Root cause: both counts were one two-line `Text` with the default clipping overflow, inside a hardcoded 40% of the bar width. A wrap in the first line consumed the second line's budget, so content was dropped with no ellipsis to show for it. Languages that put the number at the end of the string (Russian `Задач в очереди: %d`) lost the digit alone; at larger font scales the whole second line went instead.
- Each count is now its own single-line `Text`, and the slot is measured against the cradled FAB's touch box instead of a fixed fraction, which also reclaims the width that fraction was leaving unused beside it.
- Auto-sizing alone is not enough. With an ellipsizing overflow its fit test is "was this line ellipsized", which only asks about width, and `TextStyle.lineHeight` is an absolute sp value that does not follow the shrunk font, so the second line still overflowed the 60dp bar at 200% font scale. Both the line box and the font are capped against the available half-band, floored to a whole pixel because a line box rounds up to the pixel grid, with the arithmetic in dp since Android's font scaling is non-linear above 100%.
- Known limit: truncation ellipsizes the middle so the end of the string survives, which covers the locales that put the count last. Six locales place it mid-sentence (Hebrew, Korean, Hindi, Odia, Slovenian, Swahili), where a hard enough squeeze can still take it. Avoiding that entirely would mean dropping the surrounding sentence.
- Worth close review: the ceiling arithmetic in `BarInfoLine`, and the semantics merge on the `Column` that keeps the two counters a single TalkBack stop as before.

Closes #2698
