### PR TITLE
Analyzer: Warn before your device runs out of space

### DIFF
--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryScreen.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/spacehistory/SpaceHistoryScreen.kt
@@ -396,7 +396,7 @@ private fun UpgradeCard(onUpgradeClick: () -> Unit) {
                 style = MaterialTheme.typography.titleMedium,
             )
             Text(
-                text = stringResource(R.string.stats_space_history_upgrade_body),
+                text = stringResource(R.string.stats_space_history_upgrade_body_v2),
                 style = MaterialTheme.typography.bodyMedium,
             )
             Row(modifier = Modifier.padding(top = 4.dp)) {

--- a/app-common-stats/src/main/res/values/strings.xml
+++ b/app-common-stats/src/main/res/values/strings.xml
@@ -54,6 +54,9 @@
     <string name="stats_space_history_delta_in_x">%1$s in %2$s</string>
     <string name="stats_space_history_upgrade_title">Full history is a Pro feature</string>
     <string name="stats_space_history_upgrade_body">Upgrade to unlock the full 90-day trend view for each storage device.</string>
+    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
+         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
+    <string name="stats_space_history_upgrade_body_v2">Upgrade to unlock the full 90-day trend view for each storage device, and get a warning before you run out of space.</string>
     <string name="stats_space_history_marker_freed">Freed %1$s</string>
     <string name="stats_storage_type_primary">Primary storage</string>
     <string name="stats_storage_type_secondary">Secondary storage</string>

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/AnalyzerSettings.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/AnalyzerSettings.kt
@@ -32,6 +32,19 @@ class AnalyzerSettings @Inject constructor(
      */
     val lowStorageThresholdBytes = dataStore.createValue<Long?>("storage.low.threshold.bytes", null)
 
+    /** Pro-gated: warn before the device runs out of space. */
+    val lowSpaceNotificationEnabled = dataStore.createValue("storage.low.notification.enabled", false)
+
+    /**
+     * Transition latch: `true` means "a crossing into the warning band may notify".
+     *
+     * Runtime state, not a preference, and therefore excluded from backup
+     * (see [eu.darken.sdmse.analyzer.core.backup.AnalyzerSettingsBackupContributor]).
+     */
+    val lowSpaceNotificationArmed = dataStore.createValue("storage.low.notification.armed", true)
+
+    val hintLowSpaceDismissed = dataStore.createValue("hint.lowspace.dismissed", false)
+
     companion object {
         internal val TAG = logTag("Analyzer", "Settings")
 

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/backup/AnalyzerSettingsBackupContributor.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/backup/AnalyzerSettingsBackupContributor.kt
@@ -16,6 +16,10 @@ class AnalyzerSettingsBackupContributor @Inject constructor(
     settings: AnalyzerSettings,
 ) : DataStoreSettingsBackupContributor(settings.dataStore) {
     override val key = "analyzer"
+
+    // The armed latch is runtime state, not a preference: restoring `armed = false` onto a fresh
+    // install would suppress that device's first low-space warning indefinitely.
+    override val excludedKeys = setOf("storage.low.notification.armed")
 }
 
 @Module

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
+import androidx.compose.material.icons.twotone.NotificationImportant
 import androidx.compose.material.icons.twotone.Storage
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -26,6 +27,7 @@ import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.settings.SettingsCategoryHeader
 import eu.darken.sdmse.common.compose.settings.SettingsPreferenceItem
+import eu.darken.sdmse.common.compose.settings.SettingsSwitchItem
 import eu.darken.sdmse.common.compose.settings.dialogs.SizeInputDialog
 import eu.darken.sdmse.common.error.ErrorEventHandler
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
@@ -44,6 +46,8 @@ fun AnalyzerSettingsScreenHost(
         state = state,
         onNavigateUp = vm::navUp,
         onThresholdChanged = vm::setThreshold,
+        onNotificationChanged = vm::setNotificationEnabled,
+        onUpgradeClick = vm::onUpgradeClick,
     )
 }
 
@@ -52,6 +56,8 @@ internal fun AnalyzerSettingsScreen(
     state: AnalyzerSettingsViewModel.State = AnalyzerSettingsViewModel.State(),
     onNavigateUp: () -> Unit = {},
     onThresholdChanged: (Long?) -> Unit = {},
+    onNotificationChanged: (Boolean) -> Unit = {},
+    onUpgradeClick: () -> Unit = {},
 ) {
     var showThresholdDialog by remember { mutableStateOf(false) }
     val context = LocalContext.current
@@ -117,6 +123,18 @@ internal fun AnalyzerSettingsScreen(
                     onClick = { showThresholdDialog = true },
                 )
             }
+            item {
+                SettingsSwitchItem(
+                    icon = Icons.TwoTone.NotificationImportant,
+                    title = stringResource(R.string.analyzer_settings_lowspace_notification_title),
+                    subtitle = stringResource(R.string.analyzer_settings_lowspace_notification_desc),
+                    // Unchecked while not Pro regardless of the stored value.
+                    checked = state.isPro && state.notificationEnabled,
+                    onCheckedChange = onNotificationChanged,
+                    requiresUpgrade = !state.isPro,
+                    onUpgrade = onUpgradeClick,
+                )
+            }
         }
     }
 }
