### PR TITLE
Fix: Say when the app list couldn't be read, and offer a retry

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/SetupViewModel.kt
@@ -63,6 +63,7 @@ class SetupViewModel @Inject constructor(
     private val webpageTool: WebpageTool,
     private val rootSetupModule: RootSetupModule,
     private val shizukuSetupModule: ShizukuSetupModule,
+    private val inventorySetupModule: InventorySetupModule,
     private val deviceDetective: DeviceDetective,
 ) : ViewModel4(dispatcherProvider, TAG) {
 
@@ -283,7 +284,8 @@ class SetupViewModel @Inject constructor(
                                 },
                                 onHelp = {
                                     webpageTool.open(InventorySetupModule.INFO_URL)
-                                }
+                                },
+                                onRetry = { launch { inventorySetupModule.refresh() } },
                             )
 
                             is SetupModule.State.Loading -> SetupLoadingCardItem(state)

--- a/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCard.kt
@@ -27,6 +27,7 @@ import eu.darken.sdmse.common.permissions.Permission
 import eu.darken.sdmse.setup.SetupCardContainer
 import eu.darken.sdmse.setup.SetupCardItem
 import eu.darken.sdmse.setup.SetupLimitationBox
+import eu.darken.sdmse.setup.inventory.InventorySetupModule.InventoryAccess
 import eu.darken.sdmse.common.R as CommonR
 
 data class InventorySetupCardItem(
@@ -54,10 +55,10 @@ internal fun InventorySetupCard(
                 .padding(horizontal = 16.dp),
         )
 
-        // Faked access is left to the limitation box below: it already carries a warning icon, its own
-        // title and a body that explains the state, so this row was a second error header with strictly
-        // less information.
-        if (item.state.missingPermission.isEmpty() && !item.state.isAccessFaked) {
+        // An incomplete list or a failed probe is left to the limitation boxes below: they already carry
+        // a warning icon, their own title and a body that explains the state, so this row was a second
+        // error header with strictly less information.
+        if (item.state.missingPermission.isEmpty() && item.state.access is InventoryAccess.Valid) {
             Row(
                 modifier = Modifier
                     .align(Alignment.CenterHorizontally)
@@ -79,7 +80,7 @@ internal fun InventorySetupCard(
             }
         }
 
-        if (item.state.missingPermission.isEmpty() && item.state.isAccessFaked) {
+        if (item.state.access is InventoryAccess.Incomplete) {
             SetupLimitationBox(
                 title = stringResource(R.string.setup_inventory_limitation_title),
                 body = stringResource(R.string.setup_inventory_limitation_body),
@@ -131,7 +132,7 @@ private fun InventorySetupCardInvalidPreview() {
             item = InventorySetupCardItem(
                 state = InventorySetupModule.Result(
                     missingPermission = emptySet(),
-                    isAccessFaked = true,
+                    access = InventorySetupModule.InventoryAccess.Incomplete,
                     settingsIntent = Intent(),
                 ),
                 onGrantAction = {},
@@ -149,7 +150,7 @@ private fun InventorySetupCardMissingPermissionPreview() {
             item = InventorySetupCardItem(
                 state = InventorySetupModule.Result(
                     missingPermission = setOf(Permission.GET_INSTALLED_APPS),
-                    isAccessFaked = false,
+                    access = InventorySetupModule.InventoryAccess.NotChecked,
                     settingsIntent = Intent(),
                 ),
                 onGrantAction = {},

--- a/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupCard.kt
@@ -34,6 +34,7 @@ data class InventorySetupCardItem(
     override val state: InventorySetupModule.Result,
     val onGrantAction: () -> Unit,
     val onHelp: () -> Unit,
+    val onRetry: () -> Unit,
 ) : SetupCardItem
 
 @Composable
@@ -101,6 +102,28 @@ internal fun InventorySetupCard(
             }
         }
 
+        if (item.state.access is InventoryAccess.ProbeFailed) {
+            // No "Open system settings" here: the permissions are granted, the request itself failed,
+            // so there is nothing for the user to change in the settings page.
+            SetupLimitationBox(
+                title = stringResource(R.string.setup_inventory_probe_failed_title),
+                body = stringResource(R.string.setup_inventory_probe_failed_body),
+            ) {
+                Button(
+                    onClick = item.onRetry,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(CommonR.string.general_retry_action))
+                }
+                OutlinedButton(
+                    onClick = item.onHelp,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(stringResource(CommonR.string.general_help_action))
+                }
+            }
+        }
+
         if (item.state.missingPermission.isNotEmpty()) {
             Button(
                 onClick = item.onGrantAction,
@@ -137,6 +160,26 @@ private fun InventorySetupCardInvalidPreview() {
                 ),
                 onGrantAction = {},
                 onHelp = {},
+                onRetry = {},
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun InventorySetupCardProbeFailedPreview() {
+    PreviewWrapper {
+        InventorySetupCard(
+            item = InventorySetupCardItem(
+                state = InventorySetupModule.Result(
+                    missingPermission = emptySet(),
+                    access = InventorySetupModule.InventoryAccess.ProbeFailed,
+                    settingsIntent = Intent(),
+                ),
+                onGrantAction = {},
+                onHelp = {},
+                onRetry = {},
             ),
         )
     }
@@ -155,6 +198,7 @@ private fun InventorySetupCardMissingPermissionPreview() {
                 ),
                 onGrantAction = {},
                 onHelp = {},
+                onRetry = {},
             ),
         )
     }

--- a/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/inventory/InventorySetupModule.kt
@@ -25,11 +25,11 @@ import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
 import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.rngString
 import eu.darken.sdmse.setup.SetupModule
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.mapLatest
-import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.transformLatest
 import java.time.Instant
 import javax.inject.Inject
 import eu.darken.sdmse.setup.SetupBinding
@@ -43,58 +43,82 @@ class InventorySetupModule @Inject constructor(
 ) : SetupModule {
 
     private val refreshTrigger = MutableStateFlow(rngString)
+
+    // transformLatest, not map: every trigger has to announce itself BEFORE the query runs. With
+    // Loading only on onStart, a refresh left the previous Result on screen for the whole query, so
+    // a failure box and its enabled retry button stayed visible while that retry was already running.
     override val state: Flow<SetupModule.State> = refreshTrigger
-        .mapLatest {
-            val requiredPermission = getRequiredPermission()
+        .transformLatest<String, SetupModule.State> {
+            emit(Loading())
 
-            val missingPermission = requiredPermission.filter {
-                val isGranted = it.isGranted(context)
-                log(TAG) { "${it.permissionId} isGranted=$isGranted" }
-                !isGranted
-            }.toSet()
+            val settled = try {
+                val requiredPermission = getRequiredPermission()
 
-            val isAccessFaked = when {
-                missingPermission.isEmpty() -> {
-                    val pkgs = try {
-                        pkgOps.queryPkgs(PackageManager.MATCH_ALL.toLong()).map { it.packageName }
-                    } catch (e: Exception) {
-                        log(TAG, ERROR) { "Check for fake access failed: ${e.asLog()}" }
-                        null
-                    }
-                    when (pkgs) {
-                        // Probe failed (binder, SecurityException, OEM PackageManager error). Don't
-                        // pretend setup is complete — tools would later throw a less actionable error.
-                        null -> true
-                        else -> {
-                            val result = PkgInventoryCheck.check(pkgs, context.packageName)
-                            val faked = result != PkgInventoryCheck.Result.Valid
-                            if (faked) {
-                                val sample = pkgs.take(PKG_LOG_SAMPLE_SIZE)
-                                log(TAG, WARN) {
-                                    "Inventory check returned $result for ${pkgs.size} pkgs (first $PKG_LOG_SAMPLE_SIZE: $sample)"
+                val missingPermission = requiredPermission.filter {
+                    val isGranted = it.isGranted(context)
+                    log(TAG) { "${it.permissionId} isGranted=$isGranted" }
+                    !isGranted
+                }.toSet()
+
+                val access = when {
+                    missingPermission.isNotEmpty() -> InventoryAccess.NotChecked
+                    else -> {
+                        val pkgs = try {
+                            pkgOps.queryPkgs(PackageManager.MATCH_ALL.toLong()).map { it.packageName }
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            log(TAG, ERROR) { "Inventory probe failed: ${e.asLog()}" }
+                            null
+                        }
+                        when (pkgs) {
+                            // Probe failed (binder, SecurityException, OEM PackageManager error). Don't
+                            // pretend setup is complete — tools would later throw a less actionable error.
+                            null -> InventoryAccess.ProbeFailed
+                            else -> {
+                                val result = PkgInventoryCheck.check(pkgs, context.packageName)
+                                if (result != PkgInventoryCheck.Result.Valid) {
+                                    val sample = pkgs.take(PKG_LOG_SAMPLE_SIZE)
+                                    log(TAG, WARN) {
+                                        "Inventory check returned $result for ${pkgs.size} pkgs " +
+                                                "(first $PKG_LOG_SAMPLE_SIZE: $sample)"
+                                    }
+                                    if (Bugs.isTrace) {
+                                        log(TAG, WARN) { "Inventory full list: $pkgs" }
+                                    }
+                                    InventoryAccess.Incomplete
+                                } else {
+                                    log(TAG) { "Inventory check returned $result for ${pkgs.size} pkgs" }
+                                    InventoryAccess.Valid
                                 }
-                                if (Bugs.isTrace) {
-                                    log(TAG, WARN) { "Inventory full list: $pkgs" }
-                                }
-                            } else {
-                                log(TAG) { "Inventory check returned $result for ${pkgs.size} pkgs" }
                             }
-                            faked
                         }
                     }
                 }
 
-                else -> false
+                Result(
+                    missingPermission = missingPermission,
+                    access = access,
+                    settingsIntent = context.packageName.toPkgId().getSettingsIntent(context),
+                )
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Must settle rather than propagate. Anything thrown after the Loading above kills the
+                // sharing coroutine with Loading left in replayingShare's replay slot, and since the
+                // coroutine is dead no refresh can ever replace it: the card is stuck on a spinner
+                // forever. Same failure mode that ShizukuSetupModule guards against. queryPkgs() has
+                // its own catch, but the permission checks and getSettingsIntent() do not.
+                log(TAG, ERROR) { "Inventory setup state failed: ${e.asLog()}" }
+                Result(
+                    missingPermission = emptySet(),
+                    access = InventoryAccess.ProbeFailed,
+                    settingsIntent = Intent(),
+                )
             }
 
-            @Suppress("USELESS_CAST")
-            Result(
-                missingPermission = missingPermission,
-                isAccessFaked = isAccessFaked,
-                settingsIntent = context.packageName.toPkgId().getSettingsIntent(context)
-            ) as SetupModule.State
+            emit(settled)
         }
-        .onStart { emit(Loading()) }
         .replayingShare(appScope)
 
     private fun getRequiredPermission(): Set<Permission> = buildSet {
@@ -113,16 +137,32 @@ class InventorySetupModule @Inject constructor(
         override val type: SetupModule.Type = SetupModule.Type.INVENTORY
     }
 
+    sealed interface InventoryAccess {
+        /** Permissions are missing, so the list was never queried. */
+        data object NotChecked : InventoryAccess
+
+        /** The query returned a usable list. */
+        data object Valid : InventoryAccess
+
+        /** A list came back, but it is not credible (empty, missing us, missing core packages). */
+        data object Incomplete : InventoryAccess
+
+        /** The query itself failed, so nothing is known about the list. */
+        data object ProbeFailed : InventoryAccess
+    }
+
     data class Result(
         val missingPermission: Set<Permission>,
-        val isAccessFaked: Boolean,
+        val access: InventoryAccess,
         val settingsIntent: Intent,
     ) : SetupModule.State.Current {
 
         override val type: SetupModule.Type
             get() = SetupModule.Type.INVENTORY
 
-        override val isComplete: Boolean = !isAccessFaked && missingPermission.isEmpty()
+        // A failed probe keeps setup incomplete: pretending it is done would let tools run and throw a
+        // less actionable error later.
+        override val isComplete: Boolean = missingPermission.isEmpty() && access is InventoryAccess.Valid
 
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -327,6 +327,9 @@
     <string name="setup_inventory_limitation_body">The system returned an incomplete list of installed apps, even though the required permissions appear to be granted.</string>
     <string name="setup_inventory_limitation_body2">Some devices (e.g. HarmonyOS) never provide a complete app list. To protect your data, app-related tools stay disabled, but you can still view storage usage with reduced detail.</string>
 
+    <string name="setup_inventory_probe_failed_title">Couldn\'t read the app list</string>
+    <string name="setup_inventory_probe_failed_body">SD Maid asked Android for the list of installed apps and the request failed. App-related tools stay disabled until it works. Trying again may help.</string>
+
     <string name="dataarea_warningcard_empty_message">SD Maid didn\'t find any data areas that can be scanned. Did you complete the setup?</string>
     <string name="dataarea_warningcard_label">Data areas</string>
     <string name="dataarea_warningcard_reload_action">Reload data areas</string>

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
@@ -129,6 +129,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                             ),
                             onGrantAction = {},
                             onHelp = {},
+                            onRetry = {},
                         ),
                     ),
                 ),
@@ -159,6 +160,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                             ),
                             onGrantAction = { settingsClicks++ },
                             onHelp = { helpClicks++ },
+                            onRetry = {},
                         ),
                     ),
                 ),
@@ -187,6 +189,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                             ),
                             onGrantAction = {},
                             onHelp = {},
+                            onRetry = {},
                         ),
                     ),
                 ),
@@ -195,6 +198,93 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithText(context.getString(CommonR.string.general_grant_access_action)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.setup_inventory_limitation_title)).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.setup_permission_granted_label)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `inventory card with a failed probe shows the retry box and no settings button`() {
+        composeRule.setSetupContent {
+            SetupScreen(
+                uiState = SetupUiState.Cards(
+                    items = listOf(
+                        InventorySetupCardItem(
+                            state = InventorySetupModule.Result(
+                                missingPermission = emptySet(),
+                                access = InventorySetupModule.InventoryAccess.ProbeFailed,
+                                settingsIntent = Intent(),
+                            ),
+                            onGrantAction = {},
+                            onHelp = {},
+                            onRetry = {},
+                        ),
+                    ),
+                ),
+            )
+        }
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_inventory_probe_failed_title))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_inventory_probe_failed_body))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(CommonR.string.general_retry_action)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(CommonR.string.general_help_action)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(CommonR.string.general_open_system_settings_action))
+            .assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_permission_granted_label)).assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_inventory_limitation_title)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `inventory card retry button invokes onRetry`() {
+        var retryClicks = 0
+        composeRule.setSetupContent {
+            SetupScreen(
+                uiState = SetupUiState.Cards(
+                    items = listOf(
+                        InventorySetupCardItem(
+                            state = InventorySetupModule.Result(
+                                missingPermission = emptySet(),
+                                access = InventorySetupModule.InventoryAccess.ProbeFailed,
+                                settingsIntent = Intent(),
+                            ),
+                            onGrantAction = {},
+                            onHelp = {},
+                            onRetry = { retryClicks++ },
+                        ),
+                    ),
+                ),
+            )
+        }
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_retry_action)).performClick()
+        composeRule.runOnIdle {
+            assertTrue(retryClicks == 1)
+        }
+    }
+
+    @Test
+    fun `inventory card probe-failed help button invokes onHelp`() {
+        var helpClicks = 0
+        composeRule.setSetupContent {
+            SetupScreen(
+                uiState = SetupUiState.Cards(
+                    items = listOf(
+                        InventorySetupCardItem(
+                            state = InventorySetupModule.Result(
+                                missingPermission = emptySet(),
+                                access = InventorySetupModule.InventoryAccess.ProbeFailed,
+                                settingsIntent = Intent(),
+                            ),
+                            onGrantAction = {},
+                            onHelp = { helpClicks++ },
+                            onRetry = {},
+                        ),
+                    ),
+                ),
+            )
+        }
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_help_action)).performClick()
+        composeRule.runOnIdle {
+            // The container help icon has no text label, so the click unambiguously hit the box button.
+            assertTrue(helpClicks == 1)
+        }
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
@@ -116,7 +116,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
     }
 
     @Test
