### PR TITLE
Analyzer: Update storage sizes immediately after deleting files

### DIFF
--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -32,6 +32,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.MediaStoreTool
 import eu.darken.sdmse.common.files.delete
@@ -55,6 +56,7 @@ import eu.darken.sdmse.setup.isComplete
 import eu.darken.sdmse.stats.core.SpaceTracker
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -66,6 +68,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.minutes
@@ -270,20 +273,53 @@ class Analyzer @Inject constructor(
             )
         }
 
-        task.targets
-            .filterDistinctRoots()
-            .forEach { target ->
-                log(TAG) { "Deleting $target" }
-                updateProgressSecondary(target.userReadablePath)
-                target.delete(gatewaySwitch, recursive = true)
-                (target as? LocalPath)?.let { mediaStoreTool.notifyDeleted(it) }
+        // Track what actually made it to the filesystem: a failure or cancellation part way through must
+        // still publish the removals that already happened, otherwise the UI keeps listing deleted files
+        // with stale sizes until the next manual refresh.
+        val deletedTargets = mutableSetOf<APath>()
+        var freedSpace = 0L
+        try {
+            task.targets
+                .filterDistinctRoots()
+                .forEach { target ->
+                    log(TAG) { "Deleting $target" }
+                    updateProgressSecondary(target.userReadablePath)
+                    target.delete(gatewaySwitch, recursive = true)
+                    deletedTargets.add(target)
+                    (target as? LocalPath)?.let { mediaStoreTool.notifyDeleted(it) }
+                }
+        } finally {
+            // NonCancellable: applyDeletion() suspends on the authoritative free-space re-read, which
+            // would be skipped on the cancellation path. Costs a few binder calls before a cancelled
+            // delete reports completion.
+            if (deletedTargets.isNotEmpty()) withContext(NonCancellable) {
+                freedSpace = applyDeletion(task, oldCategory, oldGroup, oldPkg, deletedTargets)
+                mediaStoreTool.flush()
             }
+        }
 
+        return ContentDeleteTask.Result(
+            affectedSpace = freedSpace,
+            affectedPaths = task.targets,
+        )
+    }
+
+    /**
+     * Publishes the post-delete state for [deletedTargets] as one atomic update: shrunken content group,
+     * refreshed device free space and a recomputed system residual. Returns the freed space that stats reports.
+     */
+    private suspend fun applyDeletion(
+        task: ContentDeleteTask,
+        oldCategory: ContentCategory,
+        oldGroup: ContentGroup,
+        oldPkg: AppCategory.PkgStat?,
+        deletedTargets: Set<APath>,
+    ): Long {
         var freedSpace = 0L
         val newContents = oldGroup.contents
             .toFlatContent()
             .filter { item ->
-                val deleted = task.targets.any { it.isAncestorOf(item.path) || it.matches(item.path) }
+                val deleted = deletedTargets.any { it.isAncestorOf(item.path) || it.matches(item.path) }
                 if (deleted) freedSpace += item.itemSize ?: 0L
                 !deleted
             }
@@ -319,20 +355,67 @@ class Analyzer @Inject constructor(
             }
         }
 
+        // The authoritative number: what the filesystem reports as free now. Called plainly, not through
+        // withProgress(), so it doesn't disturb the delete's own progress.
+        val refreshedFree: Long? = try {
+            deviceScanner.get().scan().firstOrNull { it.id == task.storageId }?.spaceFree
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "applyDeletion(): free-space re-read failed, using accounted delta: ${e.asLog()}" }
+            null
+        }
+
+        // Fallback uses the group-size delta, not the flat `freedSpace` sum, so the storage card moves by
+        // exactly what the category card moved by. The two differ for entries whose ContentItem.size is null
+        // but whose itemSize is not (symlinks and other non-file/dir types).
+        val groupSizeDelta = oldGroup.groupSize - newGroup.groupSize
+
         coreState.update { state ->
+            val newStorage = state.storages.singleOrNull { it.id == task.storageId }?.let { oldStorage ->
+                val newFree = refreshedFree ?: run {
+                    // Clamped against remaining capacity headroom, so the addition can neither overflow
+                    // Long nor push free space beyond the storage's capacity.
+                    val headroom = (oldStorage.spaceCapacity - oldStorage.spaceFree).coerceAtLeast(0L)
+                    oldStorage.spaceFree + groupSizeDelta.coerceIn(0L, headroom)
+                }
+                oldStorage.copy(spaceFree = newFree)
+            }
+
+            val updatedCategories = state.categories[task.storageId]!!.minus(oldCategory).plus(newCategory)
+
+            // SystemCategory.spaceUsedOverride is a scan-time residual (used bytes minus apps/media/other
+            // users), so it goes stale the moment the device's used bytes change.
+            val finalCategories = when {
+                newStorage == null -> updatedCategories
+                else -> updatedCategories.map { category ->
+                    if (category !is SystemCategory || category.spaceUsedOverride == null) return@map category
+                    category.copy(
+                        spaceUsedOverride = StorageScanner.computeResidual(
+                            spaceUsed = newStorage.spaceUsed,
+                            apps = updatedCategories.filterIsInstance<AppCategory>().sumOf { it.spaceUsed },
+                            media = updatedCategories.filterIsInstance<MediaCategory>().sumOf { it.spaceUsed },
+                            otherUsers = updatedCategories
+                                .filterIsInstance<OtherUsersCategory>()
+                                .sumOf { it.spaceUsed },
+                        ),
+                    )
+                }
+            }
+
             state.copy(
+                storages = when {
+                    // A delete never adds or removes storages, it only refreshes the target's free space.
+                    newStorage == null -> state.storages
+                    else -> state.storages.map { if (it.id == newStorage.id) newStorage else it }.toSet()
+                },
                 categories = state.categories.mutate {
-                    this[task.storageId] = this[task.storageId]!!.minus(oldCategory).plus(newCategory)
+                    this[task.storageId] = finalCategories
                 },
             )
         }
 
