### PR TITLE
General: Show each app's icon as it gets scanned

### DIFF
--- a/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/AppIconExtraSlot.kt
+++ b/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/AppIconExtraSlot.kt
@@ -1,0 +1,24 @@
+package eu.darken.sdmse.common.coil
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.io.R as IoR
+
+/**
+ * Shared `ProgressOverlay` extra slot: renders a [Pkg] progress payload as its launcher icon.
+ *
+ * `Progress.Data.extra` is `Any?` because `app-common` sits below every module that knows what an app
+ * is. This is the single place that turns the payload back into something drawable; any other payload
+ * type renders nothing at all, leaving no reserved space behind.
+ */
+val AppIconExtraSlot: @Composable (extra: Any, modifier: Modifier) -> Unit = { extra, modifier ->
+    (extra as? Pkg)?.let {
+        AppIconImage(
+            pkg = it,
+            modifier = modifier,
+            placeholder = painterResource(IoR.drawable.ic_default_app_icon_24),
+        )
+    }
+}

--- a/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/AppIconImage.kt
+++ b/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/AppIconImage.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -28,6 +29,7 @@ fun AppIconImage(
     pkg: Pkg,
     modifier: Modifier = Modifier,
     contentDescription: String? = null,
+    placeholder: Painter? = null,
 ) {
     if (LocalInspectionMode.current) {
         val sample = LocalPreviewImageProvider.current?.appIcon(pkg)
@@ -54,5 +56,7 @@ fun AppIconImage(
         model = remember(pkg) { ImageRequest.Builder(context).data(pkg).build() },
         contentDescription = contentDescription,
         modifier = modifier,
+        placeholder = placeholder,
+        error = placeholder,
     )
 }

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/progress/ProgressOverlay.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/progress/ProgressOverlay.kt
@@ -64,9 +64,10 @@ private const val RING_SUB_STROKE_FACTOR = 0.024f
 // TextUnit.Unspecified and for em values).
 private val HERO_HEIGHT_FALLBACK = 52.dp
 
-// Must stay below the height of two bodySmall lines, otherwise the extra slot grows the block that
-// already reserves 2 lines, and the vertically centered column jumps when a payload appears.
-// bodySmall's lineHeight is 16sp, so two lines are ~32dp at fontScale 1.0 and ~27dp at the 0.85 minimum.
+// Must stay below the height of two bodySmall lines, otherwise the extra slot outgrows the two-line
+// reservation it sits in and drives the block height itself, so the vertically centered column jumps
+// when a payload appears. bodySmall's lineHeight is 16sp, so two lines are ~32dp at fontScale 1.0 and
+// ~27dp at the 0.85 minimum.
 private val PROGRESS_EXTRA_ICON_SIZE = 20.dp
 
 /** Which count supplies the hero number: sub-progress when it is determinate, else the overall count. */
@@ -212,29 +213,42 @@ private fun ProgressOverlayPanel(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(top = if (countText.isNullOrEmpty()) 0.dp else 12.dp),
                 )
-                Row(
+                // Height reservation and content are separated on purpose. The reservation is a glyph-free
+                // two-line Text in the same style, so the block's height is constant (no re-centering jump,
+                // same rationale as the note above) and exact at any density or fontScale without a
+                // hand-computed dp value. The real row is centered inside it, so the icon lines up with the
+                // label whether the label renders on one line or wraps to two.
+                Box(
                     modifier = Modifier.padding(top = 6.dp),
-                    verticalAlignment = Alignment.CenterVertically,
+                    contentAlignment = Alignment.Center,
                 ) {
-                    val extra = data.extra
-                    if (extraSlot != null && extra != null) {
-                        extraSlot(
-                            extra,
-                            Modifier
-                                .padding(end = 6.dp)
-                                .size(PROGRESS_EXTRA_ICON_SIZE),
-                        )
-                    }
                     Text(
-                        text = secondary,
+                        text = "",
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        textAlign = TextAlign.Center,
                         minLines = 2,
                         maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f, fill = false),
+                        modifier = Modifier.clearAndSetSemantics {},
                     )
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        val extra = data.extra
+                        if (extraSlot != null && extra != null) {
+                            extraSlot(
+                                extra,
+                                Modifier
+                                    .padding(end = 6.dp)
+                                    .size(PROGRESS_EXTRA_ICON_SIZE),
+                            )
+                        }
+                        Text(
+                            text = secondary,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f, fill = false),
+                        )
+                    }
                 }
             }
         }

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/progress/ProgressOverlay.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/progress/ProgressOverlay.kt
@@ -214,7 +214,7 @@ private fun ProgressOverlayPanel(
                 )
                 Row(
                     modifier = Modifier.padding(top = 6.dp),
-                    verticalAlignment = Alignment.Top,
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     val extra = data.extra
                     if (extraSlot != null && extra != null) {

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/progress/ProgressOverlay.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/progress/ProgressOverlay.kt
@@ -11,12 +11,16 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Android
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ProgressIndicatorDefaults
 import androidx.compose.material3.Text
@@ -60,6 +64,11 @@ private const val RING_SUB_STROKE_FACTOR = 0.024f
 // TextUnit.Unspecified and for em values).
 private val HERO_HEIGHT_FALLBACK = 52.dp
 
+// Must stay below the height of two bodySmall lines, otherwise the extra slot grows the block that
+// already reserves 2 lines, and the vertically centered column jumps when a payload appears.
+// bodySmall's lineHeight is 16sp, so two lines are ~32dp at fontScale 1.0 and ~27dp at the 0.85 minimum.
+private val PROGRESS_EXTRA_ICON_SIZE = 20.dp
+
 /** Which count supplies the hero number: sub-progress when it is determinate, else the overall count. */
 internal fun heroCount(count: Progress.Count, subCount: Progress.Count?): Progress.Count =
     if (subCount.determinateFraction() != null) subCount!! else count
@@ -76,6 +85,7 @@ internal fun heroCount(count: Progress.Count, subCount: Progress.Count?): Progre
 fun ProgressOverlay(
     data: Progress.Data?,
     modifier: Modifier = Modifier,
+    extraSlot: (@Composable (extra: Any, modifier: Modifier) -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
     // Fade the content out as the overlay fades in (over the same window) instead of snapping it to
@@ -104,7 +114,7 @@ fun ProgressOverlay(
             exit = ExitTransition.None,
         ) {
             val current = data ?: Progress.Data()
-            ProgressOverlayPanel(data = current)
+            ProgressOverlayPanel(data = current, extraSlot = extraSlot)
         }
     }
 }
@@ -113,6 +123,7 @@ fun ProgressOverlay(
 private fun ProgressOverlayPanel(
     data: Progress.Data,
     modifier: Modifier = Modifier,
+    extraSlot: (@Composable (extra: Any, modifier: Modifier) -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val primary = data.primary.get(context)
@@ -201,16 +212,30 @@ private fun ProgressOverlayPanel(
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.padding(top = if (countText.isNullOrEmpty()) 0.dp else 12.dp),
                 )
-                Text(
-                    text = secondary,
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    textAlign = TextAlign.Center,
-                    minLines = 2,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
+                Row(
                     modifier = Modifier.padding(top = 6.dp),
-                )
+                    verticalAlignment = Alignment.Top,
+                ) {
+                    val extra = data.extra
+                    if (extraSlot != null && extra != null) {
+                        extraSlot(
+                            extra,
+                            Modifier
+                                .padding(end = 6.dp)
+                                .size(PROGRESS_EXTRA_ICON_SIZE),
+                        )
+                    }
+                    Text(
+                        text = secondary,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        textAlign = TextAlign.Center,
+                        minLines = 2,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
+                    )
+                }
             }
         }
     }
@@ -287,6 +312,56 @@ private fun ProgressOverlayCounterPreview() {
             modifier = Modifier.fillMaxSize(),
         ) {}
     }
+}
+
+private val previewExtraSlot: @Composable (extra: Any, modifier: Modifier) -> Unit = { _, modifier ->
+    Icon(
+        imageVector = Icons.TwoTone.Android,
+        contentDescription = null,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun ProgressOverlayExtraSample(appName: String) {
+    PreviewWrapper {
+        ProgressOverlay(
+            data = Progress.Data(
+                primary = "Scanning apps".toCaString(),
+                secondary = appName.toCaString(),
+                count = Progress.Count.Percent(42, 100),
+                extra = "preview-payload",
+            ),
+            modifier = Modifier.fillMaxSize(),
+            extraSlot = previewExtraSlot,
+        ) {}
+    }
+}
+
+@Preview2
+@Composable
+private fun ProgressOverlayExtraPreview() {
+    ProgressOverlayExtraSample(appName = "SD Maid")
+}
+
+@Preview2
+@Composable
+private fun ProgressOverlayExtraLongLabelPreview() {
+    ProgressOverlayExtraSample(
+        appName = "Some Extremely Long Application Name That Keeps Going And Going Until It Ellipsizes",
+    )
+}
+
+@Preview(showBackground = true, fontScale = 0.85f)
+@Composable
+private fun ProgressOverlayExtraSmallFontPreview() {
+    ProgressOverlayExtraSample(appName = "SD Maid")
+}
+
+@Preview(showBackground = true, fontScale = 1.3f)
+@Composable
+private fun ProgressOverlayExtraLargeFontPreview() {
+    ProgressOverlayExtraSample(appName = "SD Maid")
 }
 
 @Preview(showBackground = true, heightDp = 200)

--- a/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
@@ -34,19 +34,28 @@ fun <T : Progress.Client> T.updateProgressPrimary(@StringRes primary: Int, varar
 }
 
 fun <T : Progress.Client> T.updateProgressSecondary(secondary: String) {
-    updateProgress { (it ?: Progress.Data()).copy(secondary = secondary.toCaString()) }
+    updateProgress { (it ?: Progress.Data()).copy(secondary = secondary.toCaString(), extra = null) }
 }
 
 fun <T : Progress.Client> T.updateProgressSecondary(resolv: (Context) -> String) {
-    updateProgress { (it ?: Progress.Data()).copy(secondary = caString { resolv(this) }) }
+    updateProgress { (it ?: Progress.Data()).copy(secondary = caString { resolv(this) }, extra = null) }
 }
 
 fun <T : Progress.Client> T.updateProgressSecondary(secondary: CaString = CaString.EMPTY) {
-    updateProgress { (it ?: Progress.Data()).copy(secondary = secondary) }
+    updateProgress { (it ?: Progress.Data()).copy(secondary = secondary, extra = null) }
 }
 
 fun <T : Progress.Client> T.updateProgressSecondary(@StringRes secondary: Int, vararg args: Any) {
-    updateProgress { (it ?: Progress.Data()).copy(secondary = (secondary to args).toCaString()) }
+    updateProgress { (it ?: Progress.Data()).copy(secondary = (secondary to args).toCaString(), extra = null) }
+}
+
+/** Sets the item label and its payload in one update, so the UI can never pair a new label with a stale payload. */
+fun <T : Progress.Client> T.updateProgressSecondary(secondary: CaString, extra: Any?) {
+    updateProgress { (it ?: Progress.Data()).copy(secondary = secondary, extra = extra) }
+}
+
+fun <T : Progress.Client> T.updateProgressSecondary(secondary: String, extra: Any?) {
+    updateProgress { (it ?: Progress.Data()).copy(secondary = secondary.toCaString(), extra = extra) }
 }
 
 fun <T : Progress.Client> T.updateProgressCount(count: Progress.Count) {

--- a/app-common/src/test/java/eu/darken/sdmse/common/progress/ProgressExtensionsTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/progress/ProgressExtensionsTest.kt
@@ -1,0 +1,113 @@
+package eu.darken.sdmse.common.progress
+
+import android.content.Context
+import eu.darken.sdmse.common.ca.toCaString
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class ProgressExtensionsTest : BaseTest() {
+
+    private val context = mockk<Context>(relaxed = true)
+
+    /** Captures every intermediate [Progress.Data], so a torn two-step write shows up as two emissions. */
+    private class RecordingClient : Progress.Client {
+        val emissions = mutableListOf<Progress.Data?>()
+        private var current: Progress.Data? = null
+
+        override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {
+            current = update(current)
+            emissions.add(current)
+        }
+    }
+
+    @Test
+    fun `the atomic CaString overload writes label and payload in one emission`() {
+        val payload = Any()
+        val client = RecordingClient()
+
+        client.updateProgressSecondary("Some app".toCaString(), extra = payload)
+
+        client.emissions.size shouldBe 1
+        client.emissions.single()!!.secondary.get(context) shouldBe "Some app"
+        client.emissions.single()!!.extra shouldBe payload
+    }
+
+    @Test
+    fun `the atomic String overload writes label and payload in one emission`() {
+        val payload = Any()
+        val client = RecordingClient()
+
+        client.updateProgressSecondary("Some app", extra = payload)
+
+        client.emissions.size shouldBe 1
+        client.emissions.single()!!.secondary.get(context) shouldBe "Some app"
+        client.emissions.single()!!.extra shouldBe payload
+    }
+
+    @Test
+    fun `the atomic overloads can clear the payload`() {
+        val client = RecordingClient()
+
+        client.updateProgressSecondary("Some app".toCaString(), extra = Any())
+        client.updateProgressSecondary("Other app".toCaString(), extra = null)
+
+        client.emissions.last()!!.extra shouldBe null
+    }
+
+    @Test
+    fun `the String overload clears a previous payload`() {
+        val client = RecordingClient()
+
+        client.updateProgressSecondary("Some app".toCaString(), extra = Any())
+        client.updateProgressSecondary("Scanning media files")
+
+        client.emissions.last()!!.secondary.get(context) shouldBe "Scanning media files"
+        client.emissions.last()!!.extra shouldBe null
+    }
+
+    @Test
+    fun `the resolver overload clears a previous payload`() {
+        val client = RecordingClient()
+
+        client.updateProgressSecondary("Some app".toCaString(), extra = Any())
+        client.updateProgressSecondary { "Scanning media files" }
+
+        client.emissions.last()!!.secondary.get(context) shouldBe "Scanning media files"
+        client.emissions.last()!!.extra shouldBe null
+    }
+
+    @Test
+    fun `the CaString overload clears a previous payload`() {
+        val client = RecordingClient()
+
+        client.updateProgressSecondary("Some app".toCaString(), extra = Any())
+        client.updateProgressSecondary("Scanning media files".toCaString())
+
+        client.emissions.last()!!.secondary.get(context) shouldBe "Scanning media files"
+        client.emissions.last()!!.extra shouldBe null
+    }
+
+    @Test
+    fun `the string resource overload clears a previous payload`() {
+        val client = RecordingClient()
+
+        client.updateProgressSecondary("Some app".toCaString(), extra = Any())
+        client.updateProgressSecondary(42, "arg")
+
+        client.emissions.last()!!.extra shouldBe null
+    }
+
+    @Test
+    fun `updating the phase label leaves the payload untouched`() {
+        val payload = Any()
+        val client = RecordingClient()
+
+        client.updateProgressSecondary("Some app".toCaString(), extra = payload)
+        client.updateProgressPrimary("Scanning apps")
+
+        client.emissions.last()!!.primary.get(context) shouldBe "Scanning apps"
+        client.emissions.last()!!.extra shouldBe payload
+    }
+}

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/storage/StorageScanner.kt
@@ -297,7 +297,7 @@ class StorageScanner @Inject constructor(
 
         val pkgStats = targetPkgs
             .map { pkg ->
-                updateProgressSecondary(pkg.label ?: pkg.packageName.toCaString())
+                updateProgressSecondary(pkg.label ?: pkg.packageName.toCaString(), extra = pkg)
 
                 // TODO This does not include nested markers, e.g. Android/something or DCIM/something
                 // Supporting this is not trivial:

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/app/AppDetailsScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/app/AppDetailsScreen.kt
@@ -31,6 +31,7 @@ import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.ui.AppDetailsRoute
 import eu.darken.sdmse.analyzer.ui.storage.app.items.AppDetailsGroupRow
 import eu.darken.sdmse.analyzer.ui.storage.app.items.AppDetailsHeaderCard
+import eu.darken.sdmse.common.coil.AppIconExtraSlot
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
 import eu.darken.sdmse.common.compose.layout.plusBottom
 import eu.darken.sdmse.common.compose.preview.Preview2
@@ -151,6 +152,7 @@ internal fun AppDetailsScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(paddingValues),
+                    extraSlot = AppIconExtraSlot,
                 ) {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/apps/AppsScreen.kt
@@ -41,6 +41,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.ui.AppsRoute
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.coil.AppIconExtraSlot
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
 import eu.darken.sdmse.common.compose.layout.plusBottom
 import eu.darken.sdmse.common.compose.preview.Preview2
@@ -160,6 +161,7 @@ internal fun AppsScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
+            extraSlot = AppIconExtraSlot,
         ) {
             LazyVerticalGrid(
                 columns = GridCells.Fixed(context.getSpanCount(widthDp = 360)),

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentScreen.kt
@@ -52,6 +52,7 @@ import eu.darken.sdmse.analyzer.ui.storage.preview.previewDeviceStorage
 import eu.darken.sdmse.common.ByteFormatter
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.coil.AppIconExtraSlot
 import eu.darken.sdmse.common.compose.dialog.SdmConfirmDialog
 import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
 import eu.darken.sdmse.common.compose.icons.SdmIcons
@@ -407,6 +408,7 @@ internal fun ContentScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(paddingValues),
+                    extraSlot = AppIconExtraSlot,
                 ) {
                     if (s.progress == null && s.items != null) {
                         when (s.layoutMode) {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/device/DeviceStorageScreen.kt
@@ -34,6 +34,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.ui.storage.device.tour.AnalyzerStorageTour
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.coil.AppIconExtraSlot
 import eu.darken.sdmse.common.compose.layout.ScrollAwareFab
 import eu.darken.sdmse.common.compose.layout.SdmListDefaults
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
@@ -133,6 +134,7 @@ internal fun DeviceStorageScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
+            extraSlot = AppIconExtraSlot,
         ) {
             LazyVerticalGrid(
                 columns = GridCells.Fixed(context.getSpanCount(widthDp = 360)),

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentScreen.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/storage/StorageContentScreen.kt
@@ -35,6 +35,7 @@ import eu.darken.sdmse.analyzer.ui.storage.storage.categories.AppCategoryCard
 import eu.darken.sdmse.analyzer.ui.storage.storage.categories.MediaCategoryCard
 import eu.darken.sdmse.analyzer.ui.storage.storage.categories.OtherUsersCategoryCard
 import eu.darken.sdmse.analyzer.ui.storage.storage.categories.SystemCategoryCard
+import eu.darken.sdmse.common.coil.AppIconExtraSlot
 import eu.darken.sdmse.common.compose.layout.ScrollAwareFab
 import eu.darken.sdmse.common.compose.layout.SdmListDefaults
 import eu.darken.sdmse.common.compose.layout.SdmTooltipIconButton
@@ -164,6 +165,7 @@ internal fun StorageContentScreen(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(paddingValues),
+                    extraSlot = AppIconExtraSlot,
                 ) {
                     LazyVerticalGrid(
                         columns = GridCells.Fixed(context.getSpanCount()),

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -323,7 +323,7 @@ class AppCleaner @Inject constructor(
 
         internalData.value = snapshot.copy(
             junks = snapshot.junks.map { appJunk ->
-                updateProgressSecondary(appJunk.label)
+                updateProgressSecondary(appJunk.label, extra = appJunk.pkg)
                 // Remove all files we deleted or children of deleted files
 
                 val deletedInaccessible = mutableSetOf<ExpendablesFilter.Match>()

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
@@ -218,7 +218,7 @@ class AppScanner @Inject constructor(
         updateProgressCount(Progress.Count.Percent(pkgsToCheck.size))
 
         for (pkg in pkgsToCheck) {
-            updateProgressSecondary(pkg.label?.get(context) ?: pkg.packageName)
+            updateProgressSecondary(pkg.label?.get(context) ?: pkg.packageName, extra = pkg)
             log(TAG) { "Generating search paths for ${pkg.installId}" }
 
             val interestingPaths = mutableSetOf<AreaInfo>()
@@ -538,7 +538,7 @@ class AppScanner @Inject constructor(
 
         return targets
             .mapNotNull {
-                updateProgressSecondary(it.label)
+                updateProgressSecondary(it.label, extra = it)
                 inaccessibleCacheProvider.determineCache(it).also { increaseProgress() }
             }
             .filter { !it.isEmpty }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsScreen.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsScreen.kt
@@ -39,6 +39,7 @@ import eu.darken.sdmse.appcleaner.ui.AppJunkDetailsRoute
 import eu.darken.sdmse.appcleaner.ui.details.page.AppJunkPage
 import eu.darken.sdmse.appcleaner.ui.labelRes
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.coil.AppIconExtraSlot
 import eu.darken.sdmse.common.compose.dialog.SdmConfirmDialog
 import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
 import eu.darken.sdmse.common.compose.layout.SdmDeleteAction
@@ -283,6 +284,7 @@ internal fun AppJunkDetailsScreen(
             ProgressOverlay(
                 data = state.progress,
                 modifier = Modifier.fillMaxSize(),
+                extraSlot = AppIconExtraSlot,
             ) {
                 if (items.isEmpty()) {
                     SdmEmptyState()

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListScreen.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListScreen.kt
@@ -36,6 +36,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.sdmse.appcleaner.R
 import eu.darken.sdmse.appcleaner.ui.list.items.AppCleanerListRow
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.coil.AppIconExtraSlot
 import eu.darken.sdmse.common.compose.dialog.SdmConfirmDialog
 import eu.darken.sdmse.common.compose.dialog.SdmDialogAction
 import eu.darken.sdmse.common.compose.layout.SdmDeleteAction
@@ -267,6 +268,7 @@ internal fun AppCleanerListScreen(
             ProgressOverlay(
                 data = state.progress,
                 modifier = Modifier.fillMaxSize(),
+                extraSlot = AppIconExtraSlot,
             ) {
                 when {
                     rows == null -> SdmLoadingState()


### PR DESCRIPTION
## What changed

When SD Maid works through your apps, in the Storage Analyzer and in AppCleaner, the progress ring now shows each app's icon next to its name. You can see at a glance which app is being worked on instead of reading the name alone.

## Technical Context

- `Progress.Data.extra` already existed but was never set anywhere in the codebase. It now carries the `Pkg` for the current item. `ProgressOverlay` gained an optional `extraSlot`, and `app-common-coil` supplies the single `AppIconExtraSlot` that turns that payload into an `AppIconImage`. A CompositionLocal was considered and rejected: the explicit slot keeps the one `as? Pkg` cast in a single place without resolving anything implicitly at runtime.
- `extra` is scoped to `secondary` (the item label) rather than `primary` (the phase label), and both fields are written in a single `copy`. Two reasons: `throttleLatest` emits and then sleeps, so a separate payload write can be observed after the label alone and pair a new app's name with the previous app's icon; and the Analyzer's app phase ends with a *secondary* update in `StorageScanner`, while the only primary update for the phase that follows sits behind a nullable `storageDir?.let` that can be skipped entirely.
- `AppIconImage` gained an optional `placeholder`, defaulting to `null` so existing call sites keep their current behavior. Icon loading runs through `IPCFunnel` and is genuinely async, while the overlay publishes as often as every 50ms, so the loading state needed defining rather than drawing nothing.
- The icon sits inside the block that already reserves two lines for the item label, and its 20dp size stays below the height of two `bodySmall` lines. That is what keeps the vertically centered ring contents from shifting when a payload appears or disappears, and it is the part most worth a close look in review.
- Layout is a plain `Row`, so the icon sits on the leading edge and mirrors correctly under RTL rather than being pinned left.