-    fun `inventory card with fake access shows limitation box and open settings button`() {
+    fun `inventory card with an incomplete list shows limitation box and open settings button`() {
         composeRule.setSetupContent {
             SetupScreen(
                 uiState = SetupUiState.Cards(
@@ -124,7 +124,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                         InventorySetupCardItem(
                             state = InventorySetupModule.Result(
                                 missingPermission = emptySet(),
-                                isAccessFaked = true,
+                                access = InventorySetupModule.InventoryAccess.Incomplete,
                                 settingsIntent = Intent(),
                             ),
                             onGrantAction = {},
@@ -154,7 +154,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                         InventorySetupCardItem(
                             state = InventorySetupModule.Result(
                                 missingPermission = emptySet(),
-                                isAccessFaked = true,
+                                access = InventorySetupModule.InventoryAccess.Incomplete,
                                 settingsIntent = Intent(),
                             ),
                             onGrantAction = { settingsClicks++ },
@@ -182,7 +182,7 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
                         InventorySetupCardItem(
                             state = InventorySetupModule.Result(
                                 missingPermission = setOf(Permission.GET_INSTALLED_APPS),
-                                isAccessFaked = false,
+                                access = InventorySetupModule.InventoryAccess.NotChecked,
                                 settingsIntent = Intent(),
                             ),
                             onGrantAction = {},

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupViewModelTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupViewModelTest.kt
@@ -1,8 +1,11 @@
 package eu.darken.sdmse.setup
 
 import android.content.Context
+import android.content.Intent
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.setup.inventory.InventorySetupCardItem
+import eu.darken.sdmse.setup.inventory.InventorySetupModule
 import eu.darken.sdmse.setup.root.RootSetupCardItem
 import eu.darken.sdmse.setup.root.RootSetupModule
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -36,6 +39,7 @@ class SetupViewModelTest : BaseTest() {
     private val testDispatcher = StandardTestDispatcher()
     private val setupManager: SetupManager = mockk(relaxed = true)
     private val rootSetupModule: RootSetupModule = mockk(relaxed = true)
+    private val inventorySetupModule: InventorySetupModule = mockk(relaxed = true)
 
     @Before
     fun setup() {
@@ -68,6 +72,7 @@ class SetupViewModelTest : BaseTest() {
         webpageTool = mockk(relaxed = true),
         rootSetupModule = rootSetupModule,
         shizukuSetupModule = mockk(relaxed = true),
+        inventorySetupModule = inventorySetupModule,
         deviceDetective = mockk(relaxed = true),
     )
 
@@ -93,5 +98,29 @@ class SetupViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 1) { rootSetupModule.refresh() }
+    }
+
+    @Test
+    fun `inventory card retry refreshes the inventory setup module`() = runTest2(context = testDispatcher) {
+        setupState(
+            InventorySetupModule.Result(
+                missingPermission = emptySet(),
+                access = InventorySetupModule.InventoryAccess.ProbeFailed,
+                settingsIntent = Intent(),
+            ),
+        )
+        val vm = buildVm()
+
+        // Keep the render state subscribed, otherwise WhileSubscribed never runs the upstream.
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.uiState.collect() }
+        advanceUntilIdle()
+
+        val cards = vm.uiState.value.shouldBeInstanceOf<SetupUiState.Cards>()
+        val inventoryCard = cards.items.filterIsInstance<InventorySetupCardItem>().single()
+
+        inventoryCard.onRetry()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { inventorySetupModule.refresh() }
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/setup/inventory/InventorySetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/inventory/InventorySetupModuleTest.kt
@@ -1,0 +1,198 @@
+package eu.darken.sdmse.setup.inventory
+
+import android.app.Application
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PermissionInfo
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.permissions.Permission
+import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.setup.SetupModule
+import eu.darken.sdmse.setup.inventory.InventorySetupModule.InventoryAccess
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class InventorySetupModuleTest : BaseTest() {
+
+    private lateinit var pkgOps: PkgOps
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Before
+    fun setup() {
+        pkgOps = mockk(relaxed = true)
+        // GET_INSTALLED_APPS is a non-AOSP permission and reports itself as granted where it does not
+        // exist, granting it too keeps this independent of whether Robolectric knows the permission.
+        Shadows.shadowOf(ApplicationProvider.getApplicationContext<Application>()).grantPermissions(
+            Permission.GET_INSTALLED_APPS.permissionId,
+            Permission.QUERY_ALL_PACKAGES.permissionId,
+        )
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `missing permissions leave the list unchecked and skip the query`() = runTest {
+        // Only a permission that exists can be missing: the module's own check treats an unknown
+        // permission id as granted.
+        Shadows.shadowOf(context.packageManager).addPermissionInfo(
+            PermissionInfo().apply {
+                name = Permission.GET_INSTALLED_APPS.permissionId
+                packageName = context.packageName
+            }
+        )
+        Shadows.shadowOf(ApplicationProvider.getApplicationContext<Application>())
+            .denyPermissions(Permission.GET_INSTALLED_APPS.permissionId)
+
+        val result = newModule(backgroundScope).awaitResult()
+
+        result.access shouldBe InventoryAccess.NotChecked
+        result.isComplete shouldBe false
+        coVerify(exactly = 0) { pkgOps.queryPkgs(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a credible list is valid and completes setup`() = runTest {
+        coEvery { pkgOps.queryPkgs(any(), any(), any()) } returns pkgs(context.packageName, "android")
+
+        val result = newModule(backgroundScope).awaitResult()
+
+        result.access shouldBe InventoryAccess.Valid
+        result.isComplete shouldBe true
+    }
+
+    @Test
+    fun `an empty list is incomplete`() = runTest {
+        coEvery { pkgOps.queryPkgs(any(), any(), any()) } returns pkgs()
+
+        val result = newModule(backgroundScope).awaitResult()
+
+        result.access shouldBe InventoryAccess.Incomplete
+        result.isComplete shouldBe false
+    }
+
+    @Test
+    fun `a list without our own package is incomplete`() = runTest {
+        coEvery { pkgOps.queryPkgs(any(), any(), any()) } returns pkgs("android", "com.example.other")
+
+        val result = newModule(backgroundScope).awaitResult()
+
+        result.access shouldBe InventoryAccess.Incomplete
+    }
+
+    @Test
+    fun `a list without any core package is incomplete`() = runTest {
+        coEvery { pkgOps.queryPkgs(any(), any(), any()) } returns pkgs(context.packageName, "com.example.other")
+
+        val result = newModule(backgroundScope).awaitResult()
+
+        result.access shouldBe InventoryAccess.Incomplete
+    }
+
+    @Test
+    fun `a failing query is a probe failure and does not complete setup`() = runTest {
+        coEvery { pkgOps.queryPkgs(any(), any(), any()) } throws SecurityException("Nope")
+
+        val result = newModule(backgroundScope).awaitResult()
+
+        result.access shouldBe InventoryAccess.ProbeFailed
+        result.isComplete shouldBe false
+    }
+
+    @Test
+    fun `a refresh after a failed probe recovers`() = runTest {
+        coEvery { pkgOps.queryPkgs(any(), any(), any()) } throws IllegalStateException("Nope")
+        val module = newModule(backgroundScope)
+        val seen = mutableListOf<SetupModule.State>()
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { module.state.toList(seen) }
+        advanceUntilIdle()
+
+        seen.results().last().access shouldBe InventoryAccess.ProbeFailed
+
+        coEvery { pkgOps.queryPkgs(any(), any(), any()) } returns pkgs(context.packageName, "android")
+        module.refresh()
+        advanceUntilIdle()
+
+        val recovered = seen.results().last()
+        recovered.access shouldBe InventoryAccess.Valid
+        recovered.isComplete shouldBe true
+    }
+
+    @Test
+    fun `every trigger emits loading before the settled result`() = runTest {
+        coEvery { pkgOps.queryPkgs(any(), any(), any()) } returns pkgs(context.packageName, "android")
+        val module = newModule(backgroundScope)
+        val seen = mutableListOf<SetupModule.State>()
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { module.state.toList(seen) }
+        advanceUntilIdle()
+
+        module.refresh()
+        advanceUntilIdle()
+
+        seen.map { it::class } shouldBe listOf(
+            InventorySetupModule.Loading::class,
+            InventorySetupModule.Result::class,
+            InventorySetupModule.Loading::class,
+            InventorySetupModule.Result::class,
+        )
+    }
+
+    @Test
+    fun `a probe cancelled by a refresh does not surface as a failure`() = runTest {
+        coEvery { pkgOps.queryPkgs(any(), any(), any()) } coAnswers { awaitCancellation() }
+        val module = newModule(backgroundScope)
+        val seen = mutableListOf<SetupModule.State>()
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { module.state.toList(seen) }
+        advanceUntilIdle()
+
+        coEvery { pkgOps.queryPkgs(any(), any(), any()) } returns pkgs(context.packageName, "android")
+        module.refresh()
+        advanceUntilIdle()
+
+        seen.results().none { it.access is InventoryAccess.ProbeFailed } shouldBe true
+        seen.results().last().access shouldBe InventoryAccess.Valid
+    }
+
+    private fun newModule(appScope: CoroutineScope) = InventorySetupModule(
+        appScope = appScope,
+        context = context,
+        pkgOps = pkgOps,
+    )
+
+    private suspend fun InventorySetupModule.awaitResult(): InventorySetupModule.Result =
+        state.filterIsInstance<InventorySetupModule.Result>().first()
+
+    private fun List<SetupModule.State>.results(): List<InventorySetupModule.Result> =
+        filterIsInstance<InventorySetupModule.Result>()
+
+    private fun pkgs(vararg names: String): Collection<PackageInfo> = names.map { name ->
+        PackageInfo().apply { packageName = name }
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/setup/inventory/InventorySetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/inventory/InventorySetupModuleTest.kt
@@ -15,13 +15,13 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -32,12 +32,14 @@ import org.robolectric.Shadows
 import org.robolectric.annotation.Config
 import testhelpers.BaseTest
 import testhelpers.TestApplication
+import testhelpers.flow.test
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [33], application = TestApplication::class)
 class InventorySetupModuleTest : BaseTest() {
 
     private lateinit var pkgOps: PkgOps
+    private lateinit var scope: CoroutineScope
 
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
@@ -45,6 +47,7 @@ class InventorySetupModuleTest : BaseTest() {
     @Before
     fun setup() {
         pkgOps = mockk(relaxed = true)
+        scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
         // GET_INSTALLED_APPS is a non-AOSP permission and reports itself as granted where it does not
         // exist, granting it too keeps this independent of whether Robolectric knows the permission.
         Shadows.shadowOf(ApplicationProvider.getApplicationContext<Application>()).grantPermissions(
@@ -55,6 +58,7 @@ class InventorySetupModuleTest : BaseTest() {
 
     @After
     fun teardown() {
+        scope.cancel()
         unmockkAll()
     }
 
@@ -127,57 +131,64 @@ class InventorySetupModuleTest : BaseTest() {
     }
 
     @Test
-    fun `a refresh after a failed probe recovers`() = runTest {
+    fun `a refresh after a failed probe recovers`() {
         coEvery { pkgOps.queryPkgs(any(), any(), any()) } throws IllegalStateException("Nope")
-        val module = newModule(backgroundScope)
-        val seen = mutableListOf<SetupModule.State>()
-        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { module.state.toList(seen) }
-        advanceUntilIdle()
+        val module = newModule(scope)
 
-        seen.results().last().access shouldBe InventoryAccess.ProbeFailed
+        val collector = module.state.test(tag = "recovery", scope = scope)
+        collector.await { values, _ -> values.results().isNotEmpty() }
+
+        collector.latestValues.results().last().access shouldBe InventoryAccess.ProbeFailed
 
         coEvery { pkgOps.queryPkgs(any(), any(), any()) } returns pkgs(context.packageName, "android")
-        module.refresh()
-        advanceUntilIdle()
+        runBlocking { module.refresh() }
+        collector.await { values, _ -> values.results().size >= 2 }
 
-        val recovered = seen.results().last()
+        val recovered = collector.latestValues.results().last()
         recovered.access shouldBe InventoryAccess.Valid
         recovered.isComplete shouldBe true
+
+        runBlocking { collector.cancelAndJoin() }
     }
 
     @Test
-    fun `every trigger emits loading before the settled result`() = runTest {
+    fun `every trigger emits loading before the settled result`() {
         coEvery { pkgOps.queryPkgs(any(), any(), any()) } returns pkgs(context.packageName, "android")
-        val module = newModule(backgroundScope)
-        val seen = mutableListOf<SetupModule.State>()
-        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { module.state.toList(seen) }
-        advanceUntilIdle()
+        val module = newModule(scope)
 
-        module.refresh()
-        advanceUntilIdle()
+        val collector = module.state.test(tag = "triggers", scope = scope)
+        collector.await { values, _ -> values.results().isNotEmpty() }
 
-        seen.map { it::class } shouldBe listOf(
+        runBlocking { module.refresh() }
+        collector.await { values, _ -> values.results().size >= 2 }
+
+        collector.latestValues.map { it::class } shouldBe listOf(
             InventorySetupModule.Loading::class,
             InventorySetupModule.Result::class,
             InventorySetupModule.Loading::class,
             InventorySetupModule.Result::class,
         )
+
+        runBlocking { collector.cancelAndJoin() }
     }
 
     @Test
-    fun `a probe cancelled by a refresh does not surface as a failure`() = runTest {
+    fun `a probe cancelled by a refresh does not surface as a failure`() {
         coEvery { pkgOps.queryPkgs(any(), any(), any()) } coAnswers { awaitCancellation() }
-        val module = newModule(backgroundScope)
-        val seen = mutableListOf<SetupModule.State>()
-        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { module.state.toList(seen) }
-        advanceUntilIdle()
+        val module = newModule(scope)
+
+        val collector = module.state.test(tag = "cancellation", scope = scope)
+        // The first probe hangs, so the module is stuck on Loading when the refresh cancels it.
+        collector.await { values, _ -> values.any { it is InventorySetupModule.Loading } }
 
         coEvery { pkgOps.queryPkgs(any(), any(), any()) } returns pkgs(context.packageName, "android")
-        module.refresh()
-        advanceUntilIdle()
+        runBlocking { module.refresh() }
+        collector.await { values, _ -> values.results().isNotEmpty() }
 
-        seen.results().none { it.access is InventoryAccess.ProbeFailed } shouldBe true
-        seen.results().last().access shouldBe InventoryAccess.Valid
+        collector.latestValues.results().none { it.access is InventoryAccess.ProbeFailed } shouldBe true
+        collector.latestValues.results().last().access shouldBe InventoryAccess.Valid
+
+        runBlocking { collector.cancelAndJoin() }
     }
 
     private fun newModule(appScope: CoroutineScope) = InventorySetupModule(


### PR DESCRIPTION
## What changed

When SD Maid cannot read the list of installed apps, the setup card now tells you which of two different things went wrong.

Until now both cases produced the same message: "The system returned an incomplete list of installed apps, even though the required permissions appear to be granted", with a button to open system settings. That is right when a device really does hand back a bogus app list, which some ROMs do. It was wrong whenever the request itself failed, because then the system returned nothing at all, and opening settings could not fix it. There was also no way to try again.

A failed request now gets its own message saying the request failed, and a Retry button instead of a settings trip. The bogus-list case is unchanged.

## Technical Context

- `InventorySetupModule` collapsed both situations into one `isAccessFaked` boolean: a non-valid verdict from the package-list sanity check, and `queryPkgs()` throwing. That boolean is replaced by a four-state sealed type, so the card can tell them apart. `isComplete` keeps its exact previous meaning, including that a failed probe leaves setup incomplete rather than pretending it is done.
- The state flow now emits `Loading` on every trigger rather than only at `onStart`. Without that, tapping Retry would leave the failure box and an enabled button on screen for the whole query, and repeated taps would keep restarting the probe.
- Everything between that `Loading` and the settled result is wrapped so it cannot propagate. An exception after `Loading` was emitted would kill the sharing coroutine with `Loading` stuck in the replay slot, leaving the card on a spinner that no refresh could ever clear. `queryPkgs()` was already guarded; the permission checks and `getSettingsIntent()` were not.
- `CancellationException` is rethrown ahead of the generic catch. It was previously swallowed and logged as an error, which happens routinely whenever a refresh supersedes an in-flight query.
- Known limitation, deliberately not addressed here: `PkgOps.queryPkgs()` calls `getInstalledPackages()` synchronously through the IPC funnel with no timeout. A wedged binder transaction therefore leaves the card loading rather than reaching the failed state, and Retry cannot recover from it. Bounding that safely means working out the funnel's permit lifecycle first, since abandoning a call that still holds its permit would wedge unrelated package operations.
- Worth close review: the `transformLatest` settle path in `InventorySetupModule`, and that the card's limitation branches can no longer render alongside the grant button.