-        mediaStoreTool.flush()
-
-        return ContentDeleteTask.Result(
-            affectedSpace = freedSpace,
-            affectedPaths = task.targets,
-        )
+        return freedSpace
     }
 
     private suspend fun deepScanApp(task: AppDeepScanTask): AppDeepScanTask.Result {

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -355,10 +355,10 @@ class Analyzer @Inject constructor(
             }
         }
 
-        // The authoritative number: what the filesystem reports as free now. Called plainly, not through
-        // withProgress(), so it doesn't disturb the delete's own progress.
-        val refreshedFree: Long? = try {
-            deviceScanner.get().scan().firstOrNull { it.id == task.storageId }?.spaceFree
+        // The authoritative numbers: what the filesystem reports as capacity and free space now. Called
+        // plainly, not through withProgress(), so it doesn't disturb the delete's own progress.
+        val refreshed: DeviceStorage? = try {
+            deviceScanner.get().scan().firstOrNull { it.id == task.storageId }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -373,13 +373,26 @@ class Analyzer @Inject constructor(
 
         coreState.update { state ->
             val newStorage = state.storages.singleOrNull { it.id == task.storageId }?.let { oldStorage ->
-                val newFree = refreshedFree ?: run {
-                    // Clamped against remaining capacity headroom, so the addition can neither overflow
-                    // Long nor push free space beyond the storage's capacity.
-                    val headroom = (oldStorage.spaceCapacity - oldStorage.spaceFree).coerceAtLeast(0L)
-                    oldStorage.spaceFree + groupSizeDelta.coerceIn(0L, headroom)
+                when {
+                    // spaceUsed is capacity minus free, so both have to come from the same measurement.
+                    // DeviceStorageScanner can fall back from StorageStatsManager2 to the File API between
+                    // two scans, and those measure different things (whole disk vs data partition) - pairing
+                    // a refreshed free value with the cached capacity would move used space by gigabytes.
+                    // setupIncomplete stays as cached: it says whether the published categories may be
+                    // permission-limited, and a space re-read doesn't rebuild them. scanStorageDevices()
+                    // owns that transition.
+                    refreshed != null -> oldStorage.copy(
+                        spaceCapacity = refreshed.spaceCapacity,
+                        spaceFree = refreshed.spaceFree,
+                    )
+
+                    else -> {
+                        // Clamped against remaining capacity headroom, so the addition can neither overflow
+                        // Long nor push free space beyond the storage's capacity.
+                        val headroom = (oldStorage.spaceCapacity - oldStorage.spaceFree).coerceAtLeast(0L)
+                        oldStorage.copy(spaceFree = oldStorage.spaceFree + groupSizeDelta.coerceIn(0L, headroom))
+                    }
                 }
-                oldStorage.copy(spaceFree = newFree)
             }
 
             val updatedCategories = state.categories[task.storageId]!!.minus(oldCategory).plus(newCategory)

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/Analyzer.kt
@@ -60,10 +60,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeoutOrNull
@@ -95,13 +95,12 @@ class Analyzer @Inject constructor(
         progressPub.value = update(progressPub.value)
     }
 
-    private val storageDevices = MutableStateFlow(emptySet<DeviceStorage>())
-    private val storageCategories = MutableStateFlow(emptyMap<StorageId, Collection<ContentCategory>>())
-    val data: Flow<Data> = combine(
-        storageDevices,
-        storageCategories,
-    ) { storages, categories ->
-        val allGroups = categories
+    // Storages and categories share a single state holder: a delete publishes new category sizes, a new
+    // device free-space value and a recomputed system residual together. Two flows joined by `combine`
+    // would expose an intermediate frame carrying some of those and not the others.
+    private val coreState = MutableStateFlow(CoreState())
+    val data: Flow<Data> = coreState.map { core ->
+        val allGroups = core.categories
             .map { category ->
                 category.value
                     .map { it.groups }
@@ -113,8 +112,8 @@ class Analyzer @Inject constructor(
             .toMap()
 
         Data(
-            storages = storages,
-            categories = categories,
+            storages = core.storages,
+            categories = core.categories,
             groups = allGroups
         )
     }
@@ -141,7 +140,7 @@ class Analyzer @Inject constructor(
         // the devices cleared (scan start empties them) — either way the condition turns false.
         combine(
             storageSetupModule.state.map { it.isComplete }.distinctUntilChanged(),
-            storageDevices,
+            coreState.map { it.storages }.distinctUntilChanged(),
         ) { setupComplete, devices ->
             setupComplete && devices.any { it.setupIncomplete }
         }
@@ -188,13 +187,12 @@ class Analyzer @Inject constructor(
     private suspend fun scanStorageDevices(task: DeviceStorageScanTask): DeviceStorageScanTask.Result {
         log(TAG, VERBOSE) { "scanStorageDevices(): $task" }
 
-        storageDevices.value = emptySet()
-        storageCategories.value = emptyMap()
+        coreState.update { CoreState() }
 
         val scanner = deviceScanner.get()
         val storages = scanner.withProgress(this) { scan() }
 
-        storageDevices.value = storages
+        coreState.update { it.copy(storages = storages) }
         spaceTracker.recordSnapshot(storages.map {
             SpaceTracker.StorageSnapshot(
                 storageId = it.id.externalId.toString(),
@@ -212,7 +210,7 @@ class Analyzer @Inject constructor(
         // Inventory completeness is checked per-category inside StorageScanner so that media/system
         // scans still succeed when the app inventory is unavailable (e.g. Huawei TAF sandbox).
 
-        val target = storageDevices.value.singleOrNull { it.id == task.target }
+        val target = coreState.value.storages.singleOrNull { it.id == task.target }
             ?: throw IllegalStateException("Couldn't find ${task.target}")
 
         val scanner = storageScanner.get()
@@ -224,8 +222,12 @@ class Analyzer @Inject constructor(
         val stop = System.currentTimeMillis()
         log(TAG) { "scanStorageContents() took ${stop - start}ms" }
 
-        storageCategories.value = storageCategories.value.mutate {
-            this[target.id] = categories
+        coreState.update { state ->
+            state.copy(
+                categories = state.categories.mutate {
+                    this[target.id] = categories
+                },
+            )
         }
 
         return DeviceStorageScanTask.Result(itemCount = 0)
@@ -234,7 +236,7 @@ class Analyzer @Inject constructor(
     private suspend fun deleteContent(task: ContentDeleteTask): ContentDeleteTask.Result {
         log(TAG, VERBOSE) { "deleteContent(): $task" }
 
-        val oldCategory: ContentCategory = storageCategories.value[task.storageId]
+        val oldCategory: ContentCategory = coreState.value.categories[task.storageId]
             ?.singleOrNull { it.ownsGroup(task.groupId) }
             ?: throw IllegalStateException("Can't find category and group for ${task.groupId}")
         val oldGroup = oldCategory.groups.single { it.id == task.groupId }
@@ -317,8 +319,12 @@ class Analyzer @Inject constructor(
             }
         }
 
-        storageCategories.value = storageCategories.value.mutate {
-            this[task.storageId] = this[task.storageId]!!.minus(oldCategory).plus(newCategory)
+        coreState.update { state ->
+            state.copy(
+                categories = state.categories.mutate {
+                    this[task.storageId] = this[task.storageId]!!.minus(oldCategory).plus(newCategory)
+                },
+            )
         }
 
         mediaStoreTool.flush()
@@ -337,9 +343,9 @@ class Analyzer @Inject constructor(
             throw IncompleteSetupException(SetupModule.Type.INVENTORY)
         }
 
-        val targetStorage = storageDevices.value.singleOrNull { it.id == task.storageId }
+        val targetStorage = coreState.value.storages.singleOrNull { it.id == task.storageId }
             ?: throw IllegalStateException("Couldn't find ${task.storageId}")
-        val targetCategory = storageCategories.first()[targetStorage.id]!!.filterIsInstance<AppCategory>().single()
+        val targetCategory = coreState.value.categories[targetStorage.id]!!.filterIsInstance<AppCategory>().single()
         val targetApp = targetCategory.pkgStats[task.installId]!!
 
         val start = System.currentTimeMillis()
@@ -356,11 +362,15 @@ class Analyzer @Inject constructor(
             return AppDeepScanTask.Result(false)
         }
 
-        storageCategories.value = storageCategories.value.mutate {
-            this[targetStorage.id] = this[targetStorage.id]!!.map { category ->
-                if (category !is AppCategory) return@map category
-                category.copy(pkgStats = category.pkgStats.mutate { replace(task.installId, updatedApp) })
-            }
+        coreState.update { state ->
+            state.copy(
+                categories = state.categories.mutate {
+                    this[targetStorage.id] = this[targetStorage.id]!!.map { category ->
+                        if (category !is AppCategory) return@map category
+                        category.copy(pkgStats = category.pkgStats.mutate { replace(task.installId, updatedApp) })
+                    }
+                },
+            )
         }
 
         return AppDeepScanTask.Result(true)
@@ -369,9 +379,9 @@ class Analyzer @Inject constructor(
     private suspend fun deepScanSystem(task: SystemDeepScanTask): SystemDeepScanTask.Result {
         log(TAG, VERBOSE) { "deepScanSystem(): $task" }
 
-        val targetStorage = storageDevices.value.singleOrNull { it.id == task.storageId }
+        val targetStorage = coreState.value.storages.singleOrNull { it.id == task.storageId }
             ?: throw IllegalStateException("Couldn't find ${task.storageId}")
-        val existingCategory = storageCategories.first()[targetStorage.id]
+        val existingCategory = coreState.value.categories[targetStorage.id]
             ?.filterIsInstance<SystemCategory>()
             ?.singleOrNull()
             ?: throw IllegalStateException("No SystemCategory for ${task.storageId}")
@@ -395,15 +405,24 @@ class Analyzer @Inject constructor(
             return SystemDeepScanTask.Result(false)
         }
 
-        storageCategories.value = storageCategories.value.mutate {
-            this[targetStorage.id] = this[targetStorage.id]!!.map { category ->
-                if (category !is SystemCategory) return@map category
-                updatedCategory
-            }
+        coreState.update { state ->
+            state.copy(
+                categories = state.categories.mutate {
+                    this[targetStorage.id] = this[targetStorage.id]!!.map { category ->
+                        if (category !is SystemCategory) return@map category
+                        updatedCategory
+                    }
+                },
+            )
         }
 
         return SystemDeepScanTask.Result(true)
     }
+
+    internal data class CoreState(
+        val storages: Set<DeviceStorage> = emptySet(),
+        val categories: Map<StorageId, Collection<ContentCategory>> = emptyMap(),
+    )
 
     data class State(
         val data: Data,

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModel.kt
@@ -44,6 +44,7 @@ import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
 import eu.darken.sdmse.exclusion.ui.PathExclusionEditorRoute
 import eu.darken.sdmse.exclusion.ui.editor.path.PathExclusionEditorOptions
+import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -66,6 +67,7 @@ class ContentViewModel @Inject constructor(
     private val filterEditorOptionsCreator: FilterEditorOptionsCreator,
     private val upgradeRepo: UpgradeRepo,
     private val swiperSessionCreator: SwiperSessionCreator,
+    private val taskSubmitter: TaskSubmitter,
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
 
     private val routeFlow = MutableStateFlow<ContentRoute?>(null)
@@ -278,7 +280,9 @@ class ContentViewModel @Inject constructor(
             targetPkg = route.installId,
             targets = targets,
         )
-        val result = analyzer.submit(task) as ContentDeleteTask.Result
+        // Routed through the TaskSubmitter, not the Analyzer directly: ContentDeleteTask is Reportable,
+        // and only the task manager reports completed tasks to the stats repo.
+        val result = taskSubmitter.submit(task) as ContentDeleteTask.Result
         events.emit(Event.ContentDeleted(result.affectedCount, result.affectedSpace))
     }
 

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteGuardTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteGuardTest.kt
@@ -72,10 +72,11 @@ class AnalyzerDeleteGuardTest : BaseTest() {
             spaceTracker = mockk(relaxed = true),
         )
 
-        val field = Analyzer::class.java.getDeclaredField("storageCategories").apply { isAccessible = true }
+        val field = Analyzer::class.java.getDeclaredField("coreState").apply { isAccessible = true }
         @Suppress("UNCHECKED_CAST")
-        (field.get(analyzer) as MutableStateFlow<Map<StorageId, Collection<ContentCategory>>>).value =
-            mapOf(storageId to categories)
+        (field.get(analyzer) as MutableStateFlow<Analyzer.CoreState>).value = Analyzer.CoreState(
+            categories = mapOf(storageId to categories),
+        )
 
         return analyzer
     }

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteSpaceTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteSpaceTest.kt
@@ -297,6 +297,36 @@ class AnalyzerDeleteSpaceTest : BaseTest() {
     }
 
     @Test
+    fun `a re-read that also moved the capacity is applied as one pair`() = runTest2 {
+        val gb = 1_024L * 1_024L * 1_024L
+        val photo = path("storage", "emulated", "0", "DCIM", "img.jpg")
+        val mediaGroup = ContentGroup(label = "Media".toCaString(), contents = setOf(file(photo, gb)))
+        val systemGroup = ContentGroup(label = "System".toCaString())
+        val analyzer = buildAnalyzer(
+            storages = setOf(storage(capacity = 128 * gb, free = 40 * gb)),
+            categories = mapOf(
+                storageId to setOf(
+                    MediaCategory(storageId, setOf(mediaGroup)),
+                    // Scan-time residual: 88 GB used - 1 GB media.
+                    SystemCategory(storageId, setOf(systemGroup), spaceUsedOverride = 87 * gb),
+                ),
+            ),
+        )
+        // The scanner fell back to a different source (whole disk vs data partition), so the capacity
+        // moved too. Taking only spaceFree from it would leave 128 GB - 45 GB = 83 GB used, i.e. MORE
+        // used space than before the delete.
+        coEvery { deviceScanner.scan() } returns setOf(storage(capacity = 110 * gb, free = 45 * gb))
+
+        analyzer.submit(deleteTask(mediaGroup, setOf(photo)))
+
+        analyzer.currentStorage().spaceCapacity shouldBe 110 * gb
+        analyzer.currentStorage().spaceFree shouldBe 45 * gb
+        analyzer.currentStorage().spaceUsed shouldBe 65 * gb
+        // The residual derives from that same pair, not from the cached capacity.
+        analyzer.currentCategory<SystemCategory>().spaceUsedOverride shouldBe 65 * gb
+    }
+
+    @Test
     fun `a delete that frees nothing leaves the storage entry unchanged`() = runTest2 {
         val unknown = path("storage", "emulated", "0", "DCIM", "unknown")
         val group = ContentGroup(

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteSpaceTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/core/AnalyzerDeleteSpaceTest.kt
@@ -1,0 +1,362 @@
+package eu.darken.sdmse.analyzer.core
+
+import eu.darken.sdmse.analyzer.core.content.ContentDeleteTask
+import eu.darken.sdmse.analyzer.core.content.ContentGroup
+import eu.darken.sdmse.analyzer.core.content.ContentItem
+import eu.darken.sdmse.analyzer.core.device.DeviceStorage
+import eu.darken.sdmse.analyzer.core.device.DeviceStorageScanner
+import eu.darken.sdmse.analyzer.core.storage.categories.AppCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.ContentCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.MediaCategory
+import eu.darken.sdmse.analyzer.core.storage.categories.SystemCategory
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.MediaStoreTool
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.storage.StorageId
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.setup.SetupModule
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.io.IOException
+import java.util.UUID
+import javax.inject.Provider
+
+/**
+ * Deleting through the Analyzer used to update the content categories only, leaving
+ * [DeviceStorage.spaceFree] (and everything derived from it: the storage card, each category's
+ * percentage, the system residual) at its last-scan value until the user hit refresh.
+ *
+ * These tests pin what a delete publishes: the re-read free space, an arithmetic fallback when that
+ * read fails, a recomputed system residual, and - for a delete that dies part way through - the
+ * removals that already happened.
+ */
+class AnalyzerDeleteSpaceTest : BaseTest() {
+
+    // The Analyzer's sharedResource + init collector need a long-lived scope.
+    private val gateScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    @AfterEach
+    fun cancelGateScope() {
+        gateScope.coroutineContext[Job]?.cancel()
+    }
+
+    private val storageId = StorageId(
+        internalId = null,
+        externalId = UUID.fromString("00000000-0000-0000-0000-000000000001"),
+    )
+    private val otherStorageId = StorageId(
+        internalId = null,
+        externalId = UUID.fromString("00000000-0000-0000-0000-000000000002"),
+    )
+
+    private val mediaStoreTool = mockk<MediaStoreTool>(relaxed = true)
+    private val gatewaySwitch = mockk<GatewaySwitch>(relaxed = true)
+    private val deviceScanner = mockk<DeviceStorageScanner>(relaxed = true)
+
+    private fun storage(
+        id: StorageId = storageId,
+        capacity: Long = 100_000L,
+        free: Long = 40_000L,
+    ) = DeviceStorage(
+        id = id,
+        label = "storage".toCaString(),
+        type = DeviceStorage.Type.PRIMARY,
+        hardware = DeviceStorage.Hardware.BUILT_IN,
+        spaceCapacity = capacity,
+        spaceFree = free,
+        setupIncomplete = false,
+    )
+
+    private fun buildAnalyzer(
+        storages: Set<DeviceStorage>,
+        categories: Map<StorageId, Collection<ContentCategory>>,
+    ): Analyzer {
+        val storageSetup = mockk<SetupModule>(relaxed = true).apply { every { state } returns emptyFlow() }
+        val analyzer = Analyzer(
+            appScope = gateScope,
+            deviceScanner = Provider { deviceScanner },
+            storageScanner = Provider { mockk(relaxed = true) },
+            gatewaySwitch = gatewaySwitch,
+            appInventorySetupModule = mockk(relaxed = true),
+            storageSetupModule = storageSetup,
+            mediaStoreTool = mediaStoreTool,
+            spaceTracker = mockk(relaxed = true),
+        )
+
+        val field = Analyzer::class.java.getDeclaredField("coreState").apply { isAccessible = true }
+        @Suppress("UNCHECKED_CAST")
+        (field.get(analyzer) as MutableStateFlow<Analyzer.CoreState>).value = Analyzer.CoreState(
+            storages = storages,
+            categories = categories,
+        )
+
+        return analyzer
+    }
+
+    private fun path(vararg segments: String): APath = LocalPath.build(*segments)
+
+    private fun file(path: APath, size: Long) = ContentItem(
+        path = path,
+        lookup = null,
+        itemSize = size,
+        type = FileType.FILE,
+        inaccessible = false,
+    )
+
+    private fun dir(path: APath, size: Long = 4096L, children: Collection<ContentItem> = emptySet()) = ContentItem(
+        path = path,
+        lookup = null,
+        itemSize = size,
+        type = FileType.DIRECTORY,
+        children = children,
+        inaccessible = false,
+    )
+
+    private fun symlink(path: APath, size: Long) = ContentItem(
+        path = path,
+        lookup = null,
+        itemSize = size,
+        type = FileType.SYMBOLIC_LINK,
+        inaccessible = false,
+    )
+
+    private fun installId(pkgName: String) = InstallId(
+        pkgId = Pkg.Id(pkgName),
+        userHandle = UserHandle2(0),
+    )
+
+    private fun pkgStat(id: InstallId, appData: ContentGroup) = AppCategory.PkgStat(
+        pkg = mockk<Installed>().apply { every { installId } returns id },
+        isShallow = false,
+        appCode = null,
+        appData = appData,
+        appMedia = null,
+        extraData = null,
+    )
+
+    private fun deleteTask(
+        group: ContentGroup,
+        targets: Set<APath>,
+        targetPkg: InstallId? = null,
+    ) = ContentDeleteTask(
+        storageId = storageId,
+        groupId = group.id,
+        targetPkg = targetPkg,
+        targets = targets,
+    )
+
+    private suspend fun Analyzer.currentStorage(id: StorageId = storageId) =
+        data.first().storages.single { it.id == id }
+
+    private suspend inline fun <reified T : ContentCategory> Analyzer.currentCategory(): T =
+        data.first().categories[storageId]!!.filterIsInstance<T>().single()
+
+    @Test
+    fun `app data deletion publishes the re-read free space`() = runTest2 {
+        val target = path("storage", "emulated", "0", "Android", "data", "com.example", "cache")
+        val group = ContentGroup(label = "App data".toCaString(), contents = setOf(dir(target, size = 5_000L)))
+        val owner = installId("com.example")
+        val analyzer = buildAnalyzer(
+            storages = setOf(storage(free = 40_000L)),
+            categories = mapOf(
+                storageId to setOf(AppCategory(storageId, pkgStats = mapOf(owner to pkgStat(owner, group)))),
+            ),
+        )
+        coEvery { deviceScanner.scan() } returns setOf(storage(free = 45_000L))
+
+        analyzer.submit(deleteTask(group, setOf(target), targetPkg = owner))
+
+        analyzer.currentStorage().spaceFree shouldBe 45_000L
+        analyzer.currentCategory<AppCategory>().spaceUsed shouldBe 0L
+    }
+
+    @Test
+    fun `media deletion publishes the re-read free space and matching sizes`() = runTest2 {
+        val dcim = path("storage", "emulated", "0", "DCIM")
+        val photo = path("storage", "emulated", "0", "DCIM", "img.jpg")
+        val group = ContentGroup(
+            label = "Media".toCaString(),
+            contents = setOf(dir(dcim, size = 4_096L, children = setOf(file(photo, 1_000L)))),
+        )
+        val analyzer = buildAnalyzer(
+            storages = setOf(storage(free = 40_000L)),
+            categories = mapOf(storageId to setOf(MediaCategory(storageId, setOf(group)))),
+        )
+        coEvery { deviceScanner.scan() } returns setOf(storage(free = 45_096L))
+
+        val result = analyzer.submit(deleteTask(group, setOf(dcim))) as ContentDeleteTask.Result
+
+        result.affectedSpace shouldBe 5_096L
+        analyzer.currentCategory<MediaCategory>().spaceUsed shouldBe 0L
+        analyzer.currentStorage().spaceFree shouldBe 45_096L
+        // Storage and category moved by the same amount as the reported result.
+        analyzer.currentStorage().spaceUsed shouldBe 60_000L - 5_096L
+        coVerify { mediaStoreTool.flush() }
+    }
+
+    @Test
+    fun `a failed free-space re-read falls back to the group size delta`() = runTest2 {
+        val photo = path("storage", "emulated", "0", "DCIM", "img.jpg")
+        val link = path("storage", "emulated", "0", "DCIM", "link")
+        val group = ContentGroup(
+            label = "Media".toCaString(),
+            // The symlink has an itemSize but no size, so the flat freed-space sum (1500) and the
+            // group-size delta (1000) differ - the storage card must move by the latter.
+            contents = setOf(file(photo, 1_000L), symlink(link, 500L)),
+        )
+        val analyzer = buildAnalyzer(
+            storages = setOf(storage(free = 40_000L)),
+            categories = mapOf(storageId to setOf(MediaCategory(storageId, setOf(group)))),
+        )
+        coEvery { deviceScanner.scan() } throws IOException("No storage stats")
+
+        val result = analyzer.submit(deleteTask(group, setOf(photo, link))) as ContentDeleteTask.Result
+
+        result.affectedSpace shouldBe 1_500L
+        analyzer.currentStorage().spaceFree shouldBe 41_000L
+    }
+
+    @Test
+    fun `the fallback can not push free space past the capacity`() = runTest2 {
+        val photo = path("storage", "emulated", "0", "DCIM", "img.jpg")
+        val group = ContentGroup(label = "Media".toCaString(), contents = setOf(file(photo, 5_000L)))
+        val analyzer = buildAnalyzer(
+            storages = setOf(storage(capacity = 1_000L, free = 900L)),
+            categories = mapOf(storageId to setOf(MediaCategory(storageId, setOf(group)))),
+        )
+        coEvery { deviceScanner.scan() } throws IOException("No storage stats")
+
+        analyzer.submit(deleteTask(group, setOf(photo)))
+
+        analyzer.currentStorage().spaceFree shouldBe 1_000L
+    }
+
+    @Test
+    fun `other storages are left untouched`() = runTest2 {
+        val photo = path("storage", "emulated", "0", "DCIM", "img.jpg")
+        val group = ContentGroup(label = "Media".toCaString(), contents = setOf(file(photo, 1_000L)))
+        val untouched = storage(id = otherStorageId, capacity = 500L, free = 200L)
+        val analyzer = buildAnalyzer(
+            storages = setOf(storage(free = 40_000L), untouched),
+            categories = mapOf(storageId to setOf(MediaCategory(storageId, setOf(group)))),
+        )
+        coEvery { deviceScanner.scan() } returns setOf(
+            storage(free = 41_000L),
+            // A delete never adopts the scan's numbers for storages it didn't touch.
+            untouched.copy(spaceFree = 1L),
+        )
+
+        analyzer.submit(deleteTask(group, setOf(photo)))
+
+        analyzer.currentStorage().spaceFree shouldBe 41_000L
+        analyzer.currentStorage(otherStorageId) shouldBe untouched
+    }
+
+    @Test
+    fun `the system residual is recomputed against the new used space`() = runTest2 {
+        val photo = path("storage", "emulated", "0", "DCIM", "img.jpg")
+        val mediaGroup = ContentGroup(label = "Media".toCaString(), contents = setOf(file(photo, 100L)))
+        val systemGroup = ContentGroup(label = "System".toCaString())
+        val analyzer = buildAnalyzer(
+            storages = setOf(storage(capacity = 1_000L, free = 400L)),
+            categories = mapOf(
+                storageId to setOf(
+                    MediaCategory(storageId, setOf(mediaGroup)),
+                    // Scan-time residual: 600 used - 100 media.
+                    SystemCategory(storageId, setOf(systemGroup), spaceUsedOverride = 500L),
+                ),
+            ),
+        )
+        coEvery { deviceScanner.scan() } returns setOf(storage(capacity = 1_000L, free = 450L))
+
+        analyzer.submit(deleteTask(mediaGroup, setOf(photo)))
+
+        analyzer.currentCategory<SystemCategory>().spaceUsedOverride shouldBe 550L
+    }
+
+    @Test
+    fun `a delete that frees nothing leaves the storage entry unchanged`() = runTest2 {
+        val unknown = path("storage", "emulated", "0", "DCIM", "unknown")
+        val group = ContentGroup(
+            label = "Media".toCaString(),
+            contents = setOf(ContentItem.fromInaccessible(unknown)),
+        )
+        val seeded = storage(free = 40_000L)
+        val analyzer = buildAnalyzer(
+            storages = setOf(seeded),
+            categories = mapOf(storageId to setOf(MediaCategory(storageId, setOf(group)))),
+        )
+        coEvery { deviceScanner.scan() } throws IOException("No storage stats")
+
+        analyzer.submit(deleteTask(group, setOf(unknown)))
+
+        analyzer.currentStorage() shouldBe seeded
+    }
+
+    @Test
+    fun `a failure part way through still publishes what was deleted`() = runTest2 {
+        val photo = path("storage", "emulated", "0", "DCIM", "img.jpg")
+        val sub = path("storage", "emulated", "0", "DCIM", "sub")
+        val nested = path("storage", "emulated", "0", "DCIM", "sub", "clip.mp4")
+        val group = ContentGroup(
+            label = "Media".toCaString(),
+            // filterDistinctRoots() sorts by segment count, so the shallower photo is deleted first.
+            contents = setOf(file(photo, 100L), dir(sub, size = 4_096L, children = setOf(file(nested, 200L)))),
+        )
+        val analyzer = buildAnalyzer(
+            storages = setOf(storage(free = 40_000L)),
+            categories = mapOf(storageId to setOf(MediaCategory(storageId, setOf(group)))),
+        )
+        coEvery { deviceScanner.scan() } returns setOf(storage(free = 40_100L))
+        coEvery { gatewaySwitch.delete(nested, any()) } throws IOException("Delete failed")
+
+        shouldThrow<IOException> { analyzer.submit(deleteTask(group, setOf(photo, nested))) }
+
+        analyzer.currentCategory<MediaCategory>().spaceUsed shouldBe 4_296L
+        analyzer.currentStorage().spaceFree shouldBe 40_100L
+    }
+
+    @Test
+    fun `a cancellation part way through still publishes what was deleted`() = runTest2 {
+        val photo = path("storage", "emulated", "0", "DCIM", "img.jpg")
+        val sub = path("storage", "emulated", "0", "DCIM", "sub")
+        val nested = path("storage", "emulated", "0", "DCIM", "sub", "clip.mp4")
+        val group = ContentGroup(
+            label = "Media".toCaString(),
+            contents = setOf(file(photo, 100L), dir(sub, size = 4_096L, children = setOf(file(nested, 200L)))),
+        )
+        val analyzer = buildAnalyzer(
+            storages = setOf(storage(free = 40_000L)),
+            categories = mapOf(storageId to setOf(MediaCategory(storageId, setOf(group)))),
+        )
+        coEvery { deviceScanner.scan() } returns setOf(storage(free = 40_100L))
+        coEvery { gatewaySwitch.delete(nested, any()) } throws CancellationException("Cancelled")
+
+        shouldThrow<CancellationException> { analyzer.submit(deleteTask(group, setOf(photo, nested))) }
+
+        analyzer.currentCategory<MediaCategory>().spaceUsed shouldBe 4_296L
+        analyzer.currentStorage().spaceFree shouldBe 40_100L
+    }
+}

--- a/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModelTest.kt
+++ b/app-tool-analyzer/src/test/java/eu/darken/sdmse/analyzer/ui/storage/content/ContentViewModelTest.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import eu.darken.sdmse.analyzer.R
 import eu.darken.sdmse.analyzer.core.Analyzer
 import eu.darken.sdmse.analyzer.core.AnalyzerSettings
+import eu.darken.sdmse.analyzer.core.content.ContentDeleteTask
 import eu.darken.sdmse.analyzer.core.content.ContentGroup
 import eu.darken.sdmse.analyzer.core.content.ContentItem
 import eu.darken.sdmse.analyzer.core.device.DeviceStorage
@@ -27,6 +28,8 @@ import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.common.ui.LayoutMode
+import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -34,6 +37,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -85,6 +89,7 @@ class ContentViewModelTest : BaseTest() {
         val filterEditorOptionsCreator: eu.darken.sdmse.common.files.FilterEditorOptionsCreator,
         val viewIntentTool: ViewIntentTool,
         val exclusionManager: ExclusionManager,
+        val taskSubmitter: TaskSubmitter,
     )
 
     private fun TestScope.harness(
@@ -110,6 +115,7 @@ class ContentViewModelTest : BaseTest() {
             mockk<eu.darken.sdmse.common.files.FilterEditorOptionsCreator>(relaxed = true)
         val viewIntentTool = mockk<ViewIntentTool>(relaxed = true)
         val exclusionManager = mockk<ExclusionManager>(relaxed = true)
+        val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
 
         val vm = ContentViewModel(
             dispatcherProvider = TestDispatcherProvider(),
@@ -120,6 +126,7 @@ class ContentViewModelTest : BaseTest() {
             filterEditorOptionsCreator = filterEditorOptionsCreator,
             upgradeRepo = mockk(relaxed = true),
             swiperSessionCreator = swiperSessionCreator,
+            taskSubmitter = taskSubmitter,
         )
         vm.bindRoute(ContentRoute(storageId = storageId, groupId = group.id))
 
@@ -133,6 +140,7 @@ class ContentViewModelTest : BaseTest() {
             filterEditorOptionsCreator,
             viewIntentTool,
             exclusionManager,
+            taskSubmitter,
         )
     }
 
@@ -233,7 +241,35 @@ class ContentViewModelTest : BaseTest() {
         h.vm.onDeleteSelected(setOf(dirItem("DCIM")))
         advanceUntilIdle()
 
-        coVerify(exactly = 0) { h.analyzer.submit(any()) }
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any(), any()) }
+    }
+
+    @Test
+    fun `delete on writable content goes through the task submitter`() = runTest2 {
+        val child = dirItem("DCIM")
+        val group = ContentGroup(label = "Media".toCaString(), contents = setOf(child))
+        val h = harness(MediaCategory(storageId, setOf(group), isReadOnly = false), group)
+        val submitted = slot<SDMTool.Task>()
+        coEvery { h.taskSubmitter.submit(capture(submitted), any()) } returns ContentDeleteTask.Result(
+            affectedSpace = 1024L,
+            affectedPaths = setOf(child.path),
+        )
+        advanceUntilIdle()
+
+        h.vm.onDeleteSelected(setOf(child))
+        advanceUntilIdle()
+
+        // ContentDeleteTask is Reportable, so it has to reach the task manager to be counted by stats.
+        val task = submitted.captured
+        task.shouldBeInstanceOf<ContentDeleteTask>()
+        task.storageId shouldBe storageId
+        task.groupId shouldBe group.id
+        task.targets shouldBe setOf(child.path)
+
+        val event = h.vm.events.first()
+        event.shouldBeInstanceOf<ContentViewModel.Event.ContentDeleted>()
+        event.count shouldBe 1
+        event.freedSpace shouldBe 1024L
     }
 
     @Test


### PR DESCRIPTION
## What changed

When you delete files through the Storage Analyzer, the sizes for the app or folder you deleted from updated right away, but the "Storage content" categories and the main storage card at the top kept showing the old numbers until you pressed refresh. Now every level updates as soon as the deletion finishes, and the free-space figure is read back from the filesystem rather than estimated, so it matches what the system reports.

Deletions made in the Storage Analyzer now also appear in Statistics, with the space they freed, like the other tools' cleanups do.

If a multi-file deletion stops partway, whether from an error or a cancellation, the files that were already deleted no longer stay listed with stale sizes.

## Technical Context

- Root cause: `Analyzer.deleteContent()` rebuilt the affected `ContentGroup` and wrote new category data but never touched `storageDevices`. `DeviceStorage.spaceFree`/`spaceUsed` were only ever written by `scanStorageDevices()`, which is what the refresh button runs. Category cards also divide by `storage.spaceUsed` for their percentages, so those were half-updated too.
- Free space is re-read from `DeviceStorageScanner` after a delete rather than adjusted arithmetically, and `SystemCategory.spaceUsedOverride` (a scan-time residual) is recomputed from the new used value via the existing `StorageScanner.computeResidual`. The clamped arithmetic fallback runs only if that read fails. One consequence worth knowing: with dry-run mode active the re-read correctly reports no change, whereas the arithmetic approach would have invented freed space that does not exist.
- `spaceCapacity` and `spaceFree` are copied from the same refreshed `DeviceStorage` because they are one measurement pair. `DeviceStorageScanner` can fall back from `StorageStatsManager2` to the File API between scans, and those two measure different things (whole disk versus data partition), so pairing a fresh free value with a cached capacity shifts used space by gigabytes. `setupIncomplete` deliberately stays cached: it drives the auto-rescan invariant, and a refreshed `false` could make stale permission-limited categories look healed.
- The two state flows are merged into a single `CoreState` holder so that a delete publishes category sizes, device free space and the recomputed residual in one emission instead of a partial intermediate frame.
- `ContentDeleteTask` now goes through `TaskSubmitter` rather than `Analyzer` directly; it is the only `Reportable` analyzer task, so it is the only one whose routing affects stats. Two side effects: the delete runs on `appScope`, so leaving the screen no longer aborts it, and it becomes cancellable through the existing analyzer cancel path, which the partial-delete handling makes safe.
