### PR TITLE
Fix: Widget "Lifetime" label came out as "lifespan" in most languages

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -415,7 +415,11 @@
     <string name="widget_home_description">Storage usage and one-tap cleanup</string>
     <string name="widget_home_storage_internal">Internal</string>
     <string name="widget_home_storage_external">External</string>
-    <string name="widget_home_freed_label">Lifetime: %1$s</string>
+    <!-- Home-screen widget: cumulative space freed since install. NOT a duration - do not
+         translate "total" as lifespan/service-life ("Lebensdauer", "duree de vie", "寿命").
+         Renders on one line with no wrapping in a narrow widget, so keep the label short;
+         dropping "freed" is fine if the language needs the room. %1$s is a byte size. -->
+    <string name="widget_home_freed_label">Total freed: %1$s</string>
     <string name="widget_home_clean_action">Clean</string>
     <string name="widget_home_working">Working…</string>
     <string name="widget_home_unavailable">Storage unavailable</string>


### PR DESCRIPTION
## What changed

The home-screen widget's info line that shows how much space SD Maid has freed since you installed it used to read "Lifetime: 1.2 GB". In English that works, but on its own the word is ambiguous, and in most languages it got translated as the *lifespan* sense: how long a device or battery lasts. German showed "Lebensdauer: 1,2 GB", which reads as "service life: 1.2 GB". Dutch, French, Swedish, Korean and around 55 other languages had the same problem.

The label now reads "Total freed: 1.2 GB", which says what the number actually is.

Translations are cleared and will land in a separate PR.

## Technical Context

- Root cause is the source string, not the translators. `Lifetime` is ambiguous read in isolation, which is how a translator sees it. About 60 of 73 locales picked the duration sense; the ones that got it right (zh-CN `累计`, pt `Total acumulado`, hr `Ukupno`) inferred the cumulative meaning from context rather than from the string.
- Rejected `Total:` on its own. The same widget renders storage as `12 GB / 64 GB` on the line directly above, so a bare "Total" reads as total capacity.
- No existing string was reusable. `stats_dash_body_size` carries the same `totalSpaceFreed` value but is a full sentence with plurals; `dashboard_hero_freed_headline` ("%1$s freed") is the last run's result, not the cumulative total, and carries no timeframe marker.
- The added translator comment is load-bearing for the retranslation, and also records a length budget. `freedLabel` renders at `maxLines = 1` with no wrapping, and `BrandingHeader` on the default 3x2 widget leaves roughly 100dp of text width at 11sp after the mascot and chrome padding, so long translations clip. That estimate is from character counts, not a measurement.
- Uploading the new source to Crowdin cleared the old translation in all 73 locales, so no locale is left showing stale copy once translations are pulled.