### PR TITLE
Fix: Stop a blue box appearing around buttons while cleaning

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/FocusHighlightOverlay.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/FocusHighlightOverlay.kt
@@ -1,5 +1,7 @@
 package eu.darken.sdmse.common.compose
 
+import android.content.pm.PackageManager
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -28,6 +30,8 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.InputMode
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.compose.preview.Preview2
@@ -46,11 +50,66 @@ class FocusHighlightController {
 val LocalFocusHighlightController = staticCompositionLocalOf<FocusHighlightController?> { null }
 
 /**
+ * Whether this device has the kind of input the focus ring exists for: a D-pad/remote, a hardware
+ * keyboard, or a TV.
+ *
+ * `InputMode.Keyboard` alone is NOT enough to conclude the user is on a remote. Compose mirrors the
+ * platform's touch-mode flag, which any navigation key event clears *display-wide* — and SD Maid's
+ * own AppCleaner injects DPAD_DOWN/RIGHT/CENTER to clear caches on Android 16+ Pixels, where
+ * Settings hides the "Clear cache" button from the accessibility service. The app therefore knocked
+ * itself out of touch mode and drew a remote-control ring for a touch-only phone user, which stayed
+ * until the next screen tap (support report: blue box around the cancel button, Pixel 8 Pro / A17).
+ *
+ * [Configuration] cannot be forged by that automation: WindowManager computes it
+ * (DisplayContent.computeScreenConfiguration) by walking the real input devices while explicitly
+ * skipping `device.isVirtual()`, and both `input keyevent` and `performGlobalAction` originate from
+ * virtual devices. Attaching or removing a keyboard/remote is a configuration change, so this
+ * re-evaluates on its own.
+ *
+ * Known limitation: this proves the hardware is *present*, not that a real keypress moved focus. On
+ * a phone with a keyboard already paired, AppCleaner's injected D-pad can still raise the ring.
+ * Closing that would need per-window key-event tracking.
+ *
+ * TV coverage needs all the signals. Standard Android TV/Google TV builds report
+ * [Configuration.NAVIGATION_DPAD] even with the remote disconnected, but only because the canonical
+ * TV overlay sets `config_hasPermanentDpad` — an overlay resource, not an API guarantee. A
+ * third-party Leanback box may set neither it nor [Configuration.UI_MODE_TYPE_TELEVISION], which is
+ * why [isTvLike] is a floor. Do not drop any of them.
+ *
+ * Trackball and wheel are deliberately excluded: the hardware is extinct, and AOSP classifies a
+ * device offering both trackball and D-pad sources as trackball, so accepting it would widen the
+ * gate for no living device.
+ */
+internal fun supportsFocusHighlightInput(
+    navigation: Int,
+    keyboard: Int,
+    uiMode: Int,
+    isTvLike: Boolean,
+): Boolean = isTvLike ||
+    navigation == Configuration.NAVIGATION_DPAD ||
+    keyboard == Configuration.KEYBOARD_QWERTY ||
+    (uiMode and Configuration.UI_MODE_TYPE_MASK) == Configuration.UI_MODE_TYPE_TELEVISION
+
+@Composable
+private fun supportsFocusHighlightInput(): Boolean {
+    val config = LocalConfiguration.current
+    val context = LocalContext.current
+    // Fixed for the process lifetime, unlike the Configuration signals.
+    val isTvLike = remember(context) {
+        val pm = context.packageManager
+        @Suppress("DEPRECATION")
+        pm.hasSystemFeature(PackageManager.FEATURE_LEANBACK) ||
+            pm.hasSystemFeature(PackageManager.FEATURE_TELEVISION)
+    }
+    return supportsFocusHighlightInput(config.navigation, config.keyboard, config.uiMode, isTvLike)
+}
+
+/**
  * Draws a high-contrast ring around whichever descendant of this node currently holds focus, but
- * only while the input mode is [InputMode.Keyboard] (D-pad on TV, hardware keyboards). Touch
- * interaction never shows the ring — including programmatic focus requests like onboarding's
- * auto-focused Continue button — and the mode is observed reactively, so the ring
- * appears/disappears as the user switches between remote and touch.
+ * only while the input mode is [InputMode.Keyboard] AND the device actually has the hardware the
+ * ring exists for (see [supportsFocusHighlightInput]). Touch interaction never shows the ring — including programmatic focus
+ * requests like onboarding's auto-focused Continue button — and both signals are observed
+ * reactively, so the ring appears/disappears as the user switches between remote and touch.
  *
  * Drawing happens after this node's content, i.e. above all children. Because the ring is based
  * on [onFocusedBoundsChanged] (not indication), it works for every focusable — Material3
@@ -64,6 +123,7 @@ fun Modifier.focusHighlightRing(
     controller: FocusHighlightController? = null,
 ): Modifier = composed {
     val inputModeManager = LocalInputModeManager.current
+    val supportsFocusHighlight = supportsFocusHighlightInput()
     var selfCoords by remember { mutableStateOf<LayoutCoordinates?>(null) }
     var focusedCoords by remember { mutableStateOf<LayoutCoordinates?>(null) }
     // The same LayoutCoordinates instance can be reported again after a reposition; bump a
@@ -81,6 +141,7 @@ fun Modifier.focusHighlightRing(
             drawContent()
 
             if (inputModeManager.inputMode != InputMode.Keyboard) return@drawWithContent
+            if (!supportsFocusHighlight) return@drawWithContent
             if (controller?.suppressed == true) return@drawWithContent
             @Suppress("UNUSED_EXPRESSION") positionTick
             val self = selfCoords?.takeIf { it.isAttached } ?: return@drawWithContent

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/FocusHighlightInputTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/FocusHighlightInputTest.kt
@@ -1,0 +1,83 @@
+package eu.darken.sdmse.common.compose
+
+import android.content.res.Configuration
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * The focus ring's hardware gate.
+ *
+ * `InputMode.Keyboard` on its own is not evidence of a remote: Compose mirrors the platform's
+ * touch-mode flag, and any navigation key event clears that flag display-wide. AppCleaner injects
+ * DPAD keys to clear caches on Android 16+ Pixels, so the app used to switch its own TV focus ring
+ * on for touch-only phone users. These cases pin the signals that gate it.
+ */
+class FocusHighlightInputTest : BaseTest() {
+
+    private data class Device(
+        val navigation: Int = Configuration.NAVIGATION_NONAV,
+        val keyboard: Int = Configuration.KEYBOARD_NOKEYS,
+        val uiMode: Int = Configuration.UI_MODE_TYPE_NORMAL,
+        val isTvLike: Boolean = false,
+    )
+
+    private fun Device.supportsRing() =
+        supportsFocusHighlightInput(navigation, keyboard, uiMode, isTvLike)
+
+    @Test
+    fun `a touch-only phone gets no ring`() {
+        Device().supportsRing() shouldBe false
+    }
+
+    @Test
+    fun `an attached d-pad counts`() {
+        Device(navigation = Configuration.NAVIGATION_DPAD).supportsRing() shouldBe true
+    }
+
+    @Test
+    fun `an attached hardware keyboard counts`() {
+        Device(keyboard = Configuration.KEYBOARD_QWERTY).supportsRing() shouldBe true
+    }
+
+    @Test
+    fun `a television ui mode counts`() {
+        Device(uiMode = Configuration.UI_MODE_TYPE_TELEVISION).supportsRing() shouldBe true
+    }
+
+    @Test
+    fun `a leanback box counts even when it reports no d-pad and no tv ui mode`() {
+        // The config_hasPermanentDpad fallback that covers standard Android TV is an overlay
+        // resource, not an API guarantee, so FEATURE_LEANBACK is the floor for third-party boxes.
+        Device(isTvLike = true).supportsRing() shouldBe true
+    }
+
+    @Test
+    fun `uiMode is masked, so night mode does not look like a television`() {
+        val darkPhone = Device(
+            uiMode = Configuration.UI_MODE_TYPE_NORMAL or Configuration.UI_MODE_NIGHT_YES,
+        )
+        darkPhone.supportsRing() shouldBe false
+    }
+
+    @Test
+    fun `a television in night mode still counts`() {
+        val darkTv = Device(
+            uiMode = Configuration.UI_MODE_TYPE_TELEVISION or Configuration.UI_MODE_NIGHT_YES,
+        )
+        darkTv.supportsRing() shouldBe true
+    }
+
+    @Test
+    fun `trackball and wheel are deliberately excluded`() {
+        Device(navigation = Configuration.NAVIGATION_TRACKBALL).supportsRing() shouldBe false
+        Device(navigation = Configuration.NAVIGATION_WHEEL).supportsRing() shouldBe false
+    }
+
+    @Test
+    fun `a device reporting only non-alphabetic keys does not count`() {
+        // Volume and power keys surface as a non-alphabetic keyboard on some devices; AOSP only
+        // sets KEYBOARD_QWERTY for KEYBOARD_TYPE_ALPHABETIC, and that is not focus-movable input.
+        Device(keyboard = Configuration.KEYBOARD_12KEY).supportsRing() shouldBe false
+    }
+}


### PR DESCRIPTION
## What changed

While the App Cleaner was clearing app caches, a coloured outline could appear around the Cancel button and sit there until you next touched the screen. In dark mode it read as a pale blue box. That outline exists for navigating with a TV remote or a hardware keyboard, and it now stays hidden on touch-only devices.

## Technical Context

- Root cause: the ring was gated only on Compose's `InputMode.Keyboard`, which mirrors the platform touch-mode flag. `ViewRootImpl.ensureTouchMode` applies that flag display-wide via `setInTouchMode(inTouchMode, displayId)`, and `isNavigationKey` counts every `DPAD_*` code. AppCleaner's Android 16+ Google-device path drives Settings with injected D-pad events plus an `ACTION_FOCUS` call, so the app knocked its own display out of touch mode and then drew its TV ring for phone users.
- Why `Configuration` is the signal: WindowManager builds it from real input devices while explicitly skipping `device.isVirtual()`, so the injected events that cause the bug cannot trip the new gate. It also re-evaluates on its own when a keyboard is attached or removed.
- The `FEATURE_LEANBACK` / `FEATURE_TELEVISION` check is a deliberate floor, not redundancy. `config_hasPermanentDpad`, which keeps `NAVIGATION_DPAD` true on a TV whose remote is disconnected, is a device overlay resource rather than an API guarantee, and a third-party Leanback box may set neither it nor `UI_MODE_TYPE_TELEVISION`. Dropping any one of the three signals risks taking the focus ring away from real remote users.
- Known limitation: the gate proves the hardware is present, not that a keypress moved focus. A phone with a keyboard already paired can still see the ring during a cache clear. Closing that would need per-window key-event tracking.
- Worth close review: the Android TV path is the regression risk here and has not been exercised on TV hardware. The unit tests cover the decision function, not the draw-pass wiring that calls it.
