### PR TITLE
Fix: Retry root access without restarting the app

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
@@ -80,7 +81,10 @@ class RootManager @Inject constructor(
         // Not suspending and deliberately not taking cacheLock: an in-flight probe holds that lock
         // across the su bind, and a retry must neither block behind it nor discard its result. The
         // running probe stores under the old key and is simply never read again.
-        refreshTrigger.value += 1
+        // update {} and not `value += 1`: a SetupManager.refresh() racing a Retry tap can otherwise
+        // have both callers read the same generation and write the same successor, dropping one
+        // refresh — the retry would then reuse the cached answer and silently do nothing.
+        refreshTrigger.update { it + 1 }
     }
 
     /**

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
@@ -87,6 +87,9 @@ class RootManager @Inject constructor(
         refreshTrigger.update { it + 1 }
     }
 
+    /** Exists so tests can assert that concurrent refreshes do not lose increments. */
+    internal val currentGeneration: Int get() = refreshTrigger.value
+
     /**
      * Did the user consent to SD Maid using root and is root available?
      */

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
@@ -6,6 +6,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.access.AccessState
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
@@ -19,15 +20,16 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.sync.Mutex
@@ -42,7 +44,7 @@ class RootManager @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     val serviceClient: RootServiceClient,
-    settings: RootSettings,
+    private val settings: RootSettings,
 ) {
 
     val binder: Flow<RootServiceClient.Connection?> = settings.useRoot.flow
@@ -82,26 +84,20 @@ class RootManager @Inject constructor(
         .setupCommonEventHandlers(TAG) { "binder" }
         .replayingShare(appScope)
 
-    private var cachedState: Boolean? = null
+    private val refreshTrigger = MutableStateFlow(0)
+
+    /** A probe answer is only valid for the setting value and generation it was taken under. */
+    private data class ProbeKey(val useRoot: Boolean?, val generation: Int)
+
+    private var cached: Pair<ProbeKey, Boolean>? = null
     private val cacheLock = Mutex()
 
-    init {
-        settings.useRoot.flow
-            .mapLatest {
-                log(TAG) { "Root access state: $it" }
-                cacheLock.withLock {
-                    cachedState = null
-                }
-            }
-            .launchIn(appScope)
-    }
+    private val probeInput: Flow<ProbeKey> =
+        combine(settings.useRoot.flow, refreshTrigger) { setting, gen -> ProbeKey(setting, gen) }
 
-    /**
-     * Is the device rooted and we have access?
-     */
-    suspend fun isRooted(): Boolean = withContext(dispatcherProvider.IO) {
+    private suspend fun isRootedFor(key: ProbeKey): Boolean = withContext(dispatcherProvider.IO) {
         cacheLock.withLock {
-            cachedState?.let { return@withContext it }
+            cached?.takeIf { it.first == key }?.let { return@withContext it.second }
 
             val newState = try {
                 serviceClient.get().use { it.item.ipc.checkBase() != null }
@@ -112,15 +108,31 @@ class RootManager @Inject constructor(
                 false
             }
             log(TAG, INFO) { "isRooted=$newState" }
-            newState.also { cachedState = it }
+            newState.also { cached = key to it }
         }
+    }
+
+    /**
+     * Is the device rooted and we have access?
+     */
+    suspend fun isRooted(): Boolean = isRootedFor(ProbeKey(settings.useRoot.value(), refreshTrigger.value))
+
+    /** Invalidate the memoised probe and make the derived state flows re-evaluate. */
+    fun refresh() {
+        log(TAG) { "refresh()" }
+        // Not suspending and deliberately not taking cacheLock: an in-flight probe holds that lock
+        // across the su bind, and a retry must neither block behind it nor discard its result. The
+        // running probe stores under the old key and is simply never read again.
+        refreshTrigger.value += 1
     }
 
     /**
      * Did the user consent to SD Maid using root and is root available?
      */
-    val useRoot: Flow<Boolean> = settings.useRoot.flow
-        .mapLatest { (it ?: false) && isRooted() }
+    // StateFlow, so equal values are conflated: a retry that changes nothing does not ripple
+    // downstream. [accessState] does re-emit, so the setup card can show the probe running.
+    val useRoot: Flow<Boolean> = probeInput
+        .mapLatest { key -> (key.useRoot ?: false) && isRootedFor(key) }
         .setupCommonEventHandlers(TAG) { "useRoot" }
         .stateIn(
             scope = appScope,
@@ -128,7 +140,7 @@ class RootManager @Inject constructor(
                 stopTimeoutMillis = 10 * 1000,
                 replayExpirationMillis = 0,
             ),
-            initialValue = null
+            initialValue = null,
         )
         .filterNotNull()
 
@@ -137,14 +149,14 @@ class RootManager @Inject constructor(
      * "opted in but unavailable" / "opted out". Shares [isRooted]'s cache, so it does not trigger
      * an additional su bind. [AccessState.Active] is equivalent to [useRoot] being true.
      */
-    val accessState: Flow<AccessState> = settings.useRoot.flow
-        .flatMapLatest { setting ->
-            when (setting) {
+    val accessState: Flow<AccessState> = probeInput
+        .flatMapLatest { key ->
+            when (key.useRoot) {
                 null -> flowOf(AccessState.Undecided)
                 false -> flowOf(AccessState.Declined)
                 true -> flow {
                     emit(AccessState.Checking)
-                    emit(if (isRooted()) AccessState.Active else AccessState.Unavailable)
+                    emit(if (isRootedFor(key)) AccessState.Active else AccessState.Unavailable)
                 }
             }
         }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/RootManager.kt
@@ -9,7 +9,6 @@ import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
-import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.replayingShare
@@ -17,15 +16,10 @@ import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import eu.darken.sdmse.common.root.service.RootServiceClient
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
@@ -46,43 +40,6 @@ class RootManager @Inject constructor(
     val serviceClient: RootServiceClient,
     private val settings: RootSettings,
 ) {
-
-    val binder: Flow<RootServiceClient.Connection?> = settings.useRoot.flow
-        .flatMapLatest {
-            if (it != true) return@flatMapLatest emptyFlow()
-
-            callbackFlow<RootServiceClient.Connection?> {
-                log(TAG, INFO) { "binder upstream: acquiring root service connection..." }
-                val resource = try {
-                    serviceClient.get()
-                } catch (e: Exception) {
-                    log(TAG, WARN) { "binder upstream: acquisition failed: ${e.asLog()}" }
-                    throw e
-                }
-                log(TAG, INFO) { "binder upstream: acquired connection: ${resource.item}" }
-
-                try {
-                    send(resource.item)
-                } catch (e: Throwable) {
-                    // send() can throw on collector cancellation before awaitClose is registered.
-                    // Release the lease deterministically so we don't leak it.
-                    log(TAG, WARN) { "binder upstream: send() failed, releasing lease: ${e.asLog()}" }
-                    withContext(NonCancellable) { resource.close() }
-                    throw e
-                }
-
-                awaitClose {
-                    log(TAG) { "Closing binder resource" }
-                    resource.close()
-                }
-            }
-        }
-        .catch {
-            log(TAG, WARN) { "RootServiceClient.Connection was unavailable: ${it.asLog()}" }
-            emit(null)
-        }
-        .setupCommonEventHandlers(TAG) { "binder" }
-        .replayingShare(appScope)
 
     private val refreshTrigger = MutableStateFlow(0)
 

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClient.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/root/service/RootServiceClient.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.plus
+import java.time.Duration
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -51,6 +52,7 @@ class RootServiceClient @Inject constructor(
     // slow host-disconnect IPC during teardown would otherwise starve Dispatchers.Default — the same
     // pool the UI's vmScope uses — wedging the dashboard. Mirrors ShellOps/PkgOps.
     parentScope = coroutineScope + dispatcherProvider.IO,
+    stopTimeout = ROOT_HOST_KEEPALIVE,
     verboseLifecycle = true,
     source = callbackFlow {
         log(TAG) { "Instantiating Root launcher..." }
@@ -118,6 +120,14 @@ class RootServiceClient @Inject constructor(
     )
 
     companion object {
+
+        // Keep the su host bound briefly after the last lease is released so back-to-back privileged
+        // operations and dashboard-to-tool navigation reuse the warm host instead of paying the su
+        // cold start again. Bounded on purpose: a root host should not linger in the background for
+        // long. Teardown still happens (and is prompt/safe); this only delays its start. It also
+        // replaces the incidental warm window that the removed RootManager.binder lease used to
+        // provide for as long as the dashboard was subscribed.
+        private val ROOT_HOST_KEEPALIVE: Duration = Duration.ofSeconds(30)
 
         fun RootHostLauncher.createHostConnection(
             /**

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/root/RootManagerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/root/RootManagerTest.kt
@@ -17,7 +17,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -146,6 +145,34 @@ class RootManagerTest : BaseTest() {
         appScope.cancel()
     }
 
+    @Test fun `two concurrent refreshes each advance the generation`() = runTest2 {
+        // A SetupManager.refresh() and a Retry tap can land on the manager at the same moment. If the
+        // generation counter lost one of the two increments, the second caller would be served the
+        // first caller's cached answer and its retry would silently do nothing.
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val appScope = CoroutineScope(SupervisorJob() + testDispatcher)
+        val mgr = manager(appScope, testDispatcher)
+
+        val barrier = CompletableDeferred<Unit>()
+        val refreshers = (1..2).map {
+            appScope.async {
+                barrier.await()
+                mgr.refresh()
+                mgr.isRooted()
+            }
+        }
+        runCurrent()
+        probeCount shouldBe 0
+
+        barrier.complete(Unit)
+        refreshers.forEach { it.await() shouldBe true }
+
+        // Two generations, so the second probe could not be answered from the first one's cache entry.
+        probeCount shouldBe 2
+
+        appScope.cancel()
+    }
+
     @Test fun `a probe that throws is cached as not-rooted and re-runs after refresh`() {
         failingProbe()
         val mgr = manager()
@@ -178,6 +205,39 @@ class RootManagerTest : BaseTest() {
         runBlocking { collector.cancelAndJoin() }
     }
 
+    @Test fun `accessState walks from Unavailable to Active when a retry is granted`() {
+        // The journey this branch exists for: the root manager denied (or timed out) the first
+        // request, the user grants it and taps Retry. No test device is rooted, so this stands in
+        // for the on-device check.
+        failingProbe()
+        val mgr = manager()
+
+        val collector = mgr.accessState.test(tag = "accessState", scope = scope)
+        collector.await { values, _ -> values.contains(AccessState.Unavailable) }
+        collector.latestValues shouldBe listOf(
+            AccessState.Checking,
+            AccessState.Unavailable,
+        )
+
+        // Root works now, the user answered the manager's prompt on the second attempt.
+        coEvery { serviceClient.get() } answers {
+            probeCount++
+            Resource(connection, mockk(relaxed = true))
+        }
+        mgr.refresh()
+        collector.await { values, _ -> values.contains(AccessState.Active) }
+
+        collector.latestValues shouldBe listOf(
+            AccessState.Checking,
+            AccessState.Unavailable,
+            AccessState.Checking,
+            AccessState.Active,
+        )
+        probeCount shouldBe 2
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
     @Test fun `refresh makes useRoot re-emit when the probe outcome changes`() {
         failingProbe()
         val mgr = manager()
@@ -204,15 +264,20 @@ class RootManagerTest : BaseTest() {
         val mgr = manager()
 
         val collector = mgr.useRoot.test(tag = "useRoot", scope = scope)
+        // accessState shares the probe input and re-emits unconditionally, so its second Active is
+        // the signal that the retry's probe finished — no wall-clock wait to prove useRoot stayed quiet.
+        val access = mgr.accessState.test(tag = "accessState", scope = scope)
         collector.await { values, _ -> values.isNotEmpty() }
+        access.await { values, _ -> values.contains(AccessState.Active) }
 
         mgr.refresh()
-        runBlocking { delay(50) }
+        access.await { values, _ -> values.count { it == AccessState.Active } == 2 }
 
         collector.latestValues shouldBe listOf(true)
         probeCount shouldBe 2
 
         runBlocking { collector.cancelAndJoin() }
+        runBlocking { access.cancelAndJoin() }
     }
 
     @Test fun `resubscribing after the last subscriber left re-runs upstream instead of replaying`() {
@@ -221,10 +286,14 @@ class RootManagerTest : BaseTest() {
         val first = mgr.accessState.test(tag = "first", scope = scope)
         first.await { values, _ -> values.contains(AccessState.Active) }
         runBlocking { first.cancelAndJoin() }
-        runBlocking { delay(50) }
 
+        // No wall-clock wait for the share to wind down: WhileSubscribed(replayExpiration=ZERO) drops
+        // the replay cache as the last subscriber leaves, so the await below is what waits — for the
+        // re-run's own Checking+Active rather than for a stopwatch.
         val second = mgr.accessState.test(tag = "second", scope = scope)
-        second.await { values, _ -> values.contains(AccessState.Active) }
+        second.await { values, _ ->
+            values == listOf(AccessState.Checking, AccessState.Active)
+        }
 
         // Not a replayed Active: the upstream ran again, starting at Checking.
         second.latestValues shouldBe listOf(AccessState.Checking, AccessState.Active)

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/root/RootManagerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/root/RootManagerTest.kt
@@ -18,6 +18,8 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runCurrent
@@ -145,32 +147,19 @@ class RootManagerTest : BaseTest() {
         appScope.cancel()
     }
 
-    @Test fun `two concurrent refreshes each advance the generation`() = runTest2 {
+    @Test fun `concurrent refreshes never lose a generation`() {
         // A SetupManager.refresh() and a Retry tap can land on the manager at the same moment. If the
-        // generation counter lost one of the two increments, the second caller would be served the
-        // first caller's cached answer and its retry would silently do nothing.
-        val testDispatcher = StandardTestDispatcher(testScheduler)
-        val appScope = CoroutineScope(SupervisorJob() + testDispatcher)
-        val mgr = manager(appScope, testDispatcher)
+        // generation counter lost an increment, the second caller would be served the first caller's
+        // cached answer and its retry would silently do nothing. This needs real parallelism: refresh()
+        // does not suspend, so a single-threaded test dispatcher can never interleave its
+        // read-modify-write and would pass even against a racy `value += 1`.
+        val mgr = manager()
 
-        val barrier = CompletableDeferred<Unit>()
-        val refreshers = (1..2).map {
-            appScope.async {
-                barrier.await()
-                mgr.refresh()
-                mgr.isRooted()
-            }
+        runBlocking(Dispatchers.Default) {
+            (1..1000).map { launch { mgr.refresh() } }.joinAll()
         }
-        runCurrent()
-        probeCount shouldBe 0
 
-        barrier.complete(Unit)
-        refreshers.forEach { it.await() shouldBe true }
-
-        // Two generations, so the second probe could not be answered from the first one's cache entry.
-        probeCount shouldBe 2
-
-        appScope.cancel()
+        mgr.currentGeneration shouldBe 1000
     }
 
     @Test fun `a probe that throws is cached as not-rooted and re-runs after refresh`() {

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/root/RootManagerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/root/RootManagerTest.kt
@@ -1,0 +1,257 @@
+package eu.darken.sdmse.common.root
+
+import android.content.Context
+import eu.darken.sdmse.common.access.AccessState
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.root.service.RootServiceClient
+import eu.darken.sdmse.common.root.service.RootServiceConnection
+import eu.darken.sdmse.common.sharedresource.Resource
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import testhelpers.flow.test
+
+class RootManagerTest : BaseTest() {
+
+    private val context: Context = mockk(relaxed = true)
+    private val serviceClient: RootServiceClient = mockk()
+    private val settings: RootSettings = mockk()
+
+    private val useRootValue: DataStoreValue<Boolean?> = mockk()
+    private lateinit var useRootFlow: MutableStateFlow<Boolean?>
+    private val connection: RootServiceClient.Connection = mockk()
+    private val ipc: RootServiceConnection = mockk()
+    private lateinit var scope: CoroutineScope
+
+    /** How often the su host was actually asked for a connection. */
+    private var probeCount = 0
+
+    @BeforeEach
+    fun setup() {
+        probeCount = 0
+        useRootFlow = MutableStateFlow(true)
+        scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
+
+        every { settings.useRoot } returns useRootValue
+        every { useRootValue.flow } returns useRootFlow
+
+        every { connection.ipc } returns ipc
+        every { ipc.checkBase() } returns "ok"
+        coEvery { serviceClient.get() } answers {
+            probeCount++
+            Resource(connection, mockk(relaxed = true))
+        }
+    }
+
+    @AfterEach
+    fun teardown() {
+        scope.cancel()
+    }
+
+    private fun manager(
+        appScope: CoroutineScope = scope,
+        dispatcher: CoroutineDispatcher? = null,
+    ) = RootManager(
+        context = context,
+        appScope = appScope,
+        dispatcherProvider = TestDispatcherProvider(dispatcher),
+        serviceClient = serviceClient,
+        settings = settings,
+    )
+
+    private fun failingProbe() {
+        coEvery { serviceClient.get() } answers {
+            probeCount++
+            throw RootUnavailableException("Root denied")
+        }
+    }
+
+    @Test fun `isRooted memoises the probe for one setting and generation`() {
+        val mgr = manager()
+
+        runBlocking { mgr.isRooted() } shouldBe true
+        runBlocking { mgr.isRooted() } shouldBe true
+
+        probeCount shouldBe 1
+    }
+
+    @Test fun `refresh invalidates the memoised probe`() {
+        val mgr = manager()
+
+        runBlocking { mgr.isRooted() } shouldBe true
+        mgr.refresh()
+        runBlocking { mgr.isRooted() } shouldBe true
+
+        probeCount shouldBe 2
+    }
+
+    @Test fun `a setting change invalidates the memoised probe`() {
+        // The setting is part of the cache key, so no invalidation collector is needed.
+        val mgr = manager()
+
+        runBlocking { mgr.isRooted() } shouldBe true
+        useRootFlow.value = false
+        runBlocking { mgr.isRooted() } shouldBe true
+
+        probeCount shouldBe 2
+    }
+
+    @Test fun `refresh does not block behind an in-flight probe and does not discard it`() = runTest2 {
+        val gate = CompletableDeferred<Unit>()
+        coEvery { serviceClient.get() } coAnswers {
+            probeCount++
+            gate.await()
+            Resource(connection, mockk(relaxed = true))
+        }
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val appScope = CoroutineScope(SupervisorJob() + testDispatcher)
+        val mgr = manager(appScope, testDispatcher)
+
+        val inFlight = appScope.async { mgr.isRooted() }
+        runCurrent()
+        probeCount shouldBe 1
+
+        // The running probe holds the cache lock across the su bind: refresh must return anyway.
+        mgr.refresh()
+
+        // ... and the probe it did not wait for must still deliver its own result.
+        inFlight.isActive shouldBe true
+        gate.complete(Unit)
+        inFlight.await() shouldBe true
+        probeCount shouldBe 1
+
+        // The refresh is not lost either: the next probe runs under the new generation.
+        mgr.isRooted() shouldBe true
+        probeCount shouldBe 2
+
+        appScope.cancel()
+    }
+
+    @Test fun `a probe that throws is cached as not-rooted and re-runs after refresh`() {
+        failingProbe()
+        val mgr = manager()
+
+        runBlocking { mgr.isRooted() } shouldBe false
+        runBlocking { mgr.isRooted() } shouldBe false
+        probeCount shouldBe 1
+
+        mgr.refresh()
+        runBlocking { mgr.isRooted() } shouldBe false
+        probeCount shouldBe 2
+    }
+
+    @Test fun `refresh makes accessState re-emit Checking then Active`() {
+        val mgr = manager()
+
+        val collector = mgr.accessState.test(tag = "accessState", scope = scope)
+        collector.await { values, _ -> values.contains(AccessState.Active) }
+
+        mgr.refresh()
+        collector.await { values, _ -> values.count { it == AccessState.Active } == 2 }
+
+        collector.latestValues shouldBe listOf(
+            AccessState.Checking,
+            AccessState.Active,
+            AccessState.Checking,
+            AccessState.Active,
+        )
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `refresh makes useRoot re-emit when the probe outcome changes`() {
+        failingProbe()
+        val mgr = manager()
+
+        val collector = mgr.useRoot.test(tag = "useRoot", scope = scope)
+        collector.await { values, _ -> values.isNotEmpty() }
+        collector.latestValues shouldBe listOf(false)
+
+        // Root works now (e.g. the user answered the manager's prompt on the second attempt).
+        coEvery { serviceClient.get() } answers {
+            probeCount++
+            Resource(connection, mockk(relaxed = true))
+        }
+        mgr.refresh()
+        collector.await { values, _ -> values.contains(true) }
+
+        collector.latestValues shouldBe listOf(false, true)
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `a retry that changes nothing does not re-emit useRoot`() {
+        // useRoot is a StateFlow, so an unchanged outcome is conflated and nothing ripples downstream.
+        val mgr = manager()
+
+        val collector = mgr.useRoot.test(tag = "useRoot", scope = scope)
+        collector.await { values, _ -> values.isNotEmpty() }
+
+        mgr.refresh()
+        runBlocking { delay(50) }
+
+        collector.latestValues shouldBe listOf(true)
+        probeCount shouldBe 2
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `resubscribing after the last subscriber left re-runs upstream instead of replaying`() {
+        val mgr = manager()
+
+        val first = mgr.accessState.test(tag = "first", scope = scope)
+        first.await { values, _ -> values.contains(AccessState.Active) }
+        runBlocking { first.cancelAndJoin() }
+        runBlocking { delay(50) }
+
+        val second = mgr.accessState.test(tag = "second", scope = scope)
+        second.await { values, _ -> values.contains(AccessState.Active) }
+
+        // Not a replayed Active: the upstream ran again, starting at Checking.
+        second.latestValues shouldBe listOf(AccessState.Checking, AccessState.Active)
+        // The memoised answer is still valid though, so no second su bind.
+        probeCount shouldBe 1
+
+        runBlocking { second.cancelAndJoin() }
+    }
+
+    @Test fun `repeated refreshes do not multiply probes beyond one per generation`() {
+        val mgr = manager()
+
+        val access = mgr.accessState.test(tag = "accessState", scope = scope)
+        val useRoot = mgr.useRoot.test(tag = "useRoot", scope = scope)
+        access.await { values, _ -> values.contains(AccessState.Active) }
+        useRoot.await { values, _ -> values.isNotEmpty() }
+        probeCount shouldBe 1
+
+        mgr.refresh()
+        access.await { values, _ -> values.count { it == AccessState.Active } == 2 }
+        probeCount shouldBe 2
+
+        mgr.refresh()
+        access.await { values, _ -> values.count { it == AccessState.Active } == 3 }
+        probeCount shouldBe 3
+
+        runBlocking { access.cancelAndJoin() }
+        runBlocking { useRoot.cancelAndJoin() }
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -171,6 +171,7 @@ class SetupViewModel @Inject constructor(
                                 onHelp = {
                                     webpageTool.open("https://github.com/d4rken-org/sdmaid-se/wiki/Setup#root-access")
                                 },
+                                onRetry = { launch { rootSetupModule.refresh() } },
                             )
 
                             is SetupModule.State.Loading -> SetupLoadingCardItem(state)

--- a/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupCard.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.AdminPanelSettings
+import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
@@ -25,11 +26,13 @@ import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.setup.SetupCardContainer
 import eu.darken.sdmse.setup.SetupCardItem
 import eu.darken.sdmse.setup.SetupLimitationBox
+import eu.darken.sdmse.common.R as CommonR
 
 data class RootSetupCardItem(
     override val state: RootSetupModule.Result,
     val onToggleUseRoot: (Boolean?) -> Unit,
     val onHelp: () -> Unit,
+    val onRetry: () -> Unit,
 ) : SetupCardItem
 
 @Composable
@@ -52,10 +55,13 @@ internal fun RootSetupCard(
         )
         if (item.state.useRoot == true) {
             val ready = item.state.ourService
-            // A known root manager is installed but our service never came up: SD Maid asked for root
-            // and didn't get it, which is worth explaining. Without a root manager (isInstalled == false)
-            // there is nothing the user can act on here, so that case keeps the plain one-liner.
-            val failed = item.state.isInstalled && !item.state.ourService
+            // SD Maid asked for root and didn't get it, which is worth explaining and retrying.
+            // Whether a known root manager is installed only picks the wording: hidden or built-in
+            // root shows up as no manager at all.
+            // Result.isComplete deliberately stays as it is: treating "opted into root that does not
+            // work" as incomplete would strand every user who picks "Try to use root access" on an
+            // ordinary unrooted phone, so this box can render on a module that reports itself complete.
+            val failed = item.state.useRoot == true && !item.state.ourService
 
             if (!failed) {
                 // The probe has settled by the time we render a Result (Loading shows a spinner card
@@ -81,12 +87,25 @@ internal fun RootSetupCard(
                 )
             } else {
                 // Start aligned, multi-line explanation instead of the centred one-liner, matching how
-                // the Shizuku card presents its settled failure. No actions: retrying is the root
-                // manager's job, and the card header already carries the help icon.
+                // the Shizuku card presents its settled failure. No help button of its own: the card
+                // header already carries a help icon pointing at the same wiki page.
                 SetupLimitationBox(
                     title = stringResource(R.string.setup_root_state_failed_title),
-                    body = stringResource(R.string.setup_root_state_failed_body),
-                )
+                    body = stringResource(
+                        if (item.state.isInstalled) R.string.setup_root_state_failed_body
+                        else R.string.setup_root_state_failed_body_nomanager,
+                    ),
+                ) {
+                    // No enabled guard: a refresh drives accessState to Checking, the module maps
+                    // that to Loading, and the whole card is replaced by a loading card while the
+                    // probe runs.
+                    Button(
+                        onClick = item.onRetry,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text(stringResource(CommonR.string.general_retry_action))
+                    }
+                }
             }
         }
         Column(
@@ -158,6 +177,7 @@ private fun RootSetupCardPreview() {
                 ),
                 onToggleUseRoot = {},
                 onHelp = {},
+                onRetry = {},
             ),
         )
     }
@@ -176,6 +196,26 @@ private fun RootSetupCardFailedPreview() {
                 ),
                 onToggleUseRoot = {},
                 onHelp = {},
+                onRetry = {},
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun RootSetupCardFailedNoManagerPreview() {
+    PreviewWrapper {
+        RootSetupCard(
+            item = RootSetupCardItem(
+                state = RootSetupModule.Result(
+                    useRoot = true,
+                    isInstalled = false,
+                    ourService = false,
+                ),
+                onToggleUseRoot = {},
+                onHelp = {},
+                onRetry = {},
             ),
         )
     }

--- a/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupCard.kt
@@ -54,7 +54,6 @@ internal fun RootSetupCard(
                 .padding(horizontal = 16.dp),
         )
         if (item.state.useRoot == true) {
-            val ready = item.state.ourService
             // SD Maid asked for root and didn't get it, which is worth explaining and retrying.
             // Whether a known root manager is installed only picks the wording: hidden or built-in
             // root shows up as no manager at all.
@@ -64,22 +63,13 @@ internal fun RootSetupCard(
             val failed = item.state.useRoot == true && !item.state.ourService
 
             if (!failed) {
-                // The probe has settled by the time we render a Result (Loading shows a spinner card
-                // instead), so ourService == false is a definitive "not available" — not "waiting".
-                // We never claim the device isn't rooted: root detection is unreliable, so we only
-                // report our own probe outcome.
-                val stateText = stringResource(
-                    if (ready) R.string.setup_root_state_ready_label
-                    else R.string.setup_root_state_waiting_label,
-                )
+                // Reaching this branch means ourService is true, so root is ready. The probe has
+                // settled by the time we render a Result (Loading shows a spinner card instead),
+                // so there is no third "still waiting" state to report here.
                 Text(
-                    text = stateText,
+                    text = stringResource(R.string.setup_root_state_ready_label),
                     style = MaterialTheme.typography.labelMedium,
-                    color = if (ready) {
-                        MaterialTheme.colorScheme.onSurfaceVariant
-                    } else {
-                        MaterialTheme.colorScheme.error
-                    },
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 16.dp),

--- a/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/root/RootSetupModule.kt
@@ -5,30 +5,21 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import eu.darken.sdmse.common.access.AccessState
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.replayingShare
-import eu.darken.sdmse.common.rngString
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.RootSettings
 import eu.darken.sdmse.setup.SetupModule
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.take
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -41,47 +32,40 @@ class RootSetupModule @Inject constructor(
     private val dataAreaManager: DataAreaManager,
 ) : SetupModule {
 
-    private val refreshTrigger = MutableStateFlow(rngString)
-
     // Last known concrete Result, kept so re-subscription (e.g. returning to the dashboard) can emit it
     // immediately instead of regressing to Loading and flickering the setup card while the availability
     // probe re-runs (acquiring the root host can cold-bind a su session). Only ever holds a real Result.
     @Volatile
     private var lastResult: Result? = null
 
-    override val state: Flow<SetupModule.State> = combine(refreshTrigger, rootSettings.useRoot.flow) { _, useRoot ->
-        val baseState = Result(
-            useRoot = useRoot,
-            isInstalled = rootManager.isInstalled(),
-        )
+    // Dedicated transition memory. Deliberately NOT lastResult, which gets cleared on
+    // toggle/refresh for the replay logic; clearing it would suppress the very transition
+    // this needs to see.
+    @Volatile
+    private var lastActive: Boolean? = null
 
-        if (useRoot != true) return@combine flowOf(baseState)
-
-        rootManager.binder
-            .map { connection ->
-                if (connection == null) return@map baseState
-
-                @Suppress("USELESS_CAST")
-                baseState.copy(
-                    ourService = try {
-                        connection.ipc.checkBase() != null
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        log(TAG, WARN) { "Error while checking for root: $e" }
-                        false
-                    },
-                ) as SetupModule.State
+    override val state: Flow<SetupModule.State> = rootManager.accessState
+        .map { access ->
+            if (access is AccessState.Checking) {
+                Loading()
+            } else {
+                Result(
+                    useRoot = access.toUseRoot(),
+                    isInstalled = rootManager.isInstalled(),
+                    ourService = access is AccessState.Active,
+                )
             }
-            // Stay in Loading while the availability probe cold-binds the su session, instead of emitting
-            // a settled incomplete Result. A synthetic null here used to map to baseState (ourService=false),
-            // briefly flagging setup as incomplete and flashing the dashboard setup card on every launch.
-            // A genuine acquisition failure still surfaces: binder emits null via its catch block (real
-            // failure), which is mapped to baseState above.
-            .onStart { emit(Loading()) }
-    }
-        .flatMapLatest { it }
-        .onEach { if (it is Result) lastResult = it }
+        }
+        .onEach { state ->
+            if (state !is Result) return@onEach
+            lastResult = state
+            val isActive = state.useRoot == true && state.ourService
+            val was = lastActive
+            lastActive = isActive
+            // Root changes which storage areas are detectable. Reload only on a real change, and
+            // never on the first observation, where nothing has changed yet.
+            if (was != null && was != isActive) dataAreaManager.reload()
+        }
         .onStart {
             // Don't regress to Loading if we already know the result: emit the last known state so the
             // dashboard setup card doesn't flicker while the probe re-runs. Guard against a useRoot
@@ -98,25 +82,24 @@ class RootSetupModule @Inject constructor(
 
     override suspend fun refresh() {
         log(TAG) { "refresh()" }
-        refreshTrigger.value = rngString
+        // Signal only: SetupManager.refresh() runs the modules sequentially, so awaiting a root
+        // connect here would stall every module behind us.
+        lastResult = null
+        rootManager.refresh()
     }
 
     suspend fun toggleUseRoot(useRoot: Boolean?) {
         log(TAG) { "toggleUseRoot(useRoot=$useRoot)" }
         // Drop any cached state so we don't replay a stale Result for the previous setting.
         lastResult = null
+        // No explicit refresh: the setting is part of the probe key, so accessState re-evaluates.
         rootSettings.useRoot.value(useRoot)
+    }
 
-        if (useRoot == true) {
-            // If we just allowed root, wait until the user has confirmed the pop-up
-            rootManager.useRoot
-                .filter { it }
-                .take(1)
-                .onEach { dataAreaManager.reload() }
-                .launchIn(appScope)
-        } else {
-            dataAreaManager.reload()
-        }
+    private fun AccessState.toUseRoot(): Boolean? = when (this) {
+        AccessState.Undecided -> null
+        AccessState.Declined -> false
+        else -> true
     }
 
     data class Loading(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -267,6 +267,7 @@
     <string name="setup_root_state_waiting_label">Root access is not available.</string>
     <string name="setup_root_state_failed_title">Root access failed</string>
     <string name="setup_root_state_failed_body">SD Maid asked for root access and didn\'t get it. If your device is rooted, open your root manager (Magisk, KernelSU or similar) and check whether the request from SD Maid was denied or is still waiting.</string>
+    <string name="setup_root_state_failed_body_nomanager">SD Maid asked for root access and didn\'t get it, and no root manager app was detected. If your device uses hidden or built-in root, try again.</string>
     <string name="setup_root_enable_root_use_label">Try to use root access</string>
     <string name="setup_root_disable_root_use_label">I didn\'t root my device</string>
     <string name="setup_root_card_body2">Only available on rooted devices. If you didn\'t make this modification, then your device is not rooted and this setting has no effect.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -264,6 +264,7 @@
     <string name="setup_root_card_title">Root access</string>
     <string name="setup_root_card_body">Should SD Maid use root access if it is available? Root access can be used to check additional system folders and private application data.</string>
     <string name="setup_root_state_ready_label">Root access is ready.</string>
+    <!-- No longer rendered, kept because the locale files already translate it and ExtraTranslation is a fatal lint check -->
     <string name="setup_root_state_waiting_label">Root access is not available.</string>
     <string name="setup_root_state_failed_title">Root access failed</string>
     <string name="setup_root_state_failed_body">SD Maid asked for root access and didn\'t get it. If your device is rooted, open your root manager (Magisk, KernelSU or similar) and check whether the request from SD Maid was denied or is still waiting.</string>

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
@@ -208,6 +208,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                             state = RootSetupModule.Result(useRoot = null),
                             onToggleUseRoot = { selection = it },
                             onHelp = {},
+                            onRetry = {},
                         ),
                     ),
                 ),
@@ -218,7 +219,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
     }
 
     @Test
-    fun `root card shows definitive not-available label when root probe failed`() {
+    fun `root card shows the failure box when no root manager is detected`() {
         composeRule.setSetupContent {
             SetupScreen(
                 uiState = SetupUiState.Cards(
@@ -231,16 +232,43 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                             ),
                             onToggleUseRoot = {},
                             onHelp = {},
+                            onRetry = {},
                         ),
                     ),
                 ),
             )
         }
 
-        // The settled probe-failure state is definitive — no "?" guesswork is appended.
-        val notAvailableText = context.getString(R.string.setup_root_state_waiting_label)
-        composeRule.onAllNodesWithText(notAvailableText).assertCountEquals(1)
-        composeRule.onAllNodesWithText("$notAvailableText ?").assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_root_state_failed_title)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_root_state_failed_body_nomanager))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_root_state_waiting_label)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `root card retry button invokes onRetry`() {
+        var retryClicks = 0
+        composeRule.setSetupContent {
+            SetupScreen(
+                uiState = SetupUiState.Cards(
+                    items = listOf(
+                        RootSetupCardItem(
+                            state = RootSetupModule.Result(
+                                useRoot = true,
+                                isInstalled = true,
+                                ourService = false,
+                            ),
+                            onToggleUseRoot = {},
+                            onHelp = {},
+                            onRetry = { retryClicks++ },
+                        ),
+                    ),
+                ),
+            )
+        }
+
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_retry_action)).performClick()
+        composeRule.runOnIdle { assertTrue(retryClicks == 1) }
     }
 
     @Test
@@ -257,6 +285,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                             ),
                             onToggleUseRoot = {},
                             onHelp = {},
+                            onRetry = {},
                         ),
                     ),
                 ),
@@ -282,6 +311,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                             ),
                             onToggleUseRoot = {},
                             onHelp = {},
+                            onRetry = {},
                         ),
                     ),
                 ),

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupViewModelTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupViewModelTest.kt
@@ -1,0 +1,97 @@
+package eu.darken.sdmse.setup
+
+import android.content.Context
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.setup.root.RootSetupCardItem
+import eu.darken.sdmse.setup.root.RootSetupModule
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class SetupViewModelTest : BaseTest() {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val setupManager: SetupManager = mockk(relaxed = true)
+    private val rootSetupModule: RootSetupModule = mockk(relaxed = true)
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun setupState(vararg moduleStates: SetupModule.State) {
+        every { setupManager.state } returns flowOf(
+            SetupManager.State(
+                moduleStates = moduleStates.toList(),
+                isDismissed = false,
+                isHealerWorking = false,
+            )
+        )
+    }
+
+    private fun buildVm() = SetupViewModel(
+        handle = SavedStateHandle(),
+        dispatcherProvider = TestDispatcherProvider(testDispatcher),
+        context = ApplicationProvider.getApplicationContext<Context>(),
+        setupManager = setupManager,
+        storageSetupModule = mockk(relaxed = true),
+        safSetupModule = mockk(relaxed = true),
+        automationSetupModule = mockk(relaxed = true),
+        webpageTool = mockk(relaxed = true),
+        rootSetupModule = rootSetupModule,
+        shizukuSetupModule = mockk(relaxed = true),
+        deviceDetective = mockk(relaxed = true),
+    )
+
+    @Test
+    fun `root card retry refreshes the root setup module`() = runTest2(context = testDispatcher) {
+        setupState(
+            RootSetupModule.Result(
+                useRoot = true,
+                isInstalled = true,
+                ourService = false,
+            ),
+        )
+        val vm = buildVm()
+
+        // Keep the render state subscribed, otherwise WhileSubscribed never runs the upstream.
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.uiState.collect() }
+        advanceUntilIdle()
+
+        val cards = vm.uiState.value.shouldBeInstanceOf<SetupUiState.Cards>()
+        val rootCard = cards.items.filterIsInstance<RootSetupCardItem>().single()
+
+        rootCard.onRetry()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { rootSetupModule.refresh() }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/setup/root/RootSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/root/RootSetupModuleTest.kt
@@ -1,26 +1,25 @@
 package eu.darken.sdmse.setup.root
 
+import eu.darken.sdmse.common.access.AccessState
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.RootSettings
-import eu.darken.sdmse.common.root.service.RootServiceClient
-import eu.darken.sdmse.common.root.service.RootServiceConnection
-import eu.darken.sdmse.setup.SetupModule
-import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -36,24 +35,22 @@ class RootSetupModuleTest : BaseTest() {
 
     private val useRootValue: DataStoreValue<Boolean?> = mockk()
     private lateinit var useRootFlow: MutableStateFlow<Boolean?>
-    private val connection: RootServiceClient.Connection = mockk()
-    private val ipc: RootServiceConnection = mockk()
+    private lateinit var accessFlow: MutableStateFlow<AccessState>
     private lateinit var scope: CoroutineScope
-    private var probeCount = 0
 
     @BeforeEach
     fun setup() {
-        probeCount = 0
         useRootFlow = MutableStateFlow(true)
+        accessFlow = MutableStateFlow(AccessState.Active)
         scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
 
         every { rootSettings.useRoot } returns useRootValue
         every { useRootValue.flow } returns useRootFlow
+        coEvery { useRootValue.update(any()) } returns DataStoreValue.Updated(old = true, new = false)
 
         coEvery { rootManager.isInstalled() } returns true
-        every { rootManager.binder } returns flowOf(connection)
-        every { connection.ipc } returns ipc
-        every { ipc.checkBase() } answers { probeCount++; "ok" }
+        every { rootManager.accessState } returns accessFlow
+        every { rootManager.refresh() } just runs
     }
 
     @AfterEach
@@ -71,6 +68,7 @@ class RootSetupModuleTest : BaseTest() {
 
         collector.latestValues.first().shouldBeInstanceOf<RootSetupModule.Loading>()
         val result = collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>()
+        result.useRoot shouldBe true
         result.ourService shouldBe true
 
         runBlocking { collector.cancelAndJoin() }
@@ -111,61 +109,51 @@ class RootSetupModuleTest : BaseTest() {
         runBlocking { second.cancelAndJoin() }
     }
 
-    @Test fun `cold-start probe stays Loading and never emits a transient incomplete Result`() {
-        // Acquiring the root host cold-binds a su session, so the binder only emits the connection
-        // after a delay. The module must report Loading during that window - never a settled
-        // Result(ourService=false), which previously flagged setup as incomplete and flashed the
-        // dashboard setup card on every launch.
-        every { rootManager.binder } returns flow {
-            delay(100)
-            emit(connection)
-        }
+    @Test fun `a running probe keeps the module on Loading`() {
+        // Acquiring the root host cold-binds a su session. While that runs the module must report
+        // Loading - never a settled Result(ourService=false), which previously flagged setup as
+        // incomplete and flashed the dashboard setup card on every launch.
+        accessFlow.value = AccessState.Checking
         val mod = module()
 
-        val collector = mod.state.test(tag = "cold", scope = scope)
-        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
+        val collector = mod.state.test(tag = "checking", scope = scope)
+        collector.await { values, _ -> values.size >= 2 }
 
-        // No incomplete Result may appear before the probe resolves.
-        collector.latestValues
-            .filterIsInstance<RootSetupModule.Result>()
-            .forEach { it.isComplete shouldBe true }
+        collector.latestValues.none { it is RootSetupModule.Result } shouldBe true
+
+        accessFlow.value = AccessState.Active
+        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
 
         val result = collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>()
         result.ourService shouldBe true
+        result.isComplete shouldBe true
 
         runBlocking { collector.cancelAndJoin() }
     }
 
-    @Test fun `genuine acquisition failure still surfaces an incomplete Result`() {
-        // binder emits null (via its catch block) when root acquisition genuinely fails. That must
-        // map to an incomplete Result so the setup screen shows the real problem - not be swallowed
-        // by the Loading anti-flicker handling.
-        every { rootManager.binder } returns flowOf(null)
+    @Test fun `a failed probe surfaces an incomplete Result`() {
+        // The user opted in and a root manager is installed, but our service never came up. That must
+        // surface as an incomplete Result so the setup screen shows the real problem.
+        accessFlow.value = AccessState.Unavailable
         val mod = module()
 
         val collector = mod.state.test(tag = "failure", scope = scope)
         collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
 
         val result = collector.latestValues.last().shouldBeInstanceOf<RootSetupModule.Result>()
+        result.useRoot shouldBe true
         result.ourService shouldBe false
         result.isComplete shouldBe false
 
         runBlocking { collector.cancelAndJoin() }
     }
 
-    @Test fun `refresh triggers a fresh probe`() {
+    @Test fun `refresh re-runs the root probe`() {
         val mod = module()
 
-        val collector = mod.state.test(tag = "refresh", scope = scope)
-        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
-        val before = probeCount
-
         runBlocking { mod.refresh() }
-        collector.await { _, _ -> probeCount > before }
 
-        probeCount shouldBeGreaterThan before
-
-        runBlocking { collector.cancelAndJoin() }
+        verify(exactly = 1) { rootManager.refresh() }
     }
 
     @Test fun `completion depends on user choice and service readiness`() {
@@ -174,5 +162,82 @@ class RootSetupModuleTest : BaseTest() {
         RootSetupModule.Result(useRoot = true, isInstalled = true, ourService = false).isComplete shouldBe false
         RootSetupModule.Result(useRoot = true, isInstalled = false, ourService = false).isComplete shouldBe true
         RootSetupModule.Result(useRoot = true, isInstalled = true, ourService = true).isComplete shouldBe true
+    }
+
+    @Test fun `data areas reload when root becomes available`() {
+        accessFlow.value = AccessState.Unavailable
+        val mod = module()
+
+        val collector = mod.state.test(tag = "gained", scope = scope)
+        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
+        coVerify(exactly = 0) { dataAreaManager.reload() }
+
+        accessFlow.value = AccessState.Active
+        collector.await { values, _ ->
+            values.filterIsInstance<RootSetupModule.Result>().any { it.ourService }
+        }
+
+        coVerify(exactly = 1) { dataAreaManager.reload() }
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `data areas reload when root is lost`() {
+        val mod = module()
+
+        val collector = mod.state.test(tag = "lost", scope = scope)
+        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
+
+        accessFlow.value = AccessState.Unavailable
+        collector.await { values, _ ->
+            values.filterIsInstance<RootSetupModule.Result>().any { !it.ourService }
+        }
+
+        coVerify(exactly = 1) { dataAreaManager.reload() }
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `data areas do not reload on the first observation`() {
+        val mod = module()
+
+        val collector = mod.state.test(tag = "initial", scope = scope)
+        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
+        runBlocking { delay(50) }
+
+        // Nothing has changed yet, so there is nothing to re-detect.
+        coVerify(exactly = 0) { dataAreaManager.reload() }
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `data areas do not reload when a retry fails`() {
+        accessFlow.value = AccessState.Unavailable
+        val mod = module()
+
+        val collector = mod.state.test(tag = "retry", scope = scope)
+        collector.await { values, _ -> values.any { it is RootSetupModule.Result } }
+
+        // Retry: probe runs again and fails again, so the effective access state never changed.
+        accessFlow.value = AccessState.Checking
+        collector.await { values, _ -> values.size >= 3 }
+        accessFlow.value = AccessState.Unavailable
+        collector.await { values, _ -> values.filterIsInstance<RootSetupModule.Result>().size >= 2 }
+
+        coVerify(exactly = 0) { dataAreaManager.reload() }
+
+        runBlocking { collector.cancelAndJoin() }
+    }
+
+    @Test fun `toggleUseRoot no longer reloads data areas directly`() {
+        val mod = module()
+
+        runBlocking { mod.toggleUseRoot(false) }
+        runBlocking { delay(50) }
+
+        coVerify(exactly = 1) { useRootValue.update(any()) }
+        // Reloading is owned by the state pipeline's transition observer, which only fires on a real
+        // change of root availability.
+        coVerify(exactly = 0) { dataAreaManager.reload() }
     }
 }


### PR DESCRIPTION
## What changed

If you allow SD Maid to use root and the request does not go through, you can now fix that and try again without restarting the app. Until now, once SD Maid had asked for root and been refused, it kept treating your device as unrooted until you restarted it or switched the setting off and back on, even after you had granted the request in Magisk or KernelSU. The root setup card now offers a Retry button, and the rest of the app picks up the new answer with it.

Retry also shows up on devices where no root manager app is detected. Hidden, renamed and built-in root all look like "no manager at all" to SD Maid, and those are exactly the setups where trying again is most likely to succeed.

## Technical Context

- Root cause: `RootManager` memoised its probe answer and only a change to the useRoot setting invalidated it, while both derived state flows (`useRoot`, `accessState`) were driven by that same setting flow. The cache is now keyed on the setting value plus a refresh generation, so `refresh()` invalidates by construction.
- `refresh()` deliberately neither suspends nor takes the cache lock. `isRooted()` holds that lock across the su bind, so a refresh landing mid-probe would otherwise block on it, throw away the fresh result and start a second probe. A probe already running writes under the old key and is simply never read again.
- The setup card no longer runs its own availability probe; it derives from `RootManager.accessState`. Two independently cached probes were what allowed the card and the tools to disagree about whether root worked. `RootManager.binder` is deleted as a consequence.
- Data-area reloads now have a single owner watching the real availability transition, which also covers losing root, not just gaining it. Both reload paths were removed from `toggleUseRoot`, since the setup screen calls that immediately before `refresh()` and would otherwise rebuild twice.
- `RootServiceClient` gains a 30 second keepalive, mirroring the existing `AdbServiceClient` decision. The deleted `binder` lease had been keeping the su host warm for as long as the dashboard was subscribed, so without a replacement every root operation would pay a fresh su bind.
- Worth close review: the generation-keyed cache in `RootManager`, and the transition observer in `RootSetupModule` that owns the data-area reload.