@@ -144,6 +162,22 @@ private fun AnalyzerSettingsScreenCustomPreview() {
                 customThresholdBytes = 10L * 1000 * 1000 * 1000,
                 primaryCapacityBytes = 128L * 1000 * 1000 * 1000,
                 effectiveThresholdBytes = 10L * 1000 * 1000 * 1000,
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun AnalyzerSettingsScreenProPreview() {
+    PreviewWrapper {
+        AnalyzerSettingsScreen(
+            state = AnalyzerSettingsViewModel.State(
+                customThresholdBytes = null,
+                primaryCapacityBytes = 128L * 1000 * 1000 * 1000,
+                effectiveThresholdBytes = LowStorage.AUTO_MAX_BYTES,
+                notificationEnabled = true,
+                isPro = true,
             ),
         )
     }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModel.kt
@@ -6,12 +6,15 @@ import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
 import eu.darken.sdmse.common.uix.ViewModel4
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.stats.core.LowStorage
 import eu.darken.sdmse.stats.core.SpaceTracker
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 
@@ -20,6 +23,7 @@ class AnalyzerSettingsViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val settings: AnalyzerSettings,
     private val spaceTracker: SpaceTracker,
+    upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
 
     // A single reading is enough: capacity only informs the "currently X" hint next to Automatic.
@@ -31,11 +35,15 @@ class AnalyzerSettingsViewModel @Inject constructor(
     val state: StateFlow<State> = combine(
         settings.lowStorageThresholdBytes.flow,
         primaryCapacity,
-    ) { custom, capacity ->
+        settings.lowSpaceNotificationEnabled.flow,
+        upgradeRepo.upgradeInfo.map { it.isPro },
+    ) { custom, capacity, notificationEnabled, isPro ->
         State(
             customThresholdBytes = custom,
             primaryCapacityBytes = capacity,
             effectiveThresholdBytes = capacity?.let { LowStorage.resolveThreshold(it, custom) },
+            notificationEnabled = notificationEnabled,
+            isPro = isPro,
         )
     }.safeStateIn(
         initialValue = State(),
@@ -47,10 +55,25 @@ class AnalyzerSettingsViewModel @Inject constructor(
         settings.lowStorageThresholdBytes.value(bytes)
     }
 
+    fun setNotificationEnabled(enabled: Boolean) = launch {
+        log(TAG) { "setNotificationEnabled($enabled)" }
+        // Defence-in-depth: the row is gated behind the upgrade badge when not Pro, but refuse
+        // here too so a future caller can't bypass the gate.
+        if (!state.value.isPro) return@launch
+        settings.lowSpaceNotificationEnabled.value(enabled)
+    }
+
+    fun onUpgradeClick() {
+        log(TAG) { "onUpgradeClick()" }
+        navTo(UpgradeRoute(forced = true))
+    }
+
     data class State(
         val customThresholdBytes: Long? = null,
         val primaryCapacityBytes: Long? = null,
         val effectiveThresholdBytes: Long? = null,
+        val notificationEnabled: Boolean = false,
+        val isPro: Boolean = false,
     )
 
     companion object {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
@@ -61,6 +62,8 @@ fun DeviceStorageScreenHost(
         onStorageClick = vm::onStorageClick,
         onTrendClick = vm::onTrendClick,
         onRefresh = vm::refresh,
+        onLowSpaceHintDismiss = vm::dismissLowSpaceHint,
+        onLowSpaceHintUpgrade = vm::openUpgrade,
     )
 }
 
@@ -71,6 +74,8 @@ internal fun DeviceStorageScreen(
     onStorageClick: (DeviceStorageViewModel.Row) -> Unit = {},
     onTrendClick: (DeviceStorageViewModel.Row) -> Unit = {},
     onRefresh: () -> Unit = {},
+    onLowSpaceHintDismiss: () -> Unit = {},
+    onLowSpaceHintUpgrade: () -> Unit = {},
 ) {
     val state by stateSource.collectAsStateWithLifecycle()
     val context = LocalContext.current
@@ -138,6 +143,14 @@ internal fun DeviceStorageScreen(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
+                if (state.showLowSpaceHint) {
+                    item(key = "lowspace-hint", span = { GridItemSpan(maxLineSpan) }) {
+                        LowSpaceHintCard(
+                            onDismiss = onLowSpaceHintDismiss,
+                            onUpgrade = onLowSpaceHintUpgrade,
+                        )
+                    }
+                }
                 itemsIndexed(state.storages, key = { _, it -> it.storage.id.hashCode() }) { index, row ->
                     DeviceStorageItemCard(
                         modifier = if (index == 0) {
@@ -160,5 +173,15 @@ internal fun DeviceStorageScreen(
 private fun DeviceStorageScreenEmptyPreview() {
     PreviewWrapper {
         DeviceStorageScreen()
+    }
+}
+
+@Preview2
+@Composable
+private fun DeviceStorageScreenLowSpaceHintPreview() {
+    PreviewWrapper {
+        DeviceStorageScreen(
+            stateSource = MutableStateFlow(DeviceStorageViewModel.State(showLowSpaceHint = true)),
+        )
     }
 }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModel.kt
@@ -2,11 +2,13 @@ package eu.darken.sdmse.analyzer.ui.storage.device
 
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
 import eu.darken.sdmse.analyzer.core.device.DeviceStorageScanTask
 import eu.darken.sdmse.analyzer.ui.StorageContentRoute
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.intervalFlow
 import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
@@ -33,6 +35,7 @@ import kotlin.time.Duration.Companion.hours
 class DeviceStorageViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val analyzer: Analyzer,
+    private val analyzerSettings: AnalyzerSettings,
     spaceHistoryRepo: SpaceHistoryRepo,
     upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
@@ -54,7 +57,8 @@ class DeviceStorageViewModel @Inject constructor(
             spaceHistoryRepo.getAllHistory(Instant.now() - Duration.ofDays(7))
         },
         upgradeRepo.upgradeInfo.map { it.isPro },
-    ) { data, snapshots, isPro ->
+        analyzerSettings.hintLowSpaceDismissed.flow,
+    ) { data, snapshots, isPro, hintDismissed ->
         val snapshotsByStorage = snapshots.groupBy { it.storageId }
         State(
             storages = data.storages.map { storage ->
@@ -66,6 +70,7 @@ class DeviceStorageViewModel @Inject constructor(
                     isPro = isPro,
                 )
             },
+            showLowSpaceHint = !isPro && !hintDismissed,
         )
     }
 
@@ -105,9 +110,22 @@ class DeviceStorageViewModel @Inject constructor(
         val isPro: Boolean = false,
     )
 
+    // No re-arm: unlike the scheduler's battery hint there is no condition that can clear and
+    // legitimately raise this pitch again.
+    fun dismissLowSpaceHint() = launch {
+        log(TAG) { "dismissLowSpaceHint()" }
+        analyzerSettings.hintLowSpaceDismissed.value(true)
+    }
+
+    fun openUpgrade() {
+        log(TAG) { "openUpgrade()" }
+        navTo(UpgradeRoute())
+    }
+
     data class State(
         val storages: List<Row> = emptyList(),
         val progress: Progress.Data? = null,
+        val showLowSpaceHint: Boolean = false,
     )
 
     companion object {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/LowSpaceHintCard.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/LowSpaceHintCard.kt
@@ -1,0 +1,87 @@
+package eu.darken.sdmse.analyzer.ui.storage.device
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.NotificationImportant
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.analyzer.R
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.R as CommonR
+
+@Composable
+internal fun LowSpaceHintCard(
+    modifier: Modifier = Modifier,
+    onDismiss: () -> Unit = {},
+    onUpgrade: () -> Unit = {},
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        ),
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    Icons.TwoTone.NotificationImportant,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = stringResource(R.string.analyzer_lowspace_hint_title),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+            Spacer(modifier = Modifier.padding(vertical = 4.dp))
+            Text(
+                text = stringResource(R.string.analyzer_lowspace_hint_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Spacer(modifier = Modifier.padding(vertical = 4.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(CommonR.string.general_dismiss_action))
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(onClick = onUpgrade) {
+                    Text(stringResource(CommonR.string.general_upgrade_action))
+                }
+            }
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun LowSpaceHintCardPreview() {
+    PreviewWrapper {
+        LowSpaceHintCard(modifier = Modifier.padding(16.dp))
+    }
+}

--- a/app-tool-analyzer/src/main/res/values/strings.xml
+++ b/app-tool-analyzer/src/main/res/values/strings.xml
@@ -63,6 +63,12 @@
     <string name="analyzer_settings_lowstorage_value_auto">Automatic (currently %1$s)</string>
     <string name="analyzer_settings_lowstorage_value_auto_unknown">Automatic</string>
     <string name="analyzer_settings_lowstorage_automatic_action">Automatic</string>
+    <string name="analyzer_settings_lowspace_notification_title">Low space warning</string>
+    <string name="analyzer_settings_lowspace_notification_desc">Get a notification before your storage runs out.</string>
+
+    <!-- Device storage upgrade hint -->
+    <string name="analyzer_lowspace_hint_title">Never get caught out of space</string>
+    <string name="analyzer_lowspace_hint_body">Upgrade to get a warning before your storage runs out, so you can clean up while there is still room to work with.</string>
 
     <!-- Guided tour -->
     <string name="tour_analyzer_intro_body">See what\'s actually filling up your storage. The Analyzer maps out where your space goes. Each of these cards is a storage chip on your device.</string>

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/backup/AnalyzerSettingsBackupContributorTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/backup/AnalyzerSettingsBackupContributorTest.kt
@@ -1,0 +1,74 @@
+package eu.darken.sdmse.analyzer.core.backup
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.common.backup.RestoreMode
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import java.nio.file.Path
+
+class AnalyzerSettingsBackupContributorTest : BaseTest() {
+
+    @Test
+    fun `the armed latch is excluded from a backup snapshot`(@TempDir tempDir: Path) = runTest {
+        // The latch is runtime state: restoring armed=false onto a fresh install would suppress
+        // that device's first low-space warning indefinitely.
+        val store = PreferenceDataStoreFactory.create(
+            scope = this,
+            produceFile = { tempDir.resolve("analyzer.preferences_pb").toFile() },
+        )
+        store.edit {
+            it[booleanPreferencesKey("storage.low.notification.enabled")] = true
+            it[booleanPreferencesKey("storage.low.notification.armed")] = false
+            it[booleanPreferencesKey("hint.lowspace.dismissed")] = true
+            it[longPreferencesKey("storage.low.threshold.bytes")] = 10_000_000_000L
+        }
+        val settings = mockk<AnalyzerSettings>().apply {
+            every { dataStore } returns store
+        }
+
+        val snapshot = AnalyzerSettingsBackupContributor(settings).snapshot()!!
+
+        snapshot.jsonObject.keys shouldBe setOf(
+            "storage.low.notification.enabled",
+            "hint.lowspace.dismissed",
+            "storage.low.threshold.bytes",
+        )
+    }
+
+    @Test
+    fun `restoring never overwrites the on-device latch`(@TempDir tempDir: Path) = runTest {
+        val source = PreferenceDataStoreFactory.create(
+            scope = this,
+            produceFile = { tempDir.resolve("source.preferences_pb").toFile() },
+        )
+        source.edit { it[booleanPreferencesKey("storage.low.notification.enabled")] = true }
+        val snapshot = AnalyzerSettingsBackupContributor(
+            mockk<AnalyzerSettings>().apply { every { dataStore } returns source },
+        ).snapshot()!!
+
+        val target = PreferenceDataStoreFactory.create(
+            scope = this,
+            produceFile = { tempDir.resolve("target.preferences_pb").toFile() },
+        )
+        target.edit { it[booleanPreferencesKey("storage.low.notification.armed")] = false }
+
+        AnalyzerSettingsBackupContributor(
+            mockk<AnalyzerSettings>().apply { every { dataStore } returns target },
+        ).restore(snapshot, RestoreMode.REPLACE)
+
+        val prefs = target.data.first()
+        prefs[booleanPreferencesKey("storage.low.notification.armed")] shouldBe false
+        prefs[booleanPreferencesKey("storage.low.notification.enabled")] shouldBe true
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreenTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsScreenTest.kt
@@ -14,12 +14,16 @@ class AnalyzerSettingsScreenTest : BaseComposeRobolectricTest() {
     private fun ComposeContentTestRule.setSettingsScreen(
         state: AnalyzerSettingsViewModel.State,
         onThresholdChanged: (Long?) -> Unit = {},
+        onNotificationChanged: (Boolean) -> Unit = {},
+        onUpgradeClick: () -> Unit = {},
     ) {
         setContent {
             PreviewWrapper {
                 AnalyzerSettingsScreen(
                     state = state,
                     onThresholdChanged = onThresholdChanged,
+                    onNotificationChanged = onNotificationChanged,
+                    onUpgradeClick = onUpgradeClick,
                 )
             }
         }
@@ -127,6 +131,45 @@ class AnalyzerSettingsScreenTest : BaseComposeRobolectricTest() {
 
         calls shouldBe 0
         composeRule.onNodeWithText("Save").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the low space warning row is visible`() {
+        composeRule.setSettingsScreen(AnalyzerSettingsViewModel.State())
+
+        composeRule.onNodeWithText("Low space warning").assertExists()
+    }
+
+    @Test
+    fun `a non-Pro tap opens the upgrade flow instead of toggling`() {
+        var toggles = 0
+        var upgrades = 0
+        composeRule.setSettingsScreen(
+            state = AnalyzerSettingsViewModel.State(isPro = false, notificationEnabled = false),
+            onNotificationChanged = { toggles++ },
+            onUpgradeClick = { upgrades++ },
+        )
+
+        composeRule.onNodeWithText("Low space warning").performClick()
+
+        toggles shouldBe 0
+        upgrades shouldBe 1
+    }
+
+    @Test
+    fun `a Pro tap toggles the warning`() {
+        var captured: Boolean? = null
+        var upgrades = 0
+        composeRule.setSettingsScreen(
+            state = AnalyzerSettingsViewModel.State(isPro = true, notificationEnabled = false),
+            onNotificationChanged = { captured = it },
+            onUpgradeClick = { upgrades++ },
+        )
+
+        composeRule.onNodeWithText("Low space warning").performClick()
+
+        captured shouldBe true
+        upgrades shouldBe 0
     }
 
     private infix fun <T> T.shouldBe(expected: T) {

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/settings/AnalyzerSettingsViewModelTest.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.analyzer.ui.settings
 
 import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.stats.core.LowStorage
 import eu.darken.sdmse.stats.core.SpaceTracker
 import io.kotest.matchers.shouldBe
@@ -10,9 +11,12 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -32,29 +36,44 @@ class AnalyzerSettingsViewModelTest : BaseTest() {
     private class Harness(
         val vm: AnalyzerSettingsViewModel,
         val threshold: DataStoreValue<Long?>,
+        val notificationEnabled: DataStoreValue<Boolean>,
     )
 
-    private fun harness(
+    private fun TestScope.harness(
         customThresholdBytes: Long? = null,
         primaryStorage: SpaceTracker.StorageSnapshot? = SpaceTracker.StorageSnapshot(
             storageId = "primary",
             spaceFree = 50_000_000_000L,
             spaceCapacity = 128_000_000_000L,
         ),
+        notificationEnabled: Boolean = false,
+        isPro: Boolean = false,
     ): Harness {
         val threshold = rwDataStoreValue(customThresholdBytes)
+        val notification = rwDataStoreValue(notificationEnabled)
         val settings = mockk<AnalyzerSettings>().apply {
             every { lowStorageThresholdBytes } returns threshold
+            every { lowSpaceNotificationEnabled } returns notification
         }
         val spaceTracker = mockk<SpaceTracker>(relaxed = true).apply {
             coEvery { readPrimaryStorage() } returns primaryStorage
+        }
+        val info = mockk<UpgradeRepo.Info>().apply {
+            every { this@apply.isPro } returns isPro
+        }
+        val upgradeRepo = mockk<UpgradeRepo>().apply {
+            every { upgradeInfo } returns flowOf(info)
         }
         val vm = AnalyzerSettingsViewModel(
             dispatcherProvider = TestDispatcherProvider(),
             settings = settings,
             spaceTracker = spaceTracker,
+            upgradeRepo = upgradeRepo,
         )
-        return Harness(vm, threshold)
+        // safeStateIn is WhileSubscribed: without a live subscriber `state.value` stays at the
+        // initial State() and the Pro guard in setNotificationEnabled would never see isPro.
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        return Harness(vm, threshold, notification)
     }
 
     // ─────────────────────────── state ───────────────────────────
@@ -129,5 +148,52 @@ class AnalyzerSettingsViewModelTest : BaseTest() {
         val captured = slot<(Long?) -> Long?>()
         coVerify(exactly = 1) { h.threshold.update(capture(captured)) }
         captured.captured(10_000_000_000L) shouldBe null
+    }
+
+    // ─────────────────────────── low space warning ───────────────────────────
+
+    @Test
+    fun `the stored toggle and the Pro state surface`() = runTest2 {
+        val h = harness(notificationEnabled = true, isPro = true)
+        advanceUntilIdle()
+
+        val state = h.vm.state.first()
+        state.notificationEnabled shouldBe true
+        state.isPro shouldBe true
+    }
+
+    @Test
+    fun `a non-Pro user sees the stored value but the row renders unchecked`() = runTest2 {
+        // The screen renders `isPro && notificationEnabled`, so the stored value stays intact.
+        val h = harness(notificationEnabled = true, isPro = false)
+        advanceUntilIdle()
+
+        val state = h.vm.state.first()
+        state.notificationEnabled shouldBe true
+        state.isPro shouldBe false
+    }
+
+    @Test
+    fun `a Pro user can enable the warning`() = runTest2 {
+        val h = harness(notificationEnabled = false, isPro = true)
+        advanceUntilIdle()
+
+        h.vm.setNotificationEnabled(true)
+        advanceUntilIdle()
+
+        val captured = slot<(Boolean) -> Boolean?>()
+        coVerify(exactly = 1) { h.notificationEnabled.update(capture(captured)) }
+        captured.captured(false) shouldBe true
+    }
+
+    @Test
+    fun `a non-Pro user cannot enable the warning`() = runTest2 {
+        val h = harness(notificationEnabled = false, isPro = false)
+        advanceUntilIdle()
+
+        h.vm.setNotificationEnabled(true)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.notificationEnabled.update(any()) }
     }
 }

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreenTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreenTest.kt
@@ -1,0 +1,71 @@
+package eu.darken.sdmse.analyzer.ui.storage.device
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.compose.tour.GuidedTourController
+import eu.darken.sdmse.common.compose.tour.LocalGuidedTourController
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class DeviceStorageScreenTest : BaseComposeRobolectricTest() {
+
+    // Relaxed mock: shouldStart() defaults to false, so no guided tour starts.
+    private val mockTourController: GuidedTourController = mockk(relaxed = true)
+
+    private fun ComposeContentTestRule.setStorageScreen(
+        state: DeviceStorageViewModel.State,
+        onLowSpaceHintDismiss: () -> Unit = {},
+        onLowSpaceHintUpgrade: () -> Unit = {},
+    ) {
+        setContent {
+            CompositionLocalProvider(LocalGuidedTourController provides mockTourController) {
+                PreviewWrapper {
+                    DeviceStorageScreen(
+                        stateSource = MutableStateFlow(state),
+                        onLowSpaceHintDismiss = onLowSpaceHintDismiss,
+                        onLowSpaceHintUpgrade = onLowSpaceHintUpgrade,
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `the low space hint renders when not Pro and not dismissed`() {
+        composeRule.setStorageScreen(DeviceStorageViewModel.State(showLowSpaceHint = true))
+
+        composeRule.onNodeWithText("Never get caught out of space").assertExists()
+    }
+
+    @Test
+    fun `the low space hint stays away when hidden`() {
+        composeRule.setStorageScreen(DeviceStorageViewModel.State(showLowSpaceHint = false))
+
+        composeRule.onNodeWithText("Never get caught out of space").assertDoesNotExist()
+    }
+
+    @Test
+    fun `the hint's buttons are wired`() {
+        var dismissals = 0
+        var upgrades = 0
+        composeRule.setStorageScreen(
+            state = DeviceStorageViewModel.State(showLowSpaceHint = true),
+            onLowSpaceHintDismiss = { dismissals++ },
+            onLowSpaceHintUpgrade = { upgrades++ },
+        )
+
+        composeRule.onNodeWithText("Dismiss").performClick()
+        composeRule.onNodeWithText("Upgrade").performClick()
+
+        composeRule.runOnIdle {
+            assertEquals(1, dismissals)
+            assertEquals(1, upgrades)
+        }
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModelTest.kt
@@ -108,11 +108,14 @@ class DeviceStorageViewModelTest : BaseTest() {
     fun `the hint's upgrade button navigates to the upgrade screen`() = runTest2 {
         val h = harness()
         val events = mutableListOf<NavEvent>()
-        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { h.vm.navEvents.collect { events += it } }
+        // Foreground scope on purpose: advanceUntilIdle() stops as soon as no FOREGROUND event is
+        // queued, so a collector in backgroundScope would never be resumed to receive the emission.
+        val job = launch(start = CoroutineStart.UNDISPATCHED) { h.vm.navEvents.collect { events += it } }
 
         h.vm.openUpgrade()
         advanceUntilIdle()
 
         (events.single() as NavEvent.GoTo).destination shouldBe UpgradeRoute()
+        job.cancel()
     }
 }

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageViewModelTest.kt
@@ -1,0 +1,118 @@
+package eu.darken.sdmse.analyzer.ui.storage.device
+
+import eu.darken.sdmse.analyzer.core.Analyzer
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.navigation.NavEvent
+import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.stats.core.SpaceHistoryRepo
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+class DeviceStorageViewModelTest : BaseTest() {
+
+    private fun <T> rwDataStoreValue(initial: T, flow: Flow<T> = flowOf(initial)): DataStoreValue<T> =
+        mockk<DataStoreValue<T>>().apply {
+            every { this@apply.flow } returns flow
+            coEvery { update(any()) } returns DataStoreValue.Updated(old = initial, new = initial)
+        }
+
+    private class Harness(
+        val vm: DeviceStorageViewModel,
+        val hintDismissed: DataStoreValue<Boolean>,
+    )
+
+    private fun TestScope.harness(
+        isPro: Boolean = false,
+        hintDismissed: Boolean = false,
+    ): Harness {
+        val dismissed = rwDataStoreValue(hintDismissed)
+        val analyzer = mockk<Analyzer>(relaxed = true).apply {
+            every { data } returns MutableStateFlow(Analyzer.Data())
+            every { progress } returns MutableStateFlow(null)
+        }
+        val settings = mockk<AnalyzerSettings>().apply {
+            every { hintLowSpaceDismissed } returns dismissed
+        }
+        val info = mockk<UpgradeRepo.Info>().apply {
+            every { this@apply.isPro } returns isPro
+        }
+        val vm = DeviceStorageViewModel(
+            dispatcherProvider = TestDispatcherProvider(),
+            analyzer = analyzer,
+            analyzerSettings = settings,
+            spaceHistoryRepo = mockk<SpaceHistoryRepo>().apply {
+                every { getAllHistory(any()) } returns flowOf(emptyList())
+            },
+            upgradeRepo = mockk<UpgradeRepo>().apply { every { upgradeInfo } returns flowOf(info) },
+        )
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        return Harness(vm, dismissed)
+    }
+
+    @Test
+    fun `the hint shows for a non-Pro user who has not dismissed it`() = runTest2 {
+        val h = harness(isPro = false, hintDismissed = false)
+        advanceUntilIdle()
+
+        h.vm.state.first().showLowSpaceHint shouldBe true
+    }
+
+    @Test
+    fun `the hint stays hidden for a Pro user`() = runTest2 {
+        val h = harness(isPro = true, hintDismissed = false)
+        advanceUntilIdle()
+
+        h.vm.state.first().showLowSpaceHint shouldBe false
+    }
+
+    @Test
+    fun `the hint stays hidden once dismissed`() = runTest2 {
+        val h = harness(isPro = false, hintDismissed = true)
+        advanceUntilIdle()
+
+        h.vm.state.first().showLowSpaceHint shouldBe false
+    }
+
+    @Test
+    fun `dismissing writes the flag through`() = runTest2 {
+        val h = harness()
+        advanceUntilIdle()
+
+        h.vm.dismissLowSpaceHint()
+        advanceUntilIdle()
+
+        val captured = slot<(Boolean) -> Boolean?>()
+        coVerify(exactly = 1) { h.hintDismissed.update(capture(captured)) }
+        captured.captured(false) shouldBe true
+    }
+
+    @Test
+    fun `the hint's upgrade button navigates to the upgrade screen`() = runTest2 {
+        val h = harness()
+        val events = mutableListOf<NavEvent>()
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { h.vm.navEvents.collect { events += it } }
+
+        h.vm.openUpgrade()
+        advanceUntilIdle()
+
+        (events.single() as NavEvent.GoTo).destination shouldBe UpgradeRoute()
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/App.kt
+++ b/app/src/main/java/eu/darken/sdmse/App.kt
@@ -32,6 +32,7 @@ import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.shortcuts.ShortcutManager
 import eu.darken.sdmse.main.core.taskmanager.TaskResultNotifier
+import eu.darken.sdmse.stats.core.LowSpaceMonitor
 import eu.darken.sdmse.stats.core.SpaceMonitorControl
 import eu.darken.sdmse.stats.core.TaskStatsCoordinator
 import eu.darken.sdmse.widget.WidgetRefreshCoordinator
@@ -61,6 +62,7 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var exitInfoLogger: ExitInfoLogger
     @Inject lateinit var shortcutManager: ShortcutManager
     @Inject lateinit var spaceMonitorControl: SpaceMonitorControl
+    @Inject lateinit var lowSpaceMonitor: LowSpaceMonitor
     @Inject lateinit var taskStatsCoordinator: TaskStatsCoordinator
     @Inject lateinit var taskResultNotifier: TaskResultNotifier
     @Inject lateinit var storageRescue: StorageRescue
@@ -122,6 +124,7 @@ open class App : Application(), Configuration.Provider {
         taskStatsCoordinator.start()
         taskResultNotifier.start()
         spaceMonitorControl.start()
+        lowSpaceMonitor.start(appScope)
         widgetRefreshCoordinator.start()
 
         val oldHandler = Thread.getDefaultUncaughtExceptionHandler()

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceAlertDecider.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceAlertDecider.kt
@@ -1,0 +1,54 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
+
+sealed interface LowSpaceAction {
+    data class Notify(val forecast: StorageForecast, val freeBytes: Long) : LowSpaceAction
+    data object Cancel : LowSpaceAction
+    data object Nothing : LowSpaceAction
+}
+
+data class LowSpaceDecision(
+    val action: LowSpaceAction,
+    /** `null` leaves the transition latch untouched. */
+    val armedAfter: Boolean?,
+)
+
+/**
+ * Whether the low-space warning should speak, go quiet, or stay out of the way.
+ *
+ * The trigger is the FORECAST, not an "is low" flag. [StorageForecast.BelowFloor] is returned the
+ * moment free space reaches the threshold, so triggering on "is low" would make the predictive copy
+ * unreachable and every warning would arrive after the fact.
+ *
+ * [LowSpaceAction.Cancel] ALWAYS re-arms. It means "no notification is standing", so the next
+ * qualifying condition has to be able to speak: an off/on of the toggle, or losing and regaining
+ * Pro, must not leave the user silently un-warned while their storage keeps filling. A successful
+ * post is the only thing that spends the latch, which is why [LowSpaceDecision.armedAfter] is left
+ * to the caller on the notify path.
+ */
+object LowSpaceAlertDecider {
+
+    fun decide(
+        enabled: Boolean,
+        isPro: Boolean,
+        armed: Boolean,
+        forecast: StorageForecast?,
+        freeBytes: Long,
+    ): LowSpaceDecision {
+        if (!enabled || !isPro) return LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+
+        val isWarning = when (forecast) {
+            is StorageForecast.Filling -> forecast.isUrgent
+            StorageForecast.BelowFloor -> true
+            else -> false
+        }
+        if (!isWarning || forecast == null) return LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+
+        // Warning state, but the latch is spent: stay quiet without clearing what is on screen.
+        if (!armed) return LowSpaceDecision(LowSpaceAction.Nothing, armedAfter = null)
+
+        // The caller sets armedAfter from the post result: false on POSTED, unchanged otherwise.
+        return LowSpaceDecision(LowSpaceAction.Notify(forecast, freeBytes), armedAfter = null)
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
@@ -20,6 +20,8 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicBoolean
@@ -43,6 +45,16 @@ class LowSpaceMonitor @Inject constructor(
 ) {
 
     private val started = AtomicBoolean(false)
+
+    /**
+     * Serializes the read-decide-post-write transaction.
+     *
+     * The worker run, the observer and a toggle-off can all land at once. Without this, two checks
+     * could both read `armed = true` and post twice, and a [cancelAndRearm] could finish before an
+     * in-flight check posts, leaving a warning on screen with the latch disarmed after the feature
+     * was switched off or Pro lapsed.
+     */
+    private val mutex = Mutex()
 
     /**
      * Reacts to the toggle and to Pro state without waiting for the next worker run.
@@ -81,7 +93,7 @@ class LowSpaceMonitor @Inject constructor(
      */
     suspend fun check() {
         try {
-            checkInternal()
+            mutex.withLock { checkInternal() }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -150,8 +162,10 @@ class LowSpaceMonitor @Inject constructor(
 
     private suspend fun cancelAndRearm() {
         try {
-            notifications.cancel()
-            setArmed(true)
+            mutex.withLock {
+                notifications.cancel()
+                setArmed(true)
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
@@ -1,0 +1,174 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.common.upgrade.isProSettled
+import eu.darken.sdmse.stats.core.forecast.StorageForecaster
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Decides whether the Pro low-space warning should be showing, and makes it so.
+ *
+ * Driven by the six-hourly [SpaceMonitorWorker] plus an observer that reacts the moment the user
+ * flips the setting or their Pro state changes. Six-hourly is inexact and Doze can defer it, which
+ * is acceptable for a gigabyte-scale advisory.
+ */
+@Singleton
+class LowSpaceMonitor @Inject constructor(
+    private val spaceTracker: SpaceTracker,
+    private val spaceHistoryRepo: SpaceHistoryRepo,
+    private val analyzerSettings: AnalyzerSettings,
+    private val upgradeRepo: UpgradeRepo,
+    private val notifications: LowSpaceNotifications,
+) {
+
+    private val started = AtomicBoolean(false)
+
+    /**
+     * Reacts to the toggle and to Pro state without waiting for the next worker run.
+     *
+     * Cancelling on the way down keeps a posted warning from lingering for up to six hours after
+     * the user switched it off, and the [check] on the way up makes enabling the setting do
+     * something observable instead of looking broken.
+     */
+    fun start(scope: CoroutineScope) {
+        if (!started.compareAndSet(false, true)) return
+        log(TAG, VERBOSE) { "start()" }
+
+        combine(
+            analyzerSettings.lowSpaceNotificationEnabled.flow,
+            // Only settled emissions: the pre-billing seed reports non-Pro even for paying users,
+            // and acting on it would cancel and re-arm on every process start, re-notifying a user
+            // who already dismissed the warning.
+            upgradeRepo.upgradeInfo.filter { it.isSettled }.map { it.isPro },
+        ) { enabled, isPro -> enabled && isPro }
+            .distinctUntilChanged()
+            .onEach { active ->
+                if (active) {
+                    log(TAG) { "Low space warning became active, checking now" }
+                    check()
+                } else {
+                    log(TAG) { "Low space warning is inactive, cancelling" }
+                    cancelAndRearm()
+                }
+            }
+            .launchIn(scope)
+    }
+
+    /**
+     * One evaluation of the primary volume. Never throws: a notification failure must not break
+     * snapshot recording or the widget refresh in [SpaceMonitorWorker].
+     */
+    suspend fun check() {
+        try {
+            checkInternal()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "check() failed: ${e.asLog()}" }
+        }
+    }
+
+    private suspend fun checkInternal() {
+        val enabled = analyzerSettings.lowSpaceNotificationEnabled.value()
+        val armed = analyzerSettings.lowSpaceNotificationArmed.value()
+
+        // recordSnapshot() returns Unit and is throttled to 30 minutes, so the worker holds no
+        // fresh reading of its own.
+        val primary = spaceTracker.readPrimaryStorage()
+        // readPrimaryStorage() can return a non-null 0/0 reading, which would otherwise classify as
+        // a warning state and post "0 B free".
+        if (primary == null || primary.spaceCapacity <= 0L || primary.spaceFree !in 0L..primary.spaceCapacity) {
+            log(TAG, WARN) { "check(): Implausible primary reading, skipping: $primary" }
+            return
+        }
+
+        // isProSettled() is the background gate; isProForUi() is for tap routing.
+        val isPro = if (enabled) upgradeRepo.isProSettled() else false
+
+        val forecast = if (enabled && isPro) {
+            // Single-storage history only: StorageTrendCalculator needs one volume's snapshots, a
+            // merged multi-volume list yields a meaningless rate.
+            val history = spaceHistoryRepo
+                .getHistory(primary.storageId, Instant.now() - HISTORY_WINDOW)
+                .first()
+            StorageForecaster.forecast(
+                history = history,
+                current = primary,
+                lowStorageThresholdBytes = LowStorage.resolveThreshold(
+                    capacityBytes = primary.spaceCapacity,
+                    customThresholdBytes = analyzerSettings.lowStorageThresholdBytes.value(),
+                ),
+            )
+        } else {
+            null
+        }
+
+        val decision = LowSpaceAlertDecider.decide(
+            enabled = enabled,
+            isPro = isPro,
+            armed = armed,
+            forecast = forecast,
+            freeBytes = primary.spaceFree,
+        )
+        log(TAG) { "check(): $decision (forecast=$forecast, armed=$armed, enabled=$enabled, isPro=$isPro)" }
+
+        var armedAfter = decision.armedAfter
+        when (val action = decision.action) {
+            is LowSpaceAction.Notify -> {
+                val result = notifications.notifyLowSpace(action.forecast, action.freeBytes)
+                // Only a successful post spends the latch.
+                if (result == LowSpaceNotifications.PostResult.POSTED) armedAfter = false
+            }
+
+            LowSpaceAction.Cancel -> notifications.cancel()
+            LowSpaceAction.Nothing -> {}
+        }
+
+        if (armedAfter != null) setArmed(armedAfter)
+    }
+
+    private suspend fun cancelAndRearm() {
+        try {
+            notifications.cancel()
+            setArmed(true)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "cancelAndRearm() failed: ${e.asLog()}" }
+        }
+    }
+
+    /** Writes only on an actual change, so a device with the feature off takes no six-hourly write. */
+    private suspend fun setArmed(value: Boolean) {
+        if (analyzerSettings.lowSpaceNotificationArmed.value() == value) return
+        log(TAG) { "setArmed($value)" }
+        analyzerSettings.lowSpaceNotificationArmed.value(value)
+    }
+
+    companion object {
+        // Same window the dashboard forecast uses.
+        private val HISTORY_WINDOW: Duration = Duration.ofDays(7)
+        private val TAG = logTag("Stats", "LowSpace", "Monitor")
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceMonitor.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -69,19 +68,34 @@ class LowSpaceMonitor @Inject constructor(
 
         combine(
             analyzerSettings.lowSpaceNotificationEnabled.flow,
-            // Only settled emissions: the pre-billing seed reports non-Pro even for paying users,
-            // and acting on it would cancel and re-arm on every process start, re-notifying a user
-            // who already dismissed the warning.
-            upgradeRepo.upgradeInfo.filter { it.isSettled }.map { it.isPro },
-        ) { enabled, isPro -> enabled && isPro }
+            // `null` means "not known yet", not "not Pro": the pre-billing seed reports non-Pro even
+            // for paying users, and acting on it would cancel and re-arm on every process start,
+            // re-notifying a user who already dismissed the warning. Mapping (instead of filtering
+            // the unsettled emissions away) keeps the toggle-off branch below reachable while
+            // billing is still settling.
+            upgradeRepo.upgradeInfo.map { if (it.isSettled) it.isPro else null },
+        ) { enabled, isPro -> enabled to isPro }
             .distinctUntilChanged()
-            .onEach { active ->
-                if (active) {
-                    log(TAG) { "Low space warning became active, checking now" }
-                    check()
-                } else {
-                    log(TAG) { "Low space warning is inactive, cancelling" }
-                    cancelAndRearm()
+            .onEach { (enabled, isPro) ->
+                when {
+                    // Switched off wins over an unknown entitlement: a warning left over from a
+                    // previous process must go away now, not once billing settles.
+                    !enabled -> {
+                        log(TAG) { "Low space warning is disabled, cancelling" }
+                        cancelAndRearm()
+                    }
+
+                    isPro == true -> {
+                        log(TAG) { "Low space warning became active, checking now" }
+                        check()
+                    }
+
+                    isPro == false -> {
+                        log(TAG) { "Low space warning is not available without Pro, cancelling" }
+                        cancelAndRearm()
+                    }
+
+                    else -> log(TAG, VERBOSE) { "Entitlement is unsettled, waiting" }
                 }
             }
             .launchIn(scope)

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceNotifications.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceNotifications.kt
@@ -78,18 +78,24 @@ class LowSpaceNotifications @Inject constructor(
         }
 
         val freeText = Formatter.formatShortFileSize(context, freeBytes)
-        val body = when (forecast) {
+        // Title and body are picked together: a trend title over an "out of space" body understates
+        // the situation the body describes.
+        val (title, body) = when (forecast) {
             is StorageForecast.Filling -> {
                 val days = forecast.daysUntilFloor.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt()
-                context.getQuantityString2(
+                val bodyText = context.getQuantityString2(
                     R.plurals.stats_lowspace_notification_forecast_body,
                     days,
                     days,
                     freeText,
                 )
+                context.getString(R.string.stats_lowspace_notification_title) to bodyText
             }
 
-            else -> context.getString(R.string.stats_lowspace_notification_low_body, freeText)
+            else -> {
+                val bodyText = context.getString(R.string.stats_lowspace_notification_low_body, freeText)
+                context.getString(R.string.stats_lowspace_notification_low_title) to bodyText
+            }
         }
 
         // Fresh builder per call: a shared builder would leak style/field state between posts.
@@ -99,7 +105,7 @@ class LowSpaceNotifications @Inject constructor(
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setSmallIcon(UiR.drawable.ic_notification_mascot_24)
             .setAutoCancel(true)
-            .setContentTitle(context.getString(R.string.stats_lowspace_notification_title))
+            .setContentTitle(title)
             .setContentText(body)
             .setStyle(BigTextStyle().bigText(body))
             .build()

--- a/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceNotifications.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/LowSpaceNotifications.kt
@@ -1,0 +1,162 @@
+package eu.darken.sdmse.stats.core
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.text.format.Formatter
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.BigTextStyle
+import androidx.core.app.NotificationManagerCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.R
+import eu.darken.sdmse.common.BuildConfigWrap
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.getQuantityString2
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.permissions.Permission
+import eu.darken.sdmse.main.ui.MainActivity
+import eu.darken.sdmse.main.ui.shortcuts.ShortcutActivity
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
+import javax.inject.Inject
+import javax.inject.Singleton
+import eu.darken.sdmse.common.ui.R as UiR
+
+/**
+ * The tap target of the low-space warning.
+ *
+ * [Intent.filterEquals] ignores extras, and both `TaskWorkerNotifications` and
+ * `TaskResultNotifications` already hold request code `0` against a bare [MainActivity] intent.
+ * Reusing that shape with `FLAG_UPDATE_CURRENT` would overwrite THEIR extras and route their taps
+ * here, so this intent carries its own [action] and is posted under its own request code.
+ */
+internal fun lowSpaceContentIntent(context: Context): Intent = Intent(context, MainActivity::class.java).apply {
+    action = LowSpaceNotifications.ACTION_LOW_SPACE
+    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+    putExtra(ShortcutActivity.EXTRA_SHORTCUT_ACTION, ShortcutActivity.ACTION_OPEN_ANALYZER)
+}
+
+@Singleton
+class LowSpaceNotifications @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val notificationManager: NotificationManager,
+) {
+
+    private val contentPendingIntent: PendingIntent
+
+    init {
+        NotificationChannel(
+            CHANNEL_ID,
+            context.getString(R.string.stats_lowspace_notification_channel_label),
+            NotificationManager.IMPORTANCE_DEFAULT,
+        ).run { notificationManager.createNotificationChannel(this) }
+
+        contentPendingIntent = PendingIntent.getActivity(
+            context,
+            REQUEST_CODE,
+            lowSpaceContentIntent(context),
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT,
+        )
+    }
+
+    /**
+     * Posts the warning for [forecast].
+     *
+     * Returns an explicit [PostResult] instead of swallowing the outcome: only [PostResult.POSTED]
+     * may spend the caller's transition latch, so a user who grants notification permission later
+     * still gets warned while the storage is still filling.
+     */
+    fun notifyLowSpace(forecast: StorageForecast, freeBytes: Long): PostResult {
+        if (!canPost()) {
+            log(TAG, WARN) { "notifyLowSpace(): Blocked, notifications are not deliverable" }
+            return PostResult.BLOCKED
+        }
+
+        val freeText = Formatter.formatShortFileSize(context, freeBytes)
+        val body = when (forecast) {
+            is StorageForecast.Filling -> {
+                val days = forecast.daysUntilFloor.coerceIn(0L, Int.MAX_VALUE.toLong()).toInt()
+                context.getQuantityString2(
+                    R.plurals.stats_lowspace_notification_forecast_body,
+                    days,
+                    days,
+                    freeText,
+                )
+            }
+
+            else -> context.getString(R.string.stats_lowspace_notification_low_body, freeText)
+        }
+
+        // Fresh builder per call: a shared builder would leak style/field state between posts.
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setChannelId(CHANNEL_ID)
+            .setContentIntent(contentPendingIntent)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setSmallIcon(UiR.drawable.ic_notification_mascot_24)
+            .setAutoCancel(true)
+            .setContentTitle(context.getString(R.string.stats_lowspace_notification_title))
+            .setContentText(body)
+            .setStyle(BigTextStyle().bigText(body))
+            .build()
+
+        return try {
+            notificationManager.notify(NOTIFICATION_ID, notification)
+            log(TAG) { "notifyLowSpace($forecast, $freeBytes): Posted" }
+            PostResult.POSTED
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "notifyLowSpace() failed: ${e.asLog()}" }
+            PostResult.FAILED
+        }
+    }
+
+    fun cancel() {
+        log(TAG) { "cancel()" }
+        try {
+            notificationManager.cancel(NOTIFICATION_ID)
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "cancel() failed: ${e.asLog()}" }
+        }
+    }
+
+    private fun canPost(): Boolean {
+        if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+            log(TAG, WARN) { "Notifications are disabled for the app" }
+            return false
+        }
+        if (hasApiLevel(33) && !Permission.POST_NOTIFICATIONS.isGranted(context)) {
+            log(TAG, WARN) { "POST_NOTIFICATIONS is not granted" }
+            return false
+        }
+        val channel = notificationManager.getNotificationChannel(CHANNEL_ID)
+        if (channel != null && channel.importance == NotificationManager.IMPORTANCE_NONE) {
+            log(TAG, WARN) { "Channel $CHANNEL_ID is muted (IMPORTANCE_NONE)" }
+            return false
+        }
+        return true
+    }
+
+    enum class PostResult {
+        POSTED,
+        BLOCKED,
+        FAILED,
+    }
+
+    companion object {
+        val TAG = logTag("Stats", "LowSpace", "Notifications")
+        internal val CHANNEL_ID = "${BuildConfigWrap.APPLICATION_ID}.notification.channel.stats.lowspace"
+        internal val ACTION_LOW_SPACE = "${BuildConfigWrap.APPLICATION_ID}.ACTION_NOTIFICATION_LOW_SPACE"
+
+        // Notification ID ranges in use: 1 (task worker), 75 (uninstall watcher),
+        // 1000-1100 (scheduler state), 1200-1300 (scheduler result), 2000-2007 (task results).
+        internal const val NOTIFICATION_ID = 3000
+
+        // Distinct from every other PendingIntent request code in the app (all of which are 0),
+        // so FLAG_UPDATE_CURRENT here can't rewrite another site's intent.
+        internal const val REQUEST_CODE = 3000
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/stats/core/SpaceMonitorWorker.kt
+++ b/app/src/main/java/eu/darken/sdmse/stats/core/SpaceMonitorWorker.kt
@@ -17,6 +17,7 @@ class SpaceMonitorWorker @AssistedInject constructor(
     @Assisted private val params: WorkerParameters,
     private val spaceTracker: SpaceTracker,
     private val widgetUpdater: WidgetUpdater,
+    private val lowSpaceMonitor: LowSpaceMonitor,
 ) : CoroutineWorker(context, params) {
 
     override suspend fun doWork(): Result {
@@ -24,6 +25,8 @@ class SpaceMonitorWorker @AssistedInject constructor(
         spaceTracker.recordSnapshot()
         // Backstop refresh for placed home-screen widgets (free space may drift between cleans).
         widgetUpdater.updateAll()
+        // Never throws: a notification failure must not break snapshot recording or the widget.
+        lowSpaceMonitor.check()
         log(TAG, VERBOSE) { "doWork(): Done" }
         return Result.success()
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -448,4 +448,13 @@
     <string name="backup_restore_warn_history_body">This backup\'s history data (statistics, compression history, swipe sessions) is from a different app version and can\'t be restored. Everything else will be restored.</string>
     <string name="backup_restore_ack_understand">I understand and want to continue</string>
     <string name="backup_restore_action_restore">Restore</string>
+
+    <!-- Low space warning -->
+    <string name="stats_lowspace_notification_channel_label">Storage warnings</string>
+    <string name="stats_lowspace_notification_title">Storage is filling up</string>
+    <string name="stats_lowspace_notification_low_body">%1$s free. Storage is running out.</string>
+    <plurals name="stats_lowspace_notification_forecast_body">
+        <item quantity="one">About %1$d day of space left at this rate. %2$s free.</item>
+        <item quantity="other">About %1$d days of space left at this rate. %2$s free.</item>
+    </plurals>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,6 +452,7 @@
     <!-- Low space warning -->
     <string name="stats_lowspace_notification_channel_label">Storage warnings</string>
     <string name="stats_lowspace_notification_title">Storage is filling up</string>
+    <string name="stats_lowspace_notification_low_title">Storage is almost full</string>
     <string name="stats_lowspace_notification_low_body">%1$s free. Storage is running out.</string>
     <plurals name="stats_lowspace_notification_forecast_body">
         <item quantity="one">About %1$d day of space left at this rate. %2$s free.</item>

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceAlertDeciderTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceAlertDeciderTest.kt
@@ -1,0 +1,138 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class LowSpaceAlertDeciderTest : BaseTest() {
+
+    private val free = 1_000_000_000L
+    private val urgent = StorageForecast.Filling(daysUntilFloor = 3, bytesPerDay = 1_000_000_000L, isUrgent = true)
+    private val calm = StorageForecast.Filling(daysUntilFloor = 90, bytesPerDay = 1_000_000L, isUrgent = false)
+
+    private fun decide(
+        enabled: Boolean = true,
+        isPro: Boolean = true,
+        armed: Boolean = true,
+        forecast: StorageForecast? = urgent,
+    ) = LowSpaceAlertDecider.decide(
+        enabled = enabled,
+        isPro = isPro,
+        armed = armed,
+        forecast = forecast,
+        freeBytes = free,
+    )
+
+    // ─────────────────────────── notify ───────────────────────────
+
+    @Test
+    fun `an urgent Filling forecast notifies with that forecast`() {
+        // Regression guard: forecast() returns BelowFloor the moment free space reaches the
+        // threshold, so a trigger on "is low" would make this branch unreachable.
+        val decision = decide(forecast = urgent)
+
+        val notify = decision.action.shouldBeInstanceOf<LowSpaceAction.Notify>()
+        notify.forecast shouldBe urgent
+        notify.freeBytes shouldBe free
+        // The caller sets the latch from the post result.
+        decision.armedAfter shouldBe null
+    }
+
+    @Test
+    fun `BelowFloor notifies`() {
+        val decision = decide(forecast = StorageForecast.BelowFloor)
+
+        val notify = decision.action.shouldBeInstanceOf<LowSpaceAction.Notify>()
+        notify.forecast shouldBe StorageForecast.BelowFloor
+        decision.armedAfter shouldBe null
+    }
+
+    // ─────────────────────────── nothing to say ───────────────────────────
+
+    @Test
+    fun `a non-urgent Filling forecast cancels and re-arms`() {
+        decide(forecast = calm) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `Stable cancels and re-arms`() {
+        decide(forecast = StorageForecast.Stable) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `Erratic cancels and re-arms`() {
+        decide(forecast = StorageForecast.Erratic) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `InsufficientData cancels and re-arms`() {
+        decide(forecast = StorageForecast.InsufficientData) shouldBe
+                LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `a missing forecast cancels and re-arms`() {
+        decide(forecast = null) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    // ─────────────────────────── gates ───────────────────────────
+
+    @Test
+    fun `a disabled toggle cancels and re-arms even in the warning band`() {
+        decide(enabled = false) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `a non-Pro user cancels and re-arms even in the warning band`() {
+        decide(isPro = false) shouldBe LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `recovery while the toggle is off re-arms`() {
+        // Latch already spent, feature switched off, storage recovered: the next crossing must
+        // still be able to speak.
+        decide(enabled = false, armed = false, forecast = StorageForecast.Stable) shouldBe
+                LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    @Test
+    fun `recovery while non-Pro re-arms`() {
+        decide(isPro = false, armed = false, forecast = StorageForecast.Stable) shouldBe
+                LowSpaceDecision(LowSpaceAction.Cancel, armedAfter = true)
+    }
+
+    // ─────────────────────────── latch ───────────────────────────
+
+    @Test
+    fun `a spent latch stays quiet without clearing the standing notification`() {
+        decide(armed = false) shouldBe LowSpaceDecision(LowSpaceAction.Nothing, armedAfter = null)
+    }
+
+    @Test
+    fun `re-enabling while still in the warning band does not re-notify a spent latch`() {
+        // Off: cancel + re-arm... but the latch was already spent and the OFF pass re-armed it,
+        // so this models the case where the user toggles off and on again in one warning episode.
+        val off = decide(enabled = false, armed = false)
+        off.armedAfter shouldBe true
+
+        // Simulate the caller NOT having written the re-arm yet (e.g. the DataStore write lost a
+        // race): the latch is still spent, so nothing is posted.
+        decide(enabled = true, armed = false) shouldBe LowSpaceDecision(LowSpaceAction.Nothing, armedAfter = null)
+    }
+
+    @Test
+    fun `Pro loss then regain lets the warning speak again`() {
+        // Warned once, latch spent.
+        decide(armed = true).action.shouldBeInstanceOf<LowSpaceAction.Notify>()
+
+        // Pro lapses: cancel + re-arm.
+        val lost = decide(isPro = false, armed = false)
+        lost.action shouldBe LowSpaceAction.Cancel
+        lost.armedAfter shouldBe true
+
+        // Pro returns with the storage still in the warning band.
+        decide(isPro = true, armed = true).action.shouldBeInstanceOf<LowSpaceAction.Notify>()
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
@@ -12,8 +12,11 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -77,6 +80,8 @@ class LowSpaceMonitorTest : BaseTest() {
         enabled: Boolean = true,
         isPro: Boolean = true,
         armed: Boolean = true,
+        /** Virtual-time suspension inside the reading, so two checks can genuinely overlap. */
+        readDelayMs: Long = 0L,
         primary: SpaceTracker.StorageSnapshot? = SpaceTracker.StorageSnapshot(
             storageId = primaryId,
             spaceFree = floor + 2_500_000_000L,
@@ -95,7 +100,10 @@ class LowSpaceMonitorTest : BaseTest() {
             every { lowStorageThresholdBytes } returns statefulValue<Long?>(null)
         }
         val spaceTracker = mockk<SpaceTracker>().apply {
-            coEvery { readPrimaryStorage() } returns primary
+            coEvery { readPrimaryStorage() } coAnswers {
+                if (readDelayMs > 0L) delay(readDelayMs)
+                primary
+            }
         }
         val historyIds = mutableListOf<String>()
         val spaceHistoryRepo = mockk<SpaceHistoryRepo>().apply {
@@ -174,6 +182,20 @@ class LowSpaceMonitorTest : BaseTest() {
         h.monitor.check()
 
         verify(exactly = 1) { h.notifications.notifyLowSpace(StorageForecast.BelowFloor, floor - 1) }
+        h.armed.value() shouldBe false
+    }
+
+    @Test
+    fun `two concurrent checks notify exactly once`() = runTest2 {
+        // The six-hourly worker can overlap the observer. Both would read armed=true and post
+        // unless the read-decide-post-write transaction is serialized.
+        val h = harness(primary = reading(), readDelayMs = 1_000L)
+
+        launch { h.monitor.check() }
+        launch { h.monitor.check() }
+        advanceUntilIdle()
+
+        verify(exactly = 1) { h.notifications.notifyLowSpace(any(), any()) }
         h.armed.value() shouldBe false
     }
 

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
@@ -1,0 +1,310 @@
+package eu.darken.sdmse.stats.core
+
+import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.stats.core.db.SpaceSnapshotEntity
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Duration
+import java.time.LocalDate
+import java.time.ZoneOffset
+
+class LowSpaceMonitorTest : BaseTest() {
+
+    private val primaryId = "primary"
+    private val secondaryId = "secondary"
+    private val capacity = 100_000_000_000L
+
+    /** The automatic threshold for [capacity]: the smaller of 5% and 2 GiB. */
+    private val floor = LowStorage.resolveThreshold(capacity, null)
+
+    private val base = LocalDate.parse("2026-06-01")
+
+    private fun snap(storageId: String, day: Long, used: Long) = SpaceSnapshotEntity(
+        storageId = storageId,
+        recordedAt = base.plusDays(day).atStartOfDay(ZoneOffset.UTC).toInstant().plus(Duration.ofHours(12)),
+        spaceFree = capacity - used,
+        spaceCapacity = capacity,
+    )
+
+    /** Seven days of a steady 1 GB/day fill, which yields a [StorageForecast.Filling]. */
+    private fun fillingHistory(storageId: String) = (0 until 7).map {
+        snap(storageId, it.toLong(), 10_000_000_000L + 1_000_000_000L * it)
+    }
+
+    /** Stateful, so the armed latch behaves like the real DataStore across repeated checks. */
+    private fun <T> statefulValue(initial: T): DataStoreValue<T> {
+        val state = MutableStateFlow(initial)
+        return mockk<DataStoreValue<T>>().apply {
+            every { this@apply.flow } returns state
+            coEvery { update(any()) } answers {
+                val mutation = firstArg<(T) -> T?>()
+                val old = state.value
+                @Suppress("UNCHECKED_CAST")
+                val new = mutation(old) as T
+                state.value = new
+                DataStoreValue.Updated(old = old, new = new)
+            }
+        }
+    }
+
+    private class Harness(
+        val monitor: LowSpaceMonitor,
+        val notifications: LowSpaceNotifications,
+        val armed: DataStoreValue<Boolean>,
+        val historyIds: MutableList<String>,
+    )
+
+    private fun reading(free: Long = floor - 1) = SpaceTracker.StorageSnapshot(
+        storageId = primaryId,
+        spaceFree = free,
+        spaceCapacity = capacity,
+    )
+
+    private fun harness(
+        enabled: Boolean = true,
+        isPro: Boolean = true,
+        armed: Boolean = true,
+        primary: SpaceTracker.StorageSnapshot? = SpaceTracker.StorageSnapshot(
+            storageId = primaryId,
+            spaceFree = floor + 2_500_000_000L,
+            spaceCapacity = capacity,
+        ),
+        history: Map<String, List<SpaceSnapshotEntity>> = mapOf(
+            primaryId to fillingHistory(primaryId),
+            secondaryId to fillingHistory(secondaryId),
+        ),
+        postResult: LowSpaceNotifications.PostResult = LowSpaceNotifications.PostResult.POSTED,
+    ): Harness {
+        val armedValue = statefulValue(armed)
+        val settings = mockk<AnalyzerSettings>().apply {
+            every { lowSpaceNotificationEnabled } returns statefulValue(enabled)
+            every { lowSpaceNotificationArmed } returns armedValue
+            every { lowStorageThresholdBytes } returns statefulValue<Long?>(null)
+        }
+        val spaceTracker = mockk<SpaceTracker>().apply {
+            coEvery { readPrimaryStorage() } returns primary
+        }
+        val historyIds = mutableListOf<String>()
+        val spaceHistoryRepo = mockk<SpaceHistoryRepo>().apply {
+            every { getHistory(any(), any()) } answers {
+                val id = firstArg<String>()
+                historyIds += id
+                flowOf(history[id].orEmpty())
+            }
+        }
+        val info = mockk<UpgradeRepo.Info>().apply {
+            every { this@apply.isPro } returns isPro
+            every { isSettled } returns true
+            every { error } returns null
+        }
+        val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
+            // A StateFlow (which never completes) so a non-Pro isProSettled() takes its documented
+            // timeout path instead of throwing on an exhausted flow.
+            every { upgradeInfo } returns MutableStateFlow(info)
+        }
+        val notifications = mockk<LowSpaceNotifications>(relaxed = true).apply {
+            every { notifyLowSpace(any(), any()) } returns postResult
+        }
+
+        return Harness(
+            monitor = LowSpaceMonitor(
+                spaceTracker = spaceTracker,
+                spaceHistoryRepo = spaceHistoryRepo,
+                analyzerSettings = settings,
+                upgradeRepo = upgradeRepo,
+                notifications = notifications,
+            ),
+            notifications = notifications,
+            armed = armedValue,
+            historyIds = historyIds,
+        )
+    }
+
+    // ─────────────────────────── the predictive branch ───────────────────────────
+
+    @Test
+    fun `an urgent Filling forecast notifies with that forecast`() = runTest2 {
+        // Regression guard: BelowFloor is returned the moment free space reaches the threshold, so
+        // a trigger on "is low" would make the predictive copy unreachable.
+        val h = harness()
+
+        h.monitor.check()
+
+        val forecast = slot<StorageForecast>()
+        val free = slot<Long>()
+        verify(exactly = 1) { h.notifications.notifyLowSpace(capture(forecast), capture(free)) }
+        val filling = forecast.captured as StorageForecast.Filling
+        filling.isUrgent shouldBe true
+        filling.daysUntilFloor shouldBe 3L
+        free.captured shouldBe floor + 2_500_000_000L
+    }
+
+    @Test
+    fun `history is read for the primary storage only`() = runTest2 {
+        // StorageTrendCalculator needs single-volume snapshots; a merged list yields a
+        // meaningless rate.
+        val h = harness()
+
+        h.monitor.check()
+
+        h.historyIds shouldBe listOf(primaryId)
+    }
+
+    // ─────────────────────────── the latch ───────────────────────────
+
+    @Test
+    fun `a persistently low volume notifies exactly once`() = runTest2 {
+        val h = harness(primary = reading())
+
+        h.monitor.check()
+        h.monitor.check()
+        h.monitor.check()
+
+        verify(exactly = 1) { h.notifications.notifyLowSpace(StorageForecast.BelowFloor, floor - 1) }
+        h.armed.value() shouldBe false
+    }
+
+    @Test
+    fun `a blocked post leaves the latch armed`() = runTest2 {
+        val h = harness(
+            primary = reading(),
+            postResult = LowSpaceNotifications.PostResult.BLOCKED,
+        )
+
+        h.monitor.check()
+        h.armed.value() shouldBe true
+
+        // Still armed, so a later run (e.g. after the user grants the permission) tries again.
+        h.monitor.check()
+        verify(exactly = 2) { h.notifications.notifyLowSpace(any(), any()) }
+    }
+
+    @Test
+    fun `a failed post leaves the latch armed`() = runTest2 {
+        val h = harness(
+            primary = reading(),
+            postResult = LowSpaceNotifications.PostResult.FAILED,
+        )
+
+        h.monitor.check()
+
+        h.armed.value() shouldBe true
+    }
+
+    @Test
+    fun `a disabled toggle cancels and re-arms`() = runTest2 {
+        val h = harness(enabled = false, armed = false, primary = reading())
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+        verify(exactly = 1) { h.notifications.cancel() }
+        h.armed.value() shouldBe true
+    }
+
+    @Test
+    fun `a non-Pro user cancels and re-arms`() = runTest2 {
+        val h = harness(isPro = false, armed = false, primary = reading())
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+        verify(exactly = 1) { h.notifications.cancel() }
+        h.armed.value() shouldBe true
+    }
+
+    @Test
+    fun `a calm forecast cancels and re-arms`() = runTest2 {
+        val h = harness(
+            armed = false,
+            // Far above the floor, so the 1 GB/day trend is not urgent.
+            primary = reading(free = 60_000_000_000L),
+        )
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+        verify(exactly = 1) { h.notifications.cancel() }
+        h.armed.value() shouldBe true
+    }
+
+    // ─────────────────────────── implausible readings ───────────────────────────
+
+    @Test
+    fun `a zero-capacity reading is rejected`() = runTest2 {
+        // readPrimaryStorage() can return a non-null 0/0, which would otherwise post "0 B free".
+        val h = harness(
+            primary = SpaceTracker.StorageSnapshot(storageId = primaryId, spaceFree = 0L, spaceCapacity = 0L),
+        )
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+        verify(exactly = 0) { h.notifications.cancel() }
+    }
+
+    @Test
+    fun `a negative free value is rejected`() = runTest2 {
+        val h = harness(primary = reading(free = -1L))
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+    }
+
+    @Test
+    fun `free space larger than capacity is rejected`() = runTest2 {
+        val h = harness(primary = reading(free = capacity + 1))
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+    }
+
+    @Test
+    fun `a missing reading is rejected`() = runTest2 {
+        val h = harness(primary = null)
+
+        h.monitor.check()
+
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+    }
+
+    // ─────────────────────────── resilience ───────────────────────────
+
+    @Test
+    fun `check swallows failures so the worker keeps going`() = runTest2 {
+        val settings = mockk<AnalyzerSettings>().apply {
+            every { lowSpaceNotificationEnabled } returns statefulValue(true)
+            every { lowSpaceNotificationArmed } returns statefulValue(true)
+            every { lowStorageThresholdBytes } returns statefulValue<Long?>(null)
+        }
+        val notifications = mockk<LowSpaceNotifications>(relaxed = true)
+        val monitor = LowSpaceMonitor(
+            spaceTracker = mockk<SpaceTracker>().apply {
+                coEvery { readPrimaryStorage() } throws IllegalStateException("boom")
+            },
+            spaceHistoryRepo = mockk(relaxed = true),
+            analyzerSettings = settings,
+            upgradeRepo = mockk(relaxed = true),
+            notifications = notifications,
+        )
+
+        monitor.check()
+
+        verify(exactly = 0) { notifications.notifyLowSpace(any(), any()) }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceMonitorTest.kt
@@ -12,10 +12,14 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -68,7 +72,14 @@ class LowSpaceMonitorTest : BaseTest() {
         val notifications: LowSpaceNotifications,
         val armed: DataStoreValue<Boolean>,
         val historyIds: MutableList<String>,
+        val upgradeInfo: MutableStateFlow<UpgradeRepo.Info>,
     )
+
+    private fun upgradeInfo(isPro: Boolean, isSettled: Boolean) = mockk<UpgradeRepo.Info>().apply {
+        every { this@apply.isPro } returns isPro
+        every { this@apply.isSettled } returns isSettled
+        every { error } returns null
+    }
 
     private fun reading(free: Long = floor - 1) = SpaceTracker.StorageSnapshot(
         storageId = primaryId,
@@ -79,6 +90,7 @@ class LowSpaceMonitorTest : BaseTest() {
     private fun harness(
         enabled: Boolean = true,
         isPro: Boolean = true,
+        isSettled: Boolean = true,
         armed: Boolean = true,
         /** Virtual-time suspension inside the reading, so two checks can genuinely overlap. */
         readDelayMs: Long = 0L,
@@ -113,15 +125,11 @@ class LowSpaceMonitorTest : BaseTest() {
                 flowOf(history[id].orEmpty())
             }
         }
-        val info = mockk<UpgradeRepo.Info>().apply {
-            every { this@apply.isPro } returns isPro
-            every { isSettled } returns true
-            every { error } returns null
-        }
+        // A StateFlow (which never completes) so a non-Pro isProSettled() takes its documented
+        // timeout path instead of throwing on an exhausted flow.
+        val infoFlow = MutableStateFlow(upgradeInfo(isPro = isPro, isSettled = isSettled))
         val upgradeRepo = mockk<UpgradeRepo>(relaxed = true).apply {
-            // A StateFlow (which never completes) so a non-Pro isProSettled() takes its documented
-            // timeout path instead of throwing on an exhausted flow.
-            every { upgradeInfo } returns MutableStateFlow(info)
+            every { upgradeInfo } returns infoFlow
         }
         val notifications = mockk<LowSpaceNotifications>(relaxed = true).apply {
             every { notifyLowSpace(any(), any()) } returns postResult
@@ -138,6 +146,7 @@ class LowSpaceMonitorTest : BaseTest() {
             notifications = notifications,
             armed = armedValue,
             historyIds = historyIds,
+            upgradeInfo = infoFlow,
         )
     }
 
@@ -261,6 +270,46 @@ class LowSpaceMonitorTest : BaseTest() {
         verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
         verify(exactly = 1) { h.notifications.cancel() }
         h.armed.value() shouldBe true
+    }
+
+    // ─────────────────────────── the observer ───────────────────────────
+
+    @Test
+    fun `an unsettled entitlement is not treated as non-Pro, and acts once it settles`() = runTest2 {
+        // The GPlay pre-billing seed reports non-Pro even for paying users, so cancelling on it
+        // would re-arm and re-notify on every process start.
+        val h = harness(primary = reading(), isPro = false, isSettled = false)
+        val scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+
+        h.monitor.start(scope)
+        advanceUntilIdle()
+
+        verify(exactly = 0) { h.notifications.cancel() }
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+
+        h.upgradeInfo.value = upgradeInfo(isPro = true, isSettled = true)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { h.notifications.notifyLowSpace(any(), any()) }
+
+        scope.cancel()
+    }
+
+    @Test
+    fun `a disabled toggle cancels even while the entitlement is unsettled`() = runTest2 {
+        // A warning surviving from a previous process has to go now, not once billing settles -
+        // the process may exit before that ever happens.
+        val h = harness(enabled = false, armed = false, isPro = false, isSettled = false)
+        val scope = CoroutineScope(SupervisorJob() + StandardTestDispatcher(testScheduler))
+
+        h.monitor.start(scope)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { h.notifications.cancel() }
+        verify(exactly = 0) { h.notifications.notifyLowSpace(any(), any()) }
+        h.armed.value() shouldBe true
+
+        scope.cancel()
     }
 
     // ─────────────────────────── implausible readings ───────────────────────────

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceNotificationsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceNotificationsTest.kt
@@ -1,0 +1,94 @@
+package eu.darken.sdmse.stats.core
+
+import android.Manifest
+import android.app.Application
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.main.ui.MainActivity
+import eu.darken.sdmse.stats.core.forecast.StorageForecast
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class LowSpaceNotificationsTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val notificationManager: NotificationManager
+        get() = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    private fun notifications(granted: Boolean = true): LowSpaceNotifications {
+        val app = Shadows.shadowOf(ApplicationProvider.getApplicationContext<Application>())
+        if (granted) {
+            app.grantPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            app.denyPermissions(Manifest.permission.POST_NOTIFICATIONS)
+        }
+        return LowSpaceNotifications(context = context, notificationManager = notificationManager)
+    }
+
+    private fun lastPosted(): Notification = Shadows
+        .shadowOf(notificationManager)
+        .getNotification(LowSpaceNotifications.NOTIFICATION_ID)
+
+    @Test
+    fun `the content intent does not collapse into the task manager PendingIntents`() {
+        // filterEquals ignores extras, and TaskWorkerNotifications / TaskResultNotifications both
+        // hold request code 0 against this bare intent. Sharing the shape would let
+        // FLAG_UPDATE_CURRENT rewrite THEIR extras and send their taps to the Analyzer.
+        val taskManagerIntent = Intent(context, MainActivity::class.java)
+
+        lowSpaceContentIntent(context).filterEquals(taskManagerIntent) shouldBe false
+        LowSpaceNotifications.REQUEST_CODE shouldBe 3000
+    }
+
+    @Test
+    fun `the content intent routes to the Analyzer`() {
+        val intent = lowSpaceContentIntent(context)
+
+        intent.component?.className shouldBe MainActivity::class.java.name
+        intent.action shouldBe LowSpaceNotifications.ACTION_LOW_SPACE
+    }
+
+    @Test
+    fun `the predictive body renders the day count`() {
+        notifications().notifyLowSpace(
+            forecast = StorageForecast.Filling(daysUntilFloor = 3, bytesPerDay = 1_000_000_000L, isUrgent = true),
+            freeBytes = 3_000_000_000L,
+        ) shouldBe LowSpaceNotifications.PostResult.POSTED
+
+        lastPosted().extras.getCharSequence(Notification.EXTRA_TEXT).toString() shouldContain "3 days"
+    }
+
+    @Test
+    fun `the below-floor body says the storage is running out`() {
+        notifications().notifyLowSpace(
+            forecast = StorageForecast.BelowFloor,
+            freeBytes = 1_000_000_000L,
+        ) shouldBe LowSpaceNotifications.PostResult.POSTED
+
+        lastPosted().extras.getCharSequence(Notification.EXTRA_TEXT).toString() shouldContain "running out"
+    }
+
+    @Test
+    fun `a missing POST_NOTIFICATIONS permission blocks instead of failing`() {
+        // API 33+ without the runtime permission must report BLOCKED so the caller keeps its latch
+        // armed for a later grant.
+        notifications(granted = false).notifyLowSpace(
+            forecast = StorageForecast.BelowFloor,
+            freeBytes = 1_000_000_000L,
+        ) shouldBe LowSpaceNotifications.PostResult.BLOCKED
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceNotificationsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/stats/core/LowSpaceNotificationsTest.kt
@@ -43,6 +43,10 @@ class LowSpaceNotificationsTest : BaseTest() {
         .shadowOf(notificationManager)
         .getNotification(LowSpaceNotifications.NOTIFICATION_ID)
 
+    private fun Notification.title(): String = extras.getCharSequence(Notification.EXTRA_TITLE).toString()
+
+    private fun Notification.body(): String = extras.getCharSequence(Notification.EXTRA_TEXT).toString()
+
     @Test
     fun `the content intent does not collapse into the task manager PendingIntents`() {
         // filterEquals ignores extras, and TaskWorkerNotifications / TaskResultNotifications both
@@ -63,23 +67,28 @@ class LowSpaceNotificationsTest : BaseTest() {
     }
 
     @Test
-    fun `the predictive body renders the day count`() {
+    fun `the predictive variant warns about filling up and renders the day count`() {
         notifications().notifyLowSpace(
             forecast = StorageForecast.Filling(daysUntilFloor = 3, bytesPerDay = 1_000_000_000L, isUrgent = true),
             freeBytes = 3_000_000_000L,
         ) shouldBe LowSpaceNotifications.PostResult.POSTED
 
-        lastPosted().extras.getCharSequence(Notification.EXTRA_TEXT).toString() shouldContain "3 days"
+        val posted = lastPosted()
+        posted.title() shouldBe "Storage is filling up"
+        posted.body() shouldContain "3 days"
     }
 
     @Test
-    fun `the below-floor body says the storage is running out`() {
+    fun `the below-floor variant warns that storage is almost full and says it is running out`() {
+        // A trend title ("filling up") over a "running out" body understates the emergency.
         notifications().notifyLowSpace(
             forecast = StorageForecast.BelowFloor,
             freeBytes = 1_000_000_000L,
         ) shouldBe LowSpaceNotifications.PostResult.POSTED
 
-        lastPosted().extras.getCharSequence(Notification.EXTRA_TEXT).toString() shouldContain "running out"
+        val posted = lastPosted()
+        posted.title() shouldBe "Storage is almost full"
+        posted.body() shouldContain "running out"
     }
 
     @Test


### PR DESCRIPTION
## What changed

SD Maid can now warn you before your device runs out of space. It is off by default, switched on in the new Storage Analyzer settings, and it is a Pro feature.

Once on, it watches the fill rate it already tracks and sends a notification when your storage is heading for the low storage threshold, saying roughly how many days you have left at the current rate. If you are already below the threshold, it says how much is left instead. Tapping it opens the storage overview. It warns once and then stays quiet, rather than repeating every few hours, and it clears itself when you free up space, when you switch it off, or if Pro lapses.

The Storage Trend screen and the storage overview now mention the warning as one of the things Pro unlocks. The hint on the storage overview can be dismissed permanently.

Stacked on #2700, which adds the settings screen and the threshold. Refs #1903.

## Technical Context

- The warning triggers on the forecast, not on a "storage is low" flag. That distinction is load-bearing: `forecast()` returns `BelowFloor` the instant free space reaches the threshold, so keying the notification off "is low" would have made the days-remaining wording unreachable and turned the whole feature into an after-the-fact alert. `LowSpaceAlertDeciderTest` and `LowSpaceMonitorTest` both guard it.
- The once-only behaviour is a stored latch, and the rules around it are the subtle part. Only a successful post clears it; a post that Android blocked (notifications disabled, channel muted, permission ungranted) leaves it armed so the warning still arrives once the user fixes that. Every cancel re-arms it, so switching the feature off and on, or losing and regaining Pro, does not leave someone silently un-warned. The latch is excluded from settings backup, since restoring it onto a new phone would otherwise suppress that phone's first warning forever.
- The six-hourly worker and the settings observer both run the same read-decide-post-write sequence, so it is serialized behind a mutex. Without it a cancel could lose to an in-flight post and strand a notification on screen after the feature was switched off.
- Entitlement is read as a nullable "unknown until settled" rather than filtered, because Google Play emits an unsettled non-Pro value at every process start. Filtering those out stalls the observer entirely; treating them as non-Pro would re-warn on every launch. Switching the toggle off cancels immediately regardless, without waiting for billing.
- The notification's content intent carries its own action and request code. `PendingIntent` identity ignores extras, and the task-manager and task-result notifications already hold request code 0 against a bare `MainActivity` intent, so sharing that shape would have hijacked their taps. There is a `filterEquals` test pinning this.
- The Storage Trend pitch uses a new string key rather than editing the existing one, which is translated into 74 locales. Editing the English source alone would have left every other locale showing the old copy.
- Verified on an emulator beyond what CI covers: the warning posts with the right text, tapping it lands on the storage overview, switching off clears it, and switching back on warns again.
