### PR TITLE
Fix: Stop cleaning tools from getting stuck on a loading spinner

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskSubmitter.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskSubmitter.kt
@@ -6,6 +6,16 @@ import java.time.Instant
 
 interface TaskSubmitter {
     suspend fun submit(task: SDMTool.Task, notifyOnFinish: Boolean = true): SDMTool.Task.Result
+
+    /**
+     * Like [submit], but atomically declines when the task's tool already has an incomplete task.
+     * The check and the registration happen under the same lock, so concurrent callers can't both
+     * see an idle tool and both queue up work.
+     *
+     * Returns null when the submission was declined.
+     */
+    suspend fun submitIfToolIdle(task: SDMTool.Task, notifyOnFinish: Boolean = true): SDMTool.Task.Result?
+
     fun cancel(type: SDMTool.Type)
     val state: Flow<State>
 

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.appcleaner.core.AppJunk
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask
 import eu.darken.sdmse.appcleaner.ui.AppJunkDetailsRoute
 import eu.darken.sdmse.common.compose.snackbar.ToolListEvent
@@ -22,7 +23,9 @@ import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.exclusion.ui.ExclusionsListRoute
+import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.main.core.taskmanager.getLatestTask
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -32,6 +35,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import javax.inject.Inject
@@ -47,12 +51,42 @@ class AppCleanerListViewModel @Inject constructor(
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
 
     init {
-        // navUp only when a non-null Data drains to empty junks — null is the loading state
-        // (set during performScan before results land) and must not trigger navigation.
+        // Start an initial scan if AppCleaner has no data yet. The Dashboard only navigates here
+        // after scanning, but the navigation back stack is saved-state backed while the tool's data
+        // is plain in-memory state: after process death the restored screen comes back with no data
+        // at all and would sit on the loading placeholder forever.
+        //
+        // Wait out any in-flight task before deciding: performScan nulls the data while it runs, so
+        // checking immediately would duplicate an expensive scan. We wait instead of bailing out
+        // because an incomplete task is no promise that data is coming — a task that completes
+        // without producing data would strand this screen on the loading placeholder for good.
+        launch {
+            val idleState = taskSubmitter.state.first { st ->
+                st.tasks.none { it.toolType == SDMTool.Type.APPCLEANER && !it.isComplete }
+            }
+            // A scan the user cancelled must not be restarted behind their back, and a failed one
+            // would most likely just fail again. Scans are started from the Dashboard, so that's
+            // where we send them. No completed entry at all is the process-death case: scan.
+            val latest = idleState.getLatestTask(SDMTool.Type.APPCLEANER)
+            if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
+                navUp()
+                return@launch
+            }
+            if (appCleaner.state.first().data != null) return@launch
+            // Atomic submit: between the idle check above and here another entry point (a second
+            // screen, the Dashboard) may have registered its own scan.
+            taskSubmitter.submitIfToolIdle(AppCleanerScanTask())
+        }
+        // navUp only on a real drain-to-empty. mapNotNull skips the null loading state performScan
+        // publishes while running, so drop(1) consumes the first REAL result — without it a cold
+        // scan that finds nothing would navUp instead of showing the empty list. The dedupe drops
+        // the repeats the tool's data/progress combine produces on every progress tick, which would
+        // otherwise get an empty cold scan past drop(1) on its second identical emission.
         appCleaner.state
-            .map { it.data }
+            .mapNotNull { it.data }
+            .distinctUntilChanged()
             .drop(1)
-            .filter { it?.junks?.isEmpty() == true }
+            .filter { it.junks.isEmpty() }
             .take(1)
             .onEach { navUp() }
             .launchIn(vmScope)

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModel.kt
@@ -13,6 +13,8 @@ import eu.darken.sdmse.appcleaner.ui.AppJunkDetailsRoute
 import eu.darken.sdmse.common.compose.snackbar.ToolListEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.SingleEventFlow
@@ -26,6 +28,9 @@ import eu.darken.sdmse.exclusion.ui.ExclusionsListRoute
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.main.core.taskmanager.getLatestTask
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -50,6 +55,9 @@ class AppCleanerListViewModel @Inject constructor(
     private val upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
 
+    /** Set when the scan this screen started for itself failed, see the entry logic below. */
+    private val entryScanFailed = MutableStateFlow(false)
+
     init {
         // Start an initial scan if AppCleaner has no data yet. The Dashboard only navigates here
         // after scanning, but the navigation back stack is saved-state backed while the tool's data
@@ -61,21 +69,45 @@ class AppCleanerListViewModel @Inject constructor(
         // because an incomplete task is no promise that data is coming — a task that completes
         // without producing data would strand this screen on the loading placeholder for good.
         launch {
-            val idleState = taskSubmitter.state.first { st ->
-                st.tasks.none { it.toolType == SDMTool.Type.APPCLEANER && !it.isComplete }
+            while (true) {
+                val idleState = taskSubmitter.state.first { st ->
+                    st.tasks.none { it.toolType == SDMTool.Type.APPCLEANER && !it.isComplete }
+                }
+                // A scan the user cancelled must not be restarted behind their back, and a failed one
+                // would most likely just fail again. Scans are started from the Dashboard, so that's
+                // where we send them. No completed entry at all is the process-death case: scan.
+                val latest = idleState.getLatestTask(SDMTool.Type.APPCLEANER)
+                if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
+                    navUp()
+                    return@launch
+                }
+                if (appCleaner.state.first().data != null) return@launch
+                // Atomic submit: between the idle check above and here another entry point (a second
+                // screen, the Dashboard) may have registered its own scan.
+                val submitted = try {
+                    taskSubmitter.submitIfToolIdle(AppCleanerScanTask())
+                } catch (e: CancellationException) {
+                    // Rethrows if the ViewModel itself is going away, so teardown doesn't navigate.
+                    currentCoroutineContext().ensureActive()
+                    log(TAG, INFO) { "Entry scan was cancelled" }
+                    navUp()
+                    return@launch
+                } catch (e: Exception) {
+                    // No navUp here: the error dialog lives in this screen's host, so navigating
+                    // away would dispose it before it renders and the user would see nothing. No
+                    // rethrow either, that would emit the same error a second time through
+                    // launchErrorHandler. The failure flag turns the placeholder into an empty state.
+                    // A missing inventory setup (IncompleteSetupException) lands here.
+                    log(TAG, WARN) { "Entry scan failed: ${e.asLog()}" }
+                    entryScanFailed.value = true
+                    errorEvents.emit(e)
+                    return@launch
+                }
+                // Declined: another task for this tool registered in the race window. It may well
+                // complete without producing any data, so wait it out and decide again instead of
+                // leaving the screen loading forever.
+                if (submitted != null) return@launch
             }
-            // A scan the user cancelled must not be restarted behind their back, and a failed one
-            // would most likely just fail again. Scans are started from the Dashboard, so that's
-            // where we send them. No completed entry at all is the process-death case: scan.
-            val latest = idleState.getLatestTask(SDMTool.Type.APPCLEANER)
-            if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
-                navUp()
-                return@launch
-            }
-            if (appCleaner.state.first().data != null) return@launch
-            // Atomic submit: between the idle check above and here another entry point (a second
-            // screen, the Dashboard) may have registered its own scan.
-            taskSubmitter.submitIfToolIdle(AppCleanerScanTask())
         }
         // navUp only on a real drain-to-empty. mapNotNull skips the null loading state performScan
         // publishes while running, so drop(1) consumes the first REAL result — without it a cold
@@ -102,8 +134,15 @@ class AppCleanerListViewModel @Inject constructor(
     private val rowsState = combine(
         appCleaner.state.map { it.data }.distinctUntilChanged(),
         searchQuery,
-    ) { data, rawQuery ->
-        val all = data?.junks?.sortedByDescending { it.size }
+        entryScanFailed,
+    ) { data, rawQuery, scanFailed ->
+        val all = when {
+            data != null -> data.junks.sortedByDescending { it.size }
+            // Null rows mean "loading". Without data and without a scan that could still deliver
+            // it, that placeholder would never go away, so show the empty state instead.
+            scanFailed -> emptyList<AppJunk>()
+            else -> null
+        }
         val normalized = AppCleanerSearchMatcher.normalizeQuery(rawQuery)
         val filtered = if (normalized.isEmpty()) {
             all

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModelTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModelTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import eu.darken.sdmse.appcleaner.core.AppCleaner
 import eu.darken.sdmse.appcleaner.core.AppJunk
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
 import eu.darken.sdmse.appcleaner.ui.preview.previewInstalled
 import eu.darken.sdmse.common.navigation.NavEvent
@@ -12,6 +13,7 @@ import eu.darken.sdmse.common.pkgs.features.InstallId
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -31,6 +33,7 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
+import java.time.Instant
 
 class AppCleanerListViewModelTest : BaseTest() {
 
@@ -68,6 +71,26 @@ class AppCleanerListViewModelTest : BaseTest() {
         val upgradeRepo: UpgradeRepo,
         val stateFlow: MutableStateFlow<AppCleaner.State>,
         val progressFlow: MutableStateFlow<Progress.Data?>,
+        val taskStateFlow: MutableStateFlow<TaskSubmitter.State>,
+        /** Builds another ViewModel against the same mocks, i.e. a second entry into the screen. */
+        val newVm: () -> AppCleanerListViewModel,
+    )
+
+    private fun managedTask(
+        id: String = "task-1",
+        complete: Boolean = false,
+        cancelled: Boolean = false,
+        error: Throwable? = null,
+        toolType: SDMTool.Type = SDMTool.Type.APPCLEANER,
+    ): TaskSubmitter.ManagedTask = TaskSubmitter.ManagedTask(
+        id = id,
+        toolType = toolType,
+        task = mockk(relaxed = true),
+        queuedAt = Instant.now(),
+        startedAt = Instant.now(),
+        cancelledAt = if (cancelled) Instant.now() else null,
+        completedAt = if (complete) Instant.now() else null,
+        error = error,
     )
 
     private class CollectedEvents<T>(
@@ -101,6 +124,7 @@ class AppCleanerListViewModelTest : BaseTest() {
         data: AppCleaner.Data? = null,
         progress: Progress.Data? = null,
         isPro: Boolean = true,
+        tasks: Collection<TaskSubmitter.ManagedTask> = emptySet(),
     ): Harness {
         val stateFlow = MutableStateFlow(appState(data = data, progress = progress))
         val progressFlow = MutableStateFlow(progress)
@@ -108,19 +132,29 @@ class AppCleanerListViewModelTest : BaseTest() {
             every { this@apply.state } returns stateFlow
             every { this@apply.progress } returns progressFlow
         }
-        val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
+        // A real flow, not the relaxed mock's empty one: the entry logic waits on
+        // taskSubmitter.state.first { ... }, which against an empty flow dies with
+        // NoSuchElementException inside vmScope - silently, leaving the whole path untested.
+        val taskStateFlow = MutableStateFlow(TaskSubmitter.State(tasks = tasks))
+        val taskSubmitter = mockk<TaskSubmitter>(relaxed = true).apply {
+            every { this@apply.state } returns taskStateFlow
+        }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
         }
         val context = mockk<Context>(relaxed = true)
-        val vm = AppCleanerListViewModel(
-            dispatcherProvider = TestDispatcherProvider(),
-            context = context,
-            appCleaner = appCleaner,
-            taskSubmitter = taskSubmitter,
-            upgradeRepo = upgradeRepo,
+        val newVm = {
+            AppCleanerListViewModel(
+                dispatcherProvider = TestDispatcherProvider(),
+                context = context,
+                appCleaner = appCleaner,
+                taskSubmitter = taskSubmitter,
+                upgradeRepo = upgradeRepo,
+            )
+        }
+        return Harness(
+            newVm(), appCleaner, taskSubmitter, upgradeRepo, stateFlow, progressFlow, taskStateFlow, newVm,
         )
-        return Harness(vm, appCleaner, taskSubmitter, upgradeRepo, stateFlow, progressFlow)
     }
 
     @Test
@@ -378,5 +412,148 @@ class AppCleanerListViewModelTest : BaseTest() {
         // transition — no navUp emitted while a refresh is in progress.
         navCollected.list shouldBe emptyList()
         navCollected.cancel()
+    }
+
+    // ──────────────────────────── entry / cold scan ────────────────────────────
+
+    private fun CoroutineScope.collectErrors(
+        vm: AppCleanerListViewModel,
+    ): CollectedEvents<Throwable> {
+        val list = mutableListOf<Throwable>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.errorEvents.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    @Test
+    fun `constructing the ViewModel does not push an error into errorEvents`() = runTest2 {
+        // Guards the harness itself: with a relaxed TaskSubmitter mock the entry logic's
+        // first { ... } dies on an empty flow and every entry test below would pass vacuously.
+        val h = harness(data = null)
+        val errors = collectErrors(h.vm)
+        advanceUntilIdle()
+
+        errors.list shouldBe emptyList()
+        errors.cancel()
+    }
+
+    @Test
+    fun `cold entry without data submits exactly one scan`() = runTest2 {
+        val h = harness(data = null)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(AppCleanerScanTask()) }
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(any()) }
+        // The entry scan must go through the atomic API, never plain submit().
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `entry with data present does not scan`() = runTest2 {
+        val h = harness(data = AppCleaner.Data(junks = listOf(junk("com.example.a"))))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+    }
+
+    @Test
+    fun `entry during a task that completes with data does not scan`() = runTest2 {
+        val h = harness(data = null, tasks = setOf(managedTask()))
+        advanceUntilIdle()
+        // Still waiting on the in-flight task, so nothing submitted yet.
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+
+        h.stateFlow.value = appState(data = AppCleaner.Data(junks = listOf(junk("com.example.a"))))
+        h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(complete = true)))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+    }
+
+    @Test
+    fun `entry during a task that completes without data scans`() = runTest2 {
+        // A task can complete normally without ever assigning data. Bailing out on it would strand
+        // the screen on the loading placeholder.
+        val h = harness(data = null, tasks = setOf(managedTask()))
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(complete = true)))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(AppCleanerScanTask()) }
+    }
+
+    @Test
+    fun `entry during a task that gets cancelled navigates up instead of scanning`() = runTest2 {
+        val h = harness(data = null, tasks = setOf(managedTask()))
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(complete = true, cancelled = true)),
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+        nav.list shouldBe listOf(NavEvent.Up)
+        nav.cancel()
+    }
+
+    @Test
+    fun `entry during a task that fails navigates up instead of scanning`() = runTest2 {
+        val h = harness(data = null, tasks = setOf(managedTask()))
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(complete = true, error = IllegalStateException("nope"))),
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+        nav.list shouldBe listOf(NavEvent.Up)
+        nav.cancel()
+    }
+
+    @Test
+    fun `two entries racing the same registration produce exactly one scan`() = runTest2 {
+        // Mirrors TaskManager.submitIfToolIdle: registration only happens while the tool has no
+        // incomplete task, and both callers get here before either registered. A ViewModel that
+        // used plain submit() would produce two full scans, the second wiping the first's results.
+        val h = harness(data = null)
+        val registered = mutableListOf<Any>()
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            if (registered.isEmpty()) registered.add(firstArg())
+            null
+        }
+
+        h.newVm()
+        h.newVm()
+        advanceUntilIdle()
+
+        registered.size shouldBe 1
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `a cold scan that finds nothing does not navigate up`() = runTest2 {
+        val h = harness(data = null)
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        // The scan lands its (empty) result...
+        h.stateFlow.value = appState(data = AppCleaner.Data(junks = emptyList()))
+        advanceUntilIdle()
+        // ...and a progress tick re-emits the same Data through the tool's combine. Without the
+        // dedupe that second identical emission would get past drop(1) and navigate away.
+        h.stateFlow.value = appState(
+            data = AppCleaner.Data(junks = emptyList()),
+            progress = Progress.Data(extra = "tick"),
+        )
+        advanceUntilIdle()
+
+        nav.list shouldBe emptyList()
+        nav.cancel()
     }
 }

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModelTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/list/AppCleanerListViewModelTest.kt
@@ -21,9 +21,12 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -138,6 +141,10 @@ class AppCleanerListViewModelTest : BaseTest() {
         val taskStateFlow = MutableStateFlow(TaskSubmitter.State(tasks = tasks))
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true).apply {
             every { this@apply.state } returns taskStateFlow
+            // Explicit "accepted": the entry loop only exits on a non-null result, so leaving this
+            // to the relaxed mock would make the loop's exit condition an implementation detail of
+            // MockK. Tests that need a decline re-stub this.
+            coEvery { submitIfToolIdle(any()) } returns mockk<SDMTool.Task.Result>(relaxed = true)
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
@@ -524,8 +531,14 @@ class AppCleanerListViewModelTest : BaseTest() {
         val h = harness(data = null)
         val registered = mutableListOf<Any>()
         coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
-            if (registered.isEmpty()) registered.add(firstArg())
-            null
+            if (registered.isEmpty()) {
+                registered.add(firstArg())
+                mockk<SDMTool.Task.Result>(relaxed = true)
+            } else {
+                // Declined, because the winner's task is in flight by the time we get here.
+                h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask()))
+                null
+            }
         }
 
         h.newVm()
@@ -534,6 +547,98 @@ class AppCleanerListViewModelTest : BaseTest() {
 
         registered.size shouldBe 1
         coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `an entry scan that fails surfaces the error and shows the empty state`() = runTest2 {
+        val h = harness(data = null)
+        val boom = IllegalStateException("scan blew up")
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } throws boom
+
+        val vm = h.newVm()
+        val errors = collectErrors(vm)
+        val nav = collectNavEvents(vm)
+        val stateJob = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        errors.list shouldBe listOf(boom)
+        // navUp would dispose this screen's host before it can render the error dialog, so the
+        // user would land on the Dashboard with no indication that anything went wrong.
+        nav.list shouldBe emptyList()
+        // Nothing is going to deliver data anymore: show the empty state, not a forever placeholder.
+        vm.state.value.rows shouldBe emptyList()
+
+        stateJob.cancel()
+        errors.cancel()
+        nav.cancel()
+    }
+
+    @Test
+    fun `an entry scan that is cancelled navigates up`() = runTest2 {
+        val h = harness(data = null)
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } throws CancellationException("user cancelled")
+
+        val vm = h.newVm()
+        val nav = collectNavEvents(vm)
+        val errors = collectErrors(vm)
+        advanceUntilIdle()
+
+        nav.list shouldBe listOf(NavEvent.Up)
+        errors.list shouldBe emptyList()
+        nav.cancel()
+        errors.cancel()
+    }
+
+    @Test
+    fun `ViewModel teardown during the entry scan does not navigate up`() = runTest2 {
+        val h = harness(data = null)
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            // What teardown looks like from inside the submit: our own job is cancelled. That must
+            // rethrow instead of being read as "the user cancelled the scan" and navigating.
+            currentCoroutineContext().cancel()
+            throw CancellationException("ViewModel cleared")
+        }
+
+        val vm = h.newVm()
+        val nav = collectNavEvents(vm)
+        val stateJob = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        nav.list shouldBe emptyList()
+        // Teardown is not a scan failure, so no empty state is faked either.
+        vm.state.value.rows shouldBe null
+
+        stateJob.cancel()
+        nav.cancel()
+    }
+
+    @Test
+    fun `a declined entry submit is retried after the competing task completes without data`() = runTest2 {
+        val h = harness(data = null)
+        val submitted = mutableListOf<Any>()
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            submitted.add(firstArg())
+            if (submitted.size == 1) {
+                // Declined: a competing task registered inside the race window and is now in flight.
+                h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(id = "competing")))
+                null
+            } else {
+                mockk<SDMTool.Task.Result>(relaxed = true)
+            }
+        }
+
+        h.newVm()
+        advanceUntilIdle()
+        submitted.size shouldBe 1
+
+        // The competing task completes normally but never assigns data. Treating the decline as
+        // "someone else will deliver" would leave the screen loading forever.
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(id = "competing", complete = true)),
+        )
+        advanceUntilIdle()
+
+        submitted shouldBe listOf(AppCleanerScanTask(), AppCleanerScanTask())
     }
 
     @Test

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModel.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModel.kt
@@ -13,8 +13,11 @@ import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
 import eu.darken.sdmse.corpsefinder.core.CorpseIdentifier
 import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderDeleteTask
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderScanTask
 import eu.darken.sdmse.corpsefinder.ui.CorpseDetailsRoute
+import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.main.core.taskmanager.getLatestTask
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -23,6 +26,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import javax.inject.Inject
@@ -35,12 +39,45 @@ class CorpseFinderListViewModel @Inject constructor(
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
 
     init {
-        // navUp only when a non-null Data drains to empty corpses — null is the loading state
-        // (set during performScan before results land) and must not trigger navigation.
+        // Start an initial scan if CorpseFinder has no data yet. The Dashboard only navigates here
+        // after scanning, but the navigation back stack is saved-state backed while the tool's data
+        // is plain in-memory state: after process death the restored screen comes back with no data
+        // at all and would sit on the loading placeholder forever.
+        //
+        // Wait out any in-flight task before deciding: performScan nulls the data while it runs, so
+        // checking immediately would duplicate an expensive scan. We wait instead of bailing out
+        // because an incomplete task is no promise that data is coming — the uninstall watcher never
+        // assigns any, and a task that completes without producing data would strand this screen on
+        // the loading placeholder for good.
+        launch {
+            val idleState = taskSubmitter.state.first { st ->
+                st.tasks.none { it.toolType == SDMTool.Type.CORPSEFINDER && !it.isComplete }
+            }
+            // A scan the user cancelled must not be restarted behind their back, and a failed one
+            // would most likely just fail again. Scans are started from the Dashboard, so that's
+            // where we send them. No completed entry at all is the process-death case: scan.
+            val latest = idleState.getLatestTask(SDMTool.Type.CORPSEFINDER)
+            if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
+                navUp()
+                return@launch
+            }
+            if (corpseFinder.state.first().data != null) return@launch
+            // Atomic submit: between the idle check above and here another entry point (a second
+            // screen, the Dashboard) may have registered its own scan.
+            taskSubmitter.submitIfToolIdle(CorpseFinderScanTask())
+        }
+        // navUp only on a real drain-to-empty. mapNotNull skips the null loading state performScan
+        // publishes while running, so drop(1) consumes the first REAL result, and the dedupe drops
+        // the repeats the tool's data/progress combine produces on every progress tick.
+        //
+        // The dedupe key is the corpse collection, not the whole Data: Data also carries lastResult,
+        // which a cold scan writes twice with different values, so two Data with identical corpses
+        // compare unequal and an empty cold scan would slip past drop(1) and navigate away.
         corpseFinder.state
-            .map { it.data }
+            .mapNotNull { it.data?.corpses }
+            .distinctUntilChanged()
             .drop(1)
-            .filter { it?.corpses?.isEmpty() == true }
+            .filter { it.isEmpty() }
             .take(1)
             .onEach { navUp() }
             .launchIn(vmScope)

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModel.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModel.kt
@@ -4,6 +4,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.compose.snackbar.ToolListEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.SingleEventFlow
@@ -18,6 +20,10 @@ import eu.darken.sdmse.corpsefinder.ui.CorpseDetailsRoute
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.main.core.taskmanager.getLatestTask
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -38,6 +44,9 @@ class CorpseFinderListViewModel @Inject constructor(
     private val taskSubmitter: TaskSubmitter,
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
 
+    /** Set when the scan this screen started for itself failed, see the entry logic below. */
+    private val entryScanFailed = MutableStateFlow(false)
+
     init {
         // Start an initial scan if CorpseFinder has no data yet. The Dashboard only navigates here
         // after scanning, but the navigation back stack is saved-state backed while the tool's data
@@ -50,21 +59,44 @@ class CorpseFinderListViewModel @Inject constructor(
         // assigns any, and a task that completes without producing data would strand this screen on
         // the loading placeholder for good.
         launch {
-            val idleState = taskSubmitter.state.first { st ->
-                st.tasks.none { it.toolType == SDMTool.Type.CORPSEFINDER && !it.isComplete }
+            while (true) {
+                val idleState = taskSubmitter.state.first { st ->
+                    st.tasks.none { it.toolType == SDMTool.Type.CORPSEFINDER && !it.isComplete }
+                }
+                // A scan the user cancelled must not be restarted behind their back, and a failed one
+                // would most likely just fail again. Scans are started from the Dashboard, so that's
+                // where we send them. No completed entry at all is the process-death case: scan.
+                val latest = idleState.getLatestTask(SDMTool.Type.CORPSEFINDER)
+                if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
+                    navUp()
+                    return@launch
+                }
+                if (corpseFinder.state.first().data != null) return@launch
+                // Atomic submit: between the idle check above and here another entry point (a second
+                // screen, the Dashboard) may have registered its own scan.
+                val submitted = try {
+                    taskSubmitter.submitIfToolIdle(CorpseFinderScanTask())
+                } catch (e: CancellationException) {
+                    // Rethrows if the ViewModel itself is going away, so teardown doesn't navigate.
+                    currentCoroutineContext().ensureActive()
+                    log(TAG, INFO) { "Entry scan was cancelled" }
+                    navUp()
+                    return@launch
+                } catch (e: Exception) {
+                    // No navUp here: the error dialog lives in this screen's host, so navigating
+                    // away would dispose it before it renders and the user would see nothing. No
+                    // rethrow either, that would emit the same error a second time through
+                    // launchErrorHandler. The failure flag turns the placeholder into an empty state.
+                    log(TAG, WARN) { "Entry scan failed: ${e.asLog()}" }
+                    entryScanFailed.value = true
+                    errorEvents.emit(e)
+                    return@launch
+                }
+                // Declined: another task for this tool registered in the race window. It may well
+                // complete without producing any data (the uninstall watcher does), so wait it out
+                // and decide again instead of leaving the screen loading forever.
+                if (submitted != null) return@launch
             }
-            // A scan the user cancelled must not be restarted behind their back, and a failed one
-            // would most likely just fail again. Scans are started from the Dashboard, so that's
-            // where we send them. No completed entry at all is the process-death case: scan.
-            val latest = idleState.getLatestTask(SDMTool.Type.CORPSEFINDER)
-            if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
-                navUp()
-                return@launch
-            }
-            if (corpseFinder.state.first().data != null) return@launch
-            // Atomic submit: between the idle check above and here another entry point (a second
-            // screen, the Dashboard) may have registered its own scan.
-            taskSubmitter.submitIfToolIdle(CorpseFinderScanTask())
         }
         // navUp only on a real drain-to-empty. mapNotNull skips the null loading state performScan
         // publishes while running, so drop(1) consumes the first REAL result, and the dedupe drops
@@ -88,15 +120,21 @@ class CorpseFinderListViewModel @Inject constructor(
     // Row production excludes progress so high-frequency progress ticks during a scan don't re-sort
     // and re-map the whole corpse list. Progress is merged in last (below) as a cheap field swap that
     // preserves the rows List instance, letting keyed lazy rows skip recomposition.
-    private val rowsState = corpseFinder.state
-        .map { it.data }
-        .distinctUntilChanged()
-        .map { data ->
-            val rows = data?.corpses
-                ?.sortedByDescending { it.size }
-                ?.map { Row(corpse = it) }
-            State(rows = rows)
+    private val rowsState = combine(
+        corpseFinder.state.map { it.data }.distinctUntilChanged(),
+        entryScanFailed,
+    ) { data, scanFailed ->
+        val rows = when {
+            data != null -> data.corpses
+                .sortedByDescending { it.size }
+                .map { Row(corpse = it) }
+            // Null rows mean "loading". Without data and without a scan that could still deliver
+            // it, that placeholder would never go away, so show the empty state instead.
+            scanFailed -> emptyList<Row>()
+            else -> null
         }
+        State(rows = rows)
+    }
 
     val state: StateFlow<State> = combine(
         rowsState,

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModelTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModelTest.kt
@@ -6,8 +6,10 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
 import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderDeleteTask
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderScanTask
 import eu.darken.sdmse.corpsefinder.ui.preview.previewCorpse
 import eu.darken.sdmse.corpsefinder.ui.preview.previewLocalPathLookup
+import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -28,6 +30,7 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
+import java.time.Instant
 
 class CorpseFinderListViewModelTest : BaseTest() {
 
@@ -60,6 +63,26 @@ class CorpseFinderListViewModelTest : BaseTest() {
         val taskSubmitter: TaskSubmitter,
         val dataFlow: MutableStateFlow<CorpseFinder.Data?>,
         val progressFlow: MutableStateFlow<Progress.Data?>,
+        val taskStateFlow: MutableStateFlow<TaskSubmitter.State>,
+        /** Builds another ViewModel against the same mocks, i.e. a second entry into the screen. */
+        val newVm: () -> CorpseFinderListViewModel,
+    )
+
+    private fun managedTask(
+        id: String = "task-1",
+        complete: Boolean = false,
+        cancelled: Boolean = false,
+        error: Throwable? = null,
+        toolType: SDMTool.Type = SDMTool.Type.CORPSEFINDER,
+    ): TaskSubmitter.ManagedTask = TaskSubmitter.ManagedTask(
+        id = id,
+        toolType = toolType,
+        task = mockk(relaxed = true),
+        queuedAt = Instant.now(),
+        startedAt = Instant.now(),
+        cancelledAt = if (cancelled) Instant.now() else null,
+        completedAt = if (complete) Instant.now() else null,
+        error = error,
     )
 
     private class CollectedEvents<T>(
@@ -84,6 +107,7 @@ class CorpseFinderListViewModelTest : BaseTest() {
     private fun harness(
         data: CorpseFinder.Data? = null,
         progress: Progress.Data? = null,
+        tasks: Collection<TaskSubmitter.ManagedTask> = emptySet(),
     ): Harness {
         val dataFlow = MutableStateFlow(data)
         val progressFlow = MutableStateFlow(progress)
@@ -97,13 +121,21 @@ class CorpseFinderListViewModelTest : BaseTest() {
             }
             every { this@apply.progress } returns progressFlow
         }
-        val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
-        val vm = CorpseFinderListViewModel(
-            dispatcherProvider = TestDispatcherProvider(),
-            corpseFinder = corpseFinder,
-            taskSubmitter = taskSubmitter,
-        )
-        return Harness(vm, corpseFinder, taskSubmitter, dataFlow, progressFlow)
+        // A real flow, not the relaxed mock's empty one: the entry logic waits on
+        // taskSubmitter.state.first { ... }, which against an empty flow dies with
+        // NoSuchElementException inside vmScope - silently, leaving the whole path untested.
+        val taskStateFlow = MutableStateFlow(TaskSubmitter.State(tasks = tasks))
+        val taskSubmitter = mockk<TaskSubmitter>(relaxed = true).apply {
+            every { this@apply.state } returns taskStateFlow
+        }
+        val newVm = {
+            CorpseFinderListViewModel(
+                dispatcherProvider = TestDispatcherProvider(),
+                corpseFinder = corpseFinder,
+                taskSubmitter = taskSubmitter,
+            )
+        }
+        return Harness(newVm(), corpseFinder, taskSubmitter, dataFlow, progressFlow, taskStateFlow, newVm)
     }
 
     @Test
@@ -370,5 +402,157 @@ class CorpseFinderListViewModelTest : BaseTest() {
             vm.navEvents.collect { list.add(it) }
         }
         return CollectedEvents(list, job)
+    }
+
+    private fun CoroutineScope.collectErrors(
+        vm: CorpseFinderListViewModel,
+    ): CollectedEvents<Throwable> {
+        val list = mutableListOf<Throwable>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.errorEvents.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    // ──────────────────────────── entry / cold scan ────────────────────────────
+
+    @Test
+    fun `constructing the ViewModel does not push an error into errorEvents`() = runTest2 {
+        // Guards the harness itself: with a relaxed TaskSubmitter mock the entry logic's
+        // first { ... } dies on an empty flow and every entry test below would pass vacuously.
+        val h = harness(data = null)
+        val errors = collectErrors(h.vm)
+        advanceUntilIdle()
+
+        errors.list shouldBe emptyList()
+        errors.cancel()
+    }
+
+    @Test
+    fun `cold entry without data submits exactly one scan`() = runTest2 {
+        val h = harness(data = null)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(CorpseFinderScanTask()) }
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(any()) }
+        // The entry scan must go through the atomic API, never plain submit().
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `entry with data present does not scan`() = runTest2 {
+        val h = harness(data = CorpseFinder.Data(corpses = listOf(corpse("a", 100))))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+    }
+
+    @Test
+    fun `entry during a task that completes with data does not scan`() = runTest2 {
+        val h = harness(data = null, tasks = setOf(managedTask()))
+        advanceUntilIdle()
+        // Still waiting on the in-flight task, so nothing submitted yet.
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+
+        h.dataFlow.value = CorpseFinder.Data(corpses = listOf(corpse("a", 100)))
+        h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(complete = true)))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+    }
+
+    @Test
+    fun `entry during a task that completes without data scans`() = runTest2 {
+        // The uninstall watcher's task completes normally but never assigns data. Bailing out on it
+        // would strand the screen on the loading placeholder.
+        val h = harness(data = null, tasks = setOf(managedTask()))
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(complete = true)))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(CorpseFinderScanTask()) }
+    }
+
+    @Test
+    fun `entry during a task that gets cancelled navigates up instead of scanning`() = runTest2 {
+        val h = harness(data = null, tasks = setOf(managedTask()))
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(complete = true, cancelled = true)),
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+        nav.list shouldBe listOf(NavEvent.Up)
+        nav.cancel()
+    }
+
+    @Test
+    fun `entry during a task that fails navigates up instead of scanning`() = runTest2 {
+        val h = harness(data = null, tasks = setOf(managedTask()))
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(complete = true, error = IllegalStateException("nope"))),
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+        nav.list shouldBe listOf(NavEvent.Up)
+        nav.cancel()
+    }
+
+    @Test
+    fun `two entries racing the same registration produce exactly one scan`() = runTest2 {
+        // Mirrors TaskManager.submitIfToolIdle: registration only happens while the tool has no
+        // incomplete task, and both callers get here before either registered. A ViewModel that
+        // used plain submit() would produce two full scans, the second wiping the first's results.
+        val h = harness(data = null)
+        val registered = mutableListOf<Any>()
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            if (registered.isEmpty()) {
+                registered.add(firstArg())
+                null
+            } else {
+                null
+            }
+        }
+
+        h.newVm()
+        h.newVm()
+        advanceUntilIdle()
+
+        registered.size shouldBe 1
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    // ─────────────────────────────── navUp guards ───────────────────────────────
+
+    @Test
+    fun `a cold scan that finds nothing does not navigate up`() = runTest2 {
+        val h = harness(data = null)
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        // The scan lands its (empty) result...
+        h.dataFlow.value = CorpseFinder.Data(corpses = emptyList())
+        advanceUntilIdle()
+        // ...a progress tick re-emits the same Data through the tool's combine...
+        h.progressFlow.value = Progress.Data(extra = "tick")
+        advanceUntilIdle()
+        // ...and the scan writes lastResult, which changes Data but not the corpses (E2). Deduping
+        // on Data instead of on the corpse collection would let this slip past drop(1).
+        h.dataFlow.value = CorpseFinder.Data(
+            corpses = emptyList(),
+            lastResult = CorpseFinderDeleteTask.Success(affectedSpace = 0L, affectedPaths = emptySet()),
+        )
+        advanceUntilIdle()
+
+        nav.list shouldBe emptyList()
+        nav.cancel()
     }
 }

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModelTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/list/CorpseFinderListViewModelTest.kt
@@ -18,9 +18,12 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
@@ -127,6 +130,10 @@ class CorpseFinderListViewModelTest : BaseTest() {
         val taskStateFlow = MutableStateFlow(TaskSubmitter.State(tasks = tasks))
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true).apply {
             every { this@apply.state } returns taskStateFlow
+            // Explicit "accepted": the entry loop only exits on a non-null result, so leaving this
+            // to the relaxed mock would make the loop's exit condition an implementation detail of
+            // MockK. Tests that need a decline re-stub this.
+            coEvery { submitIfToolIdle(any()) } returns mockk<SDMTool.Task.Result>(relaxed = true)
         }
         val newVm = {
             CorpseFinderListViewModel(
@@ -516,8 +523,10 @@ class CorpseFinderListViewModelTest : BaseTest() {
         coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
             if (registered.isEmpty()) {
                 registered.add(firstArg())
-                null
+                mockk<SDMTool.Task.Result>(relaxed = true)
             } else {
+                // Declined, because the winner's task is in flight by the time we get here.
+                h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask()))
                 null
             }
         }
@@ -528,6 +537,99 @@ class CorpseFinderListViewModelTest : BaseTest() {
 
         registered.size shouldBe 1
         coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `an entry scan that fails surfaces the error and shows the empty state`() = runTest2 {
+        val h = harness(data = null)
+        val boom = IllegalStateException("scan blew up")
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } throws boom
+
+        val vm = h.newVm()
+        val errors = collectErrors(vm)
+        val nav = collectNavEvents(vm)
+        val stateJob = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        errors.list shouldBe listOf(boom)
+        // navUp would dispose this screen's host before it can render the error dialog, so the
+        // user would land on the Dashboard with no indication that anything went wrong.
+        nav.list shouldBe emptyList()
+        // Nothing is going to deliver data anymore: show the empty state, not a forever placeholder.
+        vm.state.value.rows shouldBe emptyList()
+
+        stateJob.cancel()
+        errors.cancel()
+        nav.cancel()
+    }
+
+    @Test
+    fun `an entry scan that is cancelled navigates up`() = runTest2 {
+        val h = harness(data = null)
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } throws CancellationException("user cancelled")
+
+        val vm = h.newVm()
+        val nav = collectNavEvents(vm)
+        val errors = collectErrors(vm)
+        advanceUntilIdle()
+
+        nav.list shouldBe listOf(NavEvent.Up)
+        errors.list shouldBe emptyList()
+        nav.cancel()
+        errors.cancel()
+    }
+
+    @Test
+    fun `ViewModel teardown during the entry scan does not navigate up`() = runTest2 {
+        val h = harness(data = null)
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            // What teardown looks like from inside the submit: our own job is cancelled. That must
+            // rethrow instead of being read as "the user cancelled the scan" and navigating.
+            currentCoroutineContext().cancel()
+            throw CancellationException("ViewModel cleared")
+        }
+
+        val vm = h.newVm()
+        val nav = collectNavEvents(vm)
+        val stateJob = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        nav.list shouldBe emptyList()
+        // Teardown is not a scan failure, so no empty state is faked either.
+        vm.state.value.rows shouldBe null
+
+        stateJob.cancel()
+        nav.cancel()
+    }
+
+    @Test
+    fun `a declined entry submit is retried after the competing task completes without data`() = runTest2 {
+        val h = harness(data = null)
+        val submitted = mutableListOf<Any>()
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            submitted.add(firstArg())
+            if (submitted.size == 1) {
+                // Declined: a competing task (the uninstall watcher) registered inside the race
+                // window and is now in flight.
+                h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(id = "competing")))
+                null
+            } else {
+                mockk<SDMTool.Task.Result>(relaxed = true)
+            }
+        }
+
+        h.newVm()
+        advanceUntilIdle()
+        submitted.size shouldBe 1
+
+        // The competing task completes normally but never assigns data. Treating the decline as
+        // "someone else will deliver" would leave the screen loading forever.
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(id = "competing", complete = true)),
+        )
+        advanceUntilIdle()
+
+        submitted shouldBe listOf(CorpseFinderScanTask(), CorpseFinderScanTask())
     }
 
     // ─────────────────────────────── navUp guards ───────────────────────────────

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
@@ -5,6 +5,8 @@ import eu.darken.sdmse.common.compose.snackbar.ToolListEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.SingleEventFlow
@@ -28,6 +30,10 @@ import eu.darken.sdmse.deduplicator.ui.DeduplicatorDetailsRoute
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.main.core.taskmanager.getLatestTask
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -51,6 +57,9 @@ class DeduplicatorListViewModel @Inject constructor(
     private val upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider = dispatcherProvider, tag = TAG) {
 
+    /** Set when the scan this screen started for itself failed, see the entry logic below. */
+    private val entryScanFailed = MutableStateFlow(false)
+
     init {
         // Start an initial scan if Deduplicator has no data yet. The Dashboard only navigates here
         // after scanning, but the navigation back stack is saved-state backed while the tool's data
@@ -62,21 +71,44 @@ class DeduplicatorListViewModel @Inject constructor(
         // because an incomplete task is no promise that data is coming — a task that completes
         // without producing data would strand this screen on the loading placeholder for good.
         launch {
-            val idleState = taskSubmitter.state.first { st ->
-                st.tasks.none { it.toolType == SDMTool.Type.DEDUPLICATOR && !it.isComplete }
+            while (true) {
+                val idleState = taskSubmitter.state.first { st ->
+                    st.tasks.none { it.toolType == SDMTool.Type.DEDUPLICATOR && !it.isComplete }
+                }
+                // A scan the user cancelled must not be restarted behind their back, and a failed one
+                // would most likely just fail again. Scans are started from the Dashboard, so that's
+                // where we send them. No completed entry at all is the process-death case: scan.
+                val latest = idleState.getLatestTask(SDMTool.Type.DEDUPLICATOR)
+                if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
+                    navUp()
+                    return@launch
+                }
+                if (deduplicator.state.first().data != null) return@launch
+                // Atomic submit: between the idle check above and here another entry point (a second
+                // screen, the Dashboard) may have registered its own scan.
+                val submitted = try {
+                    taskSubmitter.submitIfToolIdle(DeduplicatorScanTask())
+                } catch (e: CancellationException) {
+                    // Rethrows if the ViewModel itself is going away, so teardown doesn't navigate.
+                    currentCoroutineContext().ensureActive()
+                    log(TAG, INFO) { "Entry scan was cancelled" }
+                    navUp()
+                    return@launch
+                } catch (e: Exception) {
+                    // No navUp here: the error dialog lives in this screen's host, so navigating
+                    // away would dispose it before it renders and the user would see nothing. No
+                    // rethrow either, that would emit the same error a second time through
+                    // launchErrorHandler. The failure flag turns the placeholder into an empty state.
+                    log(TAG, WARN) { "Entry scan failed: ${e.asLog()}" }
+                    entryScanFailed.value = true
+                    errorEvents.emit(e)
+                    return@launch
+                }
+                // Declined: another task for this tool registered in the race window. It may well
+                // complete without producing any data, so wait it out and decide again instead of
+                // leaving the screen loading forever.
+                if (submitted != null) return@launch
             }
-            // A scan the user cancelled must not be restarted behind their back, and a failed one
-            // would most likely just fail again. Scans are started from the Dashboard, so that's
-            // where we send them. No completed entry at all is the process-death case: scan.
-            val latest = idleState.getLatestTask(SDMTool.Type.DEDUPLICATOR)
-            if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
-                navUp()
-                return@launch
-            }
-            if (deduplicator.state.first().data != null) return@launch
-            // Atomic submit: between the idle check above and here another entry point (a second
-            // screen, the Dashboard) may have registered its own scan.
-            taskSubmitter.submitIfToolIdle(DeduplicatorScanTask())
         }
         // navUp only on a real drain-to-empty. mapNotNull skips the null loading state, and
         // distinctUntilChanged() drops the repeats: the tool's state combines data with progress, so
@@ -113,12 +145,12 @@ class DeduplicatorListViewModel @Inject constructor(
     // the clusters and re-run computeDeleteTargets/freeableSizeOf per cluster. Progress, layout and
     // allowDeleteAll are merged in the outer combine (below) as a cheap field swap that preserves the
     // rows List instance, letting keyed lazy rows skip recomposition.
-    private val rowsFlow = deduplicator.state
-        .map { it.data }
-        .filterNotNull()
-        .distinctUntilChanged()
-        .map { data ->
-            data.clusters
+    private val rowsFlow = combine(
+        deduplicator.state.map { it.data }.distinctUntilChanged(),
+        entryScanFailed,
+    ) { data, scanFailed ->
+        when {
+            data != null -> data.clusters
                 .sortedByDescending { it.averageSize }
                 .map { cluster ->
                     val deleteTargetIds = cluster.computeDeleteTargets()
@@ -128,7 +160,12 @@ class DeduplicatorListViewModel @Inject constructor(
                         freeableSize = cluster.freeableSizeOf(deleteTargetIds),
                     )
                 }
+            // Null rows mean "loading". Without data and without a scan that could still deliver
+            // it, that placeholder would never go away, so show the empty state instead.
+            scanFailed -> emptyList<DeduplicatorListRow>()
+            else -> null
         }
+    }
 
     val state: StateFlow<State?> = combine(
         rowsFlow,
@@ -136,7 +173,11 @@ class DeduplicatorListViewModel @Inject constructor(
         settings.layoutMode.flow,
         settings.allowDeleteAll.flow,
     ) { rows, progress, layoutMode, allowDeleteAll ->
-        State(rows = rows, progress = progress, layoutMode = layoutMode, allowDeleteAll = allowDeleteAll)
+        // A null state is what the screen renders as loading, so rows stay null until there is
+        // either data or a failed entry scan.
+        rows?.let {
+            State(rows = it, progress = progress, layoutMode = layoutMode, allowDeleteAll = allowDeleteAll)
+        }
     }.safeStateIn(
         initialValue = null,
         onError = { null },

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
@@ -21,6 +21,7 @@ import eu.darken.sdmse.deduplicator.core.DeduplicatorSettings
 import eu.darken.sdmse.deduplicator.core.Duplicate
 import eu.darken.sdmse.deduplicator.core.hasData
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorDeleteTask
+import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorScanTask
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorTask
 import eu.darken.sdmse.deduplicator.core.tasks.isSingleDuplicateDelete
 import eu.darken.sdmse.deduplicator.ui.DeduplicatorDetailsRoute
@@ -51,8 +52,39 @@ class DeduplicatorListViewModel @Inject constructor(
 ) : ViewModel4(dispatcherProvider = dispatcherProvider, tag = TAG) {
 
     init {
+        // Start an initial scan if Deduplicator has no data yet. The Dashboard only navigates here
+        // after scanning, but the navigation back stack is saved-state backed while the tool's data
+        // is plain in-memory state: after process death the restored screen comes back with no data
+        // at all and would sit on the loading placeholder forever.
+        //
+        // Wait out any in-flight task before deciding: performScan nulls the data while it runs, so
+        // checking immediately would duplicate an expensive scan. We wait instead of bailing out
+        // because an incomplete task is no promise that data is coming — a task that completes
+        // without producing data would strand this screen on the loading placeholder for good.
+        launch {
+            val idleState = taskSubmitter.state.first { st ->
+                st.tasks.none { it.toolType == SDMTool.Type.DEDUPLICATOR && !it.isComplete }
+            }
+            // A scan the user cancelled must not be restarted behind their back, and a failed one
+            // would most likely just fail again. Scans are started from the Dashboard, so that's
+            // where we send them. No completed entry at all is the process-death case: scan.
+            val latest = idleState.getLatestTask(SDMTool.Type.DEDUPLICATOR)
+            if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
+                navUp()
+                return@launch
+            }
+            if (deduplicator.state.first().data != null) return@launch
+            // Atomic submit: between the idle check above and here another entry point (a second
+            // screen, the Dashboard) may have registered its own scan.
+            taskSubmitter.submitIfToolIdle(DeduplicatorScanTask())
+        }
+        // navUp only on a real drain-to-empty. mapNotNull skips the null loading state, and
+        // distinctUntilChanged() drops the repeats: the tool's state combines data with progress, so
+        // the same Data re-emits on every progress tick and a cold empty scan would otherwise get
+        // past drop(1) on its second identical emission.
         deduplicator.state
             .mapNotNull { it.data }
+            .distinctUntilChanged()
             .drop(1)
             .filter { !it.hasData }
             .take(1)

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModelTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModelTest.kt
@@ -26,9 +26,12 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -175,6 +178,10 @@ class DeduplicatorListViewModelTest : BaseTest() {
         }
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true).apply {
             every { state } returns taskStateFlow
+            // Explicit "accepted": the entry loop only exits on a non-null result, so leaving this
+            // to the relaxed mock would make the loop's exit condition an implementation detail of
+            // MockK. Tests that need a decline re-stub this.
+            coEvery { submitIfToolIdle(any()) } returns mockk<SDMTool.Task.Result>(relaxed = true)
         }
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
@@ -208,8 +215,8 @@ class DeduplicatorListViewModelTest : BaseTest() {
     @Test
     fun `state stays null when Deduplicator data is null`() = runTest2 {
         val h = harness(clusters = null)
-        // combine() requires data != null (filterNotNull). With no data, the StateFlow stays at
-        // its safeStateIn initial value (null).
+        // Null rows publish a null state, which the screen renders as loading. With no data and no
+        // failed entry scan, the StateFlow stays at its safeStateIn initial value (null).
         h.vm.state.first() shouldBe null
     }
 
@@ -587,8 +594,14 @@ class DeduplicatorListViewModelTest : BaseTest() {
         val h = harness(clusters = null)
         val registered = mutableListOf<Any>()
         coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
-            if (registered.isEmpty()) registered.add(firstArg())
-            null
+            if (registered.isEmpty()) {
+                registered.add(firstArg())
+                mockk<SDMTool.Task.Result>(relaxed = true)
+            } else {
+                // Declined, because the winner's task is in flight by the time we get here.
+                h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask()))
+                null
+            }
         }
 
         h.newVm()
@@ -597,6 +610,98 @@ class DeduplicatorListViewModelTest : BaseTest() {
 
         registered.size shouldBe 1
         coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `an entry scan that fails surfaces the error and shows the empty state`() = runTest2 {
+        val h = harness(clusters = null)
+        val boom = IllegalStateException("scan blew up")
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } throws boom
+
+        val vm = h.newVm()
+        val errors = collectErrors(vm)
+        val nav = collectNavEvents(vm)
+        val stateJob = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        errors.list shouldBe listOf(boom)
+        // navUp would dispose this screen's host before it can render the error dialog, so the
+        // user would land on the Dashboard with no indication that anything went wrong.
+        nav.list shouldBe emptyList()
+        // Nothing is going to deliver data anymore: show the empty state, not a forever placeholder.
+        vm.state.value?.rows shouldBe emptyList()
+
+        stateJob.cancel()
+        errors.cancel()
+        nav.cancel()
+    }
+
+    @Test
+    fun `an entry scan that is cancelled navigates up`() = runTest2 {
+        val h = harness(clusters = null)
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } throws CancellationException("user cancelled")
+
+        val vm = h.newVm()
+        val nav = collectNavEvents(vm)
+        val errors = collectErrors(vm)
+        advanceUntilIdle()
+
+        nav.list shouldBe listOf(NavEvent.Up)
+        errors.list shouldBe emptyList()
+        nav.cancel()
+        errors.cancel()
+    }
+
+    @Test
+    fun `ViewModel teardown during the entry scan does not navigate up`() = runTest2 {
+        val h = harness(clusters = null)
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            // What teardown looks like from inside the submit: our own job is cancelled. That must
+            // rethrow instead of being read as "the user cancelled the scan" and navigating.
+            currentCoroutineContext().cancel()
+            throw CancellationException("ViewModel cleared")
+        }
+
+        val vm = h.newVm()
+        val nav = collectNavEvents(vm)
+        val stateJob = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        nav.list shouldBe emptyList()
+        // Teardown is not a scan failure, so no empty state is faked either.
+        vm.state.value shouldBe null
+
+        stateJob.cancel()
+        nav.cancel()
+    }
+
+    @Test
+    fun `a declined entry submit is retried after the competing task completes without data`() = runTest2 {
+        val h = harness(clusters = null)
+        val submitted = mutableListOf<Any>()
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            submitted.add(firstArg())
+            if (submitted.size == 1) {
+                // Declined: a competing task registered inside the race window and is now in flight.
+                h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(id = "competing")))
+                null
+            } else {
+                mockk<SDMTool.Task.Result>(relaxed = true)
+            }
+        }
+
+        h.newVm()
+        advanceUntilIdle()
+        submitted.size shouldBe 1
+
+        // The competing task completes normally but never assigns data. Treating the decline as
+        // "someone else will deliver" would leave the screen loading forever.
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(id = "competing", complete = true)),
+        )
+        advanceUntilIdle()
+
+        submitted shouldBe listOf(DeduplicatorScanTask(), DeduplicatorScanTask())
     }
 
     @Test

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModelTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModelTest.kt
@@ -11,6 +11,7 @@ import eu.darken.sdmse.deduplicator.core.DeduplicatorSettings
 import eu.darken.sdmse.deduplicator.core.Duplicate
 import eu.darken.sdmse.deduplicator.core.scanner.checksum.ChecksumDuplicate
 import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorDeleteTask
+import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorScanTask
 import eu.darken.sdmse.deduplicator.ui.DeduplicatorDetailsRoute
 import eu.darken.sdmse.deduplicator.ui.preview.previewChecksumDuplicate
 import eu.darken.sdmse.deduplicator.ui.preview.previewChecksumGroup
@@ -97,6 +98,25 @@ class DeduplicatorListViewModelTest : BaseTest() {
         val layoutModeFlow: MutableStateFlow<LayoutMode>,
         val allowDeleteAllFlow: MutableStateFlow<Boolean>,
         val values: Values,
+        /** Builds another ViewModel against the same mocks, i.e. a second entry into the screen. */
+        val newVm: () -> DeduplicatorListViewModel,
+    )
+
+    private fun managedTask(
+        id: String = "task-1",
+        complete: Boolean = false,
+        cancelled: Boolean = false,
+        error: Throwable? = null,
+        toolType: SDMTool.Type = SDMTool.Type.DEDUPLICATOR,
+    ): TaskSubmitter.ManagedTask = TaskSubmitter.ManagedTask(
+        id = id,
+        toolType = toolType,
+        task = mockk(relaxed = true),
+        queuedAt = Instant.now(),
+        startedAt = Instant.now(),
+        cancelledAt = if (cancelled) Instant.now() else null,
+        completedAt = if (complete) Instant.now() else null,
+        error = error,
     )
 
     private class CollectedEvents<T>(
@@ -128,11 +148,12 @@ class DeduplicatorListViewModelTest : BaseTest() {
         layoutMode: LayoutMode = LayoutMode.GRID,
         allowDeleteAll: Boolean = false,
         isPro: Boolean = true,
+        tasks: Collection<TaskSubmitter.ManagedTask> = emptySet(),
     ): Harness {
         val data = clusters?.let { Deduplicator.Data(clusters = it) }
         val stateFlow = MutableStateFlow(Deduplicator.State(data = data, progress = progress))
         val progressFlow = MutableStateFlow(progress)
-        val taskStateFlow = MutableStateFlow(TaskSubmitter.State(tasks = emptySet()))
+        val taskStateFlow = MutableStateFlow(TaskSubmitter.State(tasks = tasks))
         val layoutModeFlow = MutableStateFlow(layoutMode)
         val allowDeleteAllFlow = MutableStateFlow(allowDeleteAll)
 
@@ -158,15 +179,17 @@ class DeduplicatorListViewModelTest : BaseTest() {
         val upgradeRepo = mockk<UpgradeRepo>().apply {
             every { upgradeInfo } returns flowOf(upgradeInfo(isPro = isPro))
         }
-        val vm = DeduplicatorListViewModel(
-            dispatcherProvider = TestDispatcherProvider(),
-            deduplicator = deduplicator,
-            settings = settings,
-            taskSubmitter = taskSubmitter,
-            upgradeRepo = upgradeRepo,
-        )
+        val newVm = {
+            DeduplicatorListViewModel(
+                dispatcherProvider = TestDispatcherProvider(),
+                deduplicator = deduplicator,
+                settings = settings,
+                taskSubmitter = taskSubmitter,
+                upgradeRepo = upgradeRepo,
+            )
+        }
         return Harness(
-            vm = vm,
+            vm = newVm(),
             deduplicator = deduplicator,
             settings = settings,
             taskSubmitter = taskSubmitter,
@@ -176,6 +199,7 @@ class DeduplicatorListViewModelTest : BaseTest() {
             layoutModeFlow = layoutModeFlow,
             allowDeleteAllFlow = allowDeleteAllFlow,
             values = values,
+            newVm = newVm,
         )
     }
 
@@ -449,6 +473,147 @@ class DeduplicatorListViewModelTest : BaseTest() {
         h.vm.state.filterNotNull().first()
 
         h.stateFlow.value = Deduplicator.State(data = null, progress = Progress.Data())
+        advanceUntilIdle()
+
+        nav.list shouldBe emptyList()
+        nav.cancel()
+    }
+
+    // ──────────────────────────── entry / cold scan ────────────────────────────
+
+    private fun CoroutineScope.collectErrors(
+        vm: DeduplicatorListViewModel,
+    ): CollectedEvents<Throwable> {
+        val list = mutableListOf<Throwable>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.errorEvents.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    @Test
+    fun `constructing the ViewModel does not push an error into errorEvents`() = runTest2 {
+        val h = harness(clusters = null)
+        val errors = collectErrors(h.vm)
+        advanceUntilIdle()
+
+        errors.list shouldBe emptyList()
+        errors.cancel()
+    }
+
+    @Test
+    fun `cold entry without data submits exactly one scan`() = runTest2 {
+        val h = harness(clusters = null)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(DeduplicatorScanTask()) }
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(any()) }
+        // The entry scan must go through the atomic API, never plain submit().
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `entry with data present does not scan`() = runTest2 {
+        val h = harness(clusters = setOf(cluster("a")))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+    }
+
+    @Test
+    fun `entry during a task that completes with data does not scan`() = runTest2 {
+        val h = harness(clusters = null, tasks = setOf(managedTask()))
+        advanceUntilIdle()
+        // Still waiting on the in-flight task, so nothing submitted yet.
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+
+        h.stateFlow.value = Deduplicator.State(data = Deduplicator.Data(clusters = setOf(cluster("a"))), progress = null)
+        h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(complete = true)))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+    }
+
+    @Test
+    fun `entry during a task that completes without data scans`() = runTest2 {
+        // A task can complete normally without ever assigning data. Bailing out on it would strand
+        // the screen on the loading placeholder.
+        val h = harness(clusters = null, tasks = setOf(managedTask()))
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(complete = true)))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(DeduplicatorScanTask()) }
+    }
+
+    @Test
+    fun `entry during a task that gets cancelled navigates up instead of scanning`() = runTest2 {
+        val h = harness(clusters = null, tasks = setOf(managedTask()))
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(complete = true, cancelled = true)),
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+        nav.list shouldBe listOf(NavEvent.Up)
+        nav.cancel()
+    }
+
+    @Test
+    fun `entry during a task that fails navigates up instead of scanning`() = runTest2 {
+        val h = harness(clusters = null, tasks = setOf(managedTask()))
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(complete = true, error = IllegalStateException("nope"))),
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+        nav.list shouldBe listOf(NavEvent.Up)
+        nav.cancel()
+    }
+
+    @Test
+    fun `two entries racing the same registration produce exactly one scan`() = runTest2 {
+        // Mirrors TaskManager.submitIfToolIdle: registration only happens while the tool has no
+        // incomplete task, and both callers get here before either registered. A ViewModel that
+        // used plain submit() would produce two full scans, the second wiping the first's results.
+        val h = harness(clusters = null)
+        val registered = mutableListOf<Any>()
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            if (registered.isEmpty()) registered.add(firstArg())
+            null
+        }
+
+        h.newVm()
+        h.newVm()
+        advanceUntilIdle()
+
+        registered.size shouldBe 1
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `a cold scan that finds nothing does not navigate up`() = runTest2 {
+        val h = harness(clusters = null)
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        // The scan lands its (empty) result...
+        h.stateFlow.value = Deduplicator.State(data = Deduplicator.Data(clusters = emptySet()), progress = null)
+        advanceUntilIdle()
+        // ...and a progress tick re-emits the same Data through the tool's combine. Without the
+        // dedupe that second identical emission would get past drop(1) and navigate away.
+        h.stateFlow.value = Deduplicator.State(
+            data = Deduplicator.Data(clusters = emptySet()),
+            progress = Progress.Data(extra = "tick"),
+        )
         advanceUntilIdle()
 
         nav.list shouldBe emptyList()

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModel.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModel.kt
@@ -4,6 +4,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.sdmse.common.compose.snackbar.ToolListEvent
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.SingleEventFlow
@@ -20,6 +22,10 @@ import eu.darken.sdmse.systemcleaner.core.hasData
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
 import eu.darken.sdmse.systemcleaner.ui.FilterContentDetailsRoute
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -40,6 +46,9 @@ class SystemCleanerListViewModel @Inject constructor(
     private val taskSubmitter: TaskSubmitter,
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
 
+    /** Set when the scan this screen started for itself failed, see the entry logic below. */
+    private val entryScanFailed = MutableStateFlow(false)
+
     init {
         // Start an initial scan if SystemCleaner has no data yet. The Dashboard only navigates here
         // after scanning, but the navigation back stack is saved-state backed while the tool's data
@@ -51,21 +60,44 @@ class SystemCleanerListViewModel @Inject constructor(
         // because an incomplete task is no promise that data is coming — a task that completes
         // without producing data would strand this screen on the loading placeholder for good.
         launch {
-            val idleState = taskSubmitter.state.first { st ->
-                st.tasks.none { it.toolType == SDMTool.Type.SYSTEMCLEANER && !it.isComplete }
+            while (true) {
+                val idleState = taskSubmitter.state.first { st ->
+                    st.tasks.none { it.toolType == SDMTool.Type.SYSTEMCLEANER && !it.isComplete }
+                }
+                // A scan the user cancelled must not be restarted behind their back, and a failed one
+                // would most likely just fail again. Scans are started from the Dashboard, so that's
+                // where we send them. No completed entry at all is the process-death case: scan.
+                val latest = idleState.getLatestTask(SDMTool.Type.SYSTEMCLEANER)
+                if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
+                    navUp()
+                    return@launch
+                }
+                if (systemCleaner.state.first().data != null) return@launch
+                // Atomic submit: between the idle check above and here another entry point (a second
+                // screen, the Dashboard) may have registered its own scan.
+                val submitted = try {
+                    taskSubmitter.submitIfToolIdle(SystemCleanerScanTask())
+                } catch (e: CancellationException) {
+                    // Rethrows if the ViewModel itself is going away, so teardown doesn't navigate.
+                    currentCoroutineContext().ensureActive()
+                    log(TAG, INFO) { "Entry scan was cancelled" }
+                    navUp()
+                    return@launch
+                } catch (e: Exception) {
+                    // No navUp here: the error dialog lives in this screen's host, so navigating
+                    // away would dispose it before it renders and the user would see nothing. No
+                    // rethrow either, that would emit the same error a second time through
+                    // launchErrorHandler. The failure flag turns the placeholder into an empty state.
+                    log(TAG, WARN) { "Entry scan failed: ${e.asLog()}" }
+                    entryScanFailed.value = true
+                    errorEvents.emit(e)
+                    return@launch
+                }
+                // Declined: another task for this tool registered in the race window. It may well
+                // complete without producing any data, so wait it out and decide again instead of
+                // leaving the screen loading forever.
+                if (submitted != null) return@launch
             }
-            // A scan the user cancelled must not be restarted behind their back, and a failed one
-            // would most likely just fail again. Scans are started from the Dashboard, so that's
-            // where we send them. No completed entry at all is the process-death case: scan.
-            val latest = idleState.getLatestTask(SDMTool.Type.SYSTEMCLEANER)
-            if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
-                navUp()
-                return@launch
-            }
-            if (systemCleaner.state.first().data != null) return@launch
-            // Atomic submit: between the idle check above and here another entry point (a second
-            // screen, the Dashboard) may have registered its own scan.
-            taskSubmitter.submitIfToolIdle(SystemCleanerScanTask())
         }
         // mapNotNull { it.data } skips the null transitions performScan publishes at the start of a
         // refresh, so navUp fires only on a real drain-to-empty, not during loading. (was BUG-FIXME-9)
@@ -88,15 +120,21 @@ class SystemCleanerListViewModel @Inject constructor(
     // Row production excludes progress so high-frequency progress ticks during a scan don't re-sort
     // and re-map the whole filter-content list. Progress is merged in last (below) as a cheap field
     // swap that preserves the rows List instance, letting keyed lazy rows skip recomposition.
-    private val rowsState = systemCleaner.state
-        .map { it.data }
-        .distinctUntilChanged()
-        .map { data ->
-            val rows = data?.filterContents
-                ?.sortedByDescending { it.size }
-                ?.map { Row(content = it) }
-            State(rows = rows)
+    private val rowsState = combine(
+        systemCleaner.state.map { it.data }.distinctUntilChanged(),
+        entryScanFailed,
+    ) { data, scanFailed ->
+        val rows = when {
+            data != null -> data.filterContents
+                .sortedByDescending { it.size }
+                .map { Row(content = it) }
+            // Null rows mean "loading". Without data and without a scan that could still deliver
+            // it, that placeholder would never go away, so show the empty state instead.
+            scanFailed -> emptyList<Row>()
+            else -> null
         }
+        State(rows = rows)
+    }
 
     val state: StateFlow<State> = combine(
         rowsState,

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModel.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModel.kt
@@ -10,12 +10,15 @@ import eu.darken.sdmse.common.flow.SingleEventFlow
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.exclusion.ui.ExclusionsListRoute
+import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.main.core.taskmanager.getLatestTask
 import eu.darken.sdmse.systemcleaner.core.FilterContent
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import eu.darken.sdmse.systemcleaner.core.filter.FilterIdentifier
 import eu.darken.sdmse.systemcleaner.core.hasData
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
 import eu.darken.sdmse.systemcleaner.ui.FilterContentDetailsRoute
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -38,10 +41,40 @@ class SystemCleanerListViewModel @Inject constructor(
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
 
     init {
+        // Start an initial scan if SystemCleaner has no data yet. The Dashboard only navigates here
+        // after scanning, but the navigation back stack is saved-state backed while the tool's data
+        // is plain in-memory state: after process death the restored screen comes back with no data
+        // at all and would sit on the loading placeholder forever.
+        //
+        // Wait out any in-flight task before deciding: performScan nulls the data while it runs, so
+        // checking immediately would duplicate an expensive scan. We wait instead of bailing out
+        // because an incomplete task is no promise that data is coming — a task that completes
+        // without producing data would strand this screen on the loading placeholder for good.
+        launch {
+            val idleState = taskSubmitter.state.first { st ->
+                st.tasks.none { it.toolType == SDMTool.Type.SYSTEMCLEANER && !it.isComplete }
+            }
+            // A scan the user cancelled must not be restarted behind their back, and a failed one
+            // would most likely just fail again. Scans are started from the Dashboard, so that's
+            // where we send them. No completed entry at all is the process-death case: scan.
+            val latest = idleState.getLatestTask(SDMTool.Type.SYSTEMCLEANER)
+            if (latest != null && (latest.cancelledAt != null || latest.error != null)) {
+                navUp()
+                return@launch
+            }
+            if (systemCleaner.state.first().data != null) return@launch
+            // Atomic submit: between the idle check above and here another entry point (a second
+            // screen, the Dashboard) may have registered its own scan.
+            taskSubmitter.submitIfToolIdle(SystemCleanerScanTask())
+        }
         // mapNotNull { it.data } skips the null transitions performScan publishes at the start of a
         // refresh, so navUp fires only on a real drain-to-empty, not during loading. (was BUG-FIXME-9)
+        // distinctUntilChanged() drops the repeats: the tool's state combines data with progress, so
+        // the same Data re-emits on every progress tick and a cold empty scan would otherwise get
+        // past drop(1) on its second identical emission.
         systemCleaner.state
             .mapNotNull { it.data }
+            .distinctUntilChanged()
             .map { it.hasData }
             .drop(1)
             .filter { !it }

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModelTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModelTest.kt
@@ -5,11 +5,13 @@ import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.LocalPathLookup
 import eu.darken.sdmse.common.navigation.NavEvent
 import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.systemcleaner.core.FilterContent
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerProcessingTask
+import eu.darken.sdmse.systemcleaner.core.tasks.SystemCleanerScanTask
 import eu.darken.sdmse.systemcleaner.ui.preview.previewFilterContent
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -39,6 +41,26 @@ class SystemCleanerListViewModelTest : BaseTest() {
         val taskSubmitter: TaskSubmitter,
         val stateFlow: MutableStateFlow<SystemCleaner.State>,
         val progressFlow: MutableStateFlow<Progress.Data?>,
+        val taskStateFlow: MutableStateFlow<TaskSubmitter.State>,
+        /** Builds another ViewModel against the same mocks, i.e. a second entry into the screen. */
+        val newVm: () -> SystemCleanerListViewModel,
+    )
+
+    private fun managedTask(
+        id: String = "task-1",
+        complete: Boolean = false,
+        cancelled: Boolean = false,
+        error: Throwable? = null,
+        toolType: SDMTool.Type = SDMTool.Type.SYSTEMCLEANER,
+    ): TaskSubmitter.ManagedTask = TaskSubmitter.ManagedTask(
+        id = id,
+        toolType = toolType,
+        task = mockk(relaxed = true),
+        queuedAt = Instant.now(),
+        startedAt = Instant.now(),
+        cancelledAt = if (cancelled) Instant.now() else null,
+        completedAt = if (complete) Instant.now() else null,
+        error = error,
     )
 
     private class CollectedEvents<T>(
@@ -81,6 +103,7 @@ class SystemCleanerListViewModelTest : BaseTest() {
 
     private fun harness(
         filterContents: List<FilterContent>? = emptyList(),
+        tasks: Collection<TaskSubmitter.ManagedTask> = emptySet(),
     ): Harness {
         val data = filterContents?.let { SystemCleaner.Data(filterContents = it) }
         val stateFlow = MutableStateFlow(scState(data = data))
@@ -89,13 +112,21 @@ class SystemCleanerListViewModelTest : BaseTest() {
             every { this@apply.state } returns stateFlow
             every { this@apply.progress } returns progressFlow
         }
-        val taskSubmitter = mockk<TaskSubmitter>(relaxed = true)
-        val vm = SystemCleanerListViewModel(
-            dispatcherProvider = TestDispatcherProvider(),
-            systemCleaner = systemCleaner,
-            taskSubmitter = taskSubmitter,
-        )
-        return Harness(vm, systemCleaner, taskSubmitter, stateFlow, progressFlow)
+        // A real flow, not the relaxed mock's empty one: the entry logic waits on
+        // taskSubmitter.state.first { ... }, which against an empty flow dies with
+        // NoSuchElementException inside vmScope - silently, leaving the whole path untested.
+        val taskStateFlow = MutableStateFlow(TaskSubmitter.State(tasks = tasks))
+        val taskSubmitter = mockk<TaskSubmitter>(relaxed = true).apply {
+            every { this@apply.state } returns taskStateFlow
+        }
+        val newVm = {
+            SystemCleanerListViewModel(
+                dispatcherProvider = TestDispatcherProvider(),
+                systemCleaner = systemCleaner,
+                taskSubmitter = taskSubmitter,
+            )
+        }
+        return Harness(newVm(), systemCleaner, taskSubmitter, stateFlow, progressFlow, taskStateFlow, newVm)
     }
 
     private fun previewMatch(path: String, size: Long = 1024L): SystemCleanerFilter.Match.Deletion =
@@ -319,6 +350,150 @@ class SystemCleanerListViewModelTest : BaseTest() {
         val nav = collectNavEvents(h.vm)
 
         h.stateFlow.value = scState(data = null)
+        advanceUntilIdle()
+
+        nav.list shouldBe emptyList()
+        nav.cancel()
+    }
+
+    // ──────────────────────────── entry / cold scan ────────────────────────────
+
+    private fun CoroutineScope.collectErrors(
+        vm: SystemCleanerListViewModel,
+    ): CollectedEvents<Throwable> {
+        val list = mutableListOf<Throwable>()
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.errorEvents.collect { list.add(it) }
+        }
+        return CollectedEvents(list, job)
+    }
+
+    @Test
+    fun `constructing the ViewModel does not push an error into errorEvents`() = runTest2 {
+        // Guards the harness itself: with a relaxed TaskSubmitter mock the entry logic's
+        // first { ... } dies on an empty flow and every entry test below would pass vacuously.
+        val h = harness(filterContents = null)
+        val errors = collectErrors(h.vm)
+        advanceUntilIdle()
+
+        errors.list shouldBe emptyList()
+        errors.cancel()
+    }
+
+    @Test
+    fun `cold entry without data submits exactly one scan`() = runTest2 {
+        val h = harness(filterContents = null)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(SystemCleanerScanTask()) }
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(any()) }
+        // The entry scan must go through the atomic API, never plain submit().
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `entry with data present does not scan`() = runTest2 {
+        val h = harness(listOf(previewFilterContent(identifier = "f", items = listOf(previewMatch("a")))))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+    }
+
+    @Test
+    fun `entry during a task that completes with data does not scan`() = runTest2 {
+        val h = harness(filterContents = null, tasks = setOf(managedTask()))
+        advanceUntilIdle()
+        // Still waiting on the in-flight task, so nothing submitted yet.
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+
+        val fc = previewFilterContent(identifier = "f", items = listOf(previewMatch("a")))
+        h.stateFlow.value = scState(data = SystemCleaner.Data(filterContents = listOf(fc)))
+        h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(complete = true)))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+    }
+
+    @Test
+    fun `entry during a task that completes without data scans`() = runTest2 {
+        // A task can complete normally without ever assigning data. Bailing out on it would strand
+        // the screen on the loading placeholder.
+        val h = harness(filterContents = null, tasks = setOf(managedTask()))
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(complete = true)))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.taskSubmitter.submitIfToolIdle(SystemCleanerScanTask()) }
+    }
+
+    @Test
+    fun `entry during a task that gets cancelled navigates up instead of scanning`() = runTest2 {
+        val h = harness(filterContents = null, tasks = setOf(managedTask()))
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(complete = true, cancelled = true)),
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+        nav.list shouldBe listOf(NavEvent.Up)
+        nav.cancel()
+    }
+
+    @Test
+    fun `entry during a task that fails navigates up instead of scanning`() = runTest2 {
+        val h = harness(filterContents = null, tasks = setOf(managedTask()))
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(complete = true, error = IllegalStateException("nope"))),
+        )
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.taskSubmitter.submitIfToolIdle(any()) }
+        nav.list shouldBe listOf(NavEvent.Up)
+        nav.cancel()
+    }
+
+    @Test
+    fun `two entries racing the same registration produce exactly one scan`() = runTest2 {
+        // Mirrors TaskManager.submitIfToolIdle: registration only happens while the tool has no
+        // incomplete task, and both callers get here before either registered. A ViewModel that
+        // used plain submit() would produce two full scans, the second wiping the first's results.
+        val h = harness(filterContents = null)
+        val registered = mutableListOf<Any>()
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            if (registered.isEmpty()) registered.add(firstArg())
+            null
+        }
+
+        h.newVm()
+        h.newVm()
+        advanceUntilIdle()
+
+        registered.size shouldBe 1
+        coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `a cold scan that finds nothing does not navigate up`() = runTest2 {
+        val h = harness(filterContents = null)
+        val nav = collectNavEvents(h.vm)
+        advanceUntilIdle()
+
+        // The scan lands its (empty) result...
+        h.stateFlow.value = scState(data = SystemCleaner.Data(filterContents = emptyList()))
+        advanceUntilIdle()
+        // ...and a progress tick re-emits the same Data through the tool's combine. Without the
+        // dedupe that second identical emission would get past drop(1) and navigate away.
+        h.stateFlow.value = scState(
+            data = SystemCleaner.Data(filterContents = emptyList()),
+            progress = Progress.Data(extra = "tick"),
+        )
         advanceUntilIdle()
 
         nav.list shouldBe emptyList()

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModelTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/list/SystemCleanerListViewModelTest.kt
@@ -20,9 +20,12 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -118,6 +121,10 @@ class SystemCleanerListViewModelTest : BaseTest() {
         val taskStateFlow = MutableStateFlow(TaskSubmitter.State(tasks = tasks))
         val taskSubmitter = mockk<TaskSubmitter>(relaxed = true).apply {
             every { this@apply.state } returns taskStateFlow
+            // Explicit "accepted": the entry loop only exits on a non-null result, so leaving this
+            // to the relaxed mock would make the loop's exit condition an implementation detail of
+            // MockK. Tests that need a decline re-stub this.
+            coEvery { submitIfToolIdle(any()) } returns mockk<SDMTool.Task.Result>(relaxed = true)
         }
         val newVm = {
             SystemCleanerListViewModel(
@@ -467,8 +474,14 @@ class SystemCleanerListViewModelTest : BaseTest() {
         val h = harness(filterContents = null)
         val registered = mutableListOf<Any>()
         coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
-            if (registered.isEmpty()) registered.add(firstArg())
-            null
+            if (registered.isEmpty()) {
+                registered.add(firstArg())
+                mockk<SDMTool.Task.Result>(relaxed = true)
+            } else {
+                // Declined, because the winner's task is in flight by the time we get here.
+                h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask()))
+                null
+            }
         }
 
         h.newVm()
@@ -477,6 +490,98 @@ class SystemCleanerListViewModelTest : BaseTest() {
 
         registered.size shouldBe 1
         coVerify(exactly = 0) { h.taskSubmitter.submit(any()) }
+    }
+
+    @Test
+    fun `an entry scan that fails surfaces the error and shows the empty state`() = runTest2 {
+        val h = harness(filterContents = null)
+        val boom = IllegalStateException("scan blew up")
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } throws boom
+
+        val vm = h.newVm()
+        val errors = collectErrors(vm)
+        val nav = collectNavEvents(vm)
+        val stateJob = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        errors.list shouldBe listOf(boom)
+        // navUp would dispose this screen's host before it can render the error dialog, so the
+        // user would land on the Dashboard with no indication that anything went wrong.
+        nav.list shouldBe emptyList()
+        // Nothing is going to deliver data anymore: show the empty state, not a forever placeholder.
+        vm.state.value.rows shouldBe emptyList()
+
+        stateJob.cancel()
+        errors.cancel()
+        nav.cancel()
+    }
+
+    @Test
+    fun `an entry scan that is cancelled navigates up`() = runTest2 {
+        val h = harness(filterContents = null)
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } throws CancellationException("user cancelled")
+
+        val vm = h.newVm()
+        val nav = collectNavEvents(vm)
+        val errors = collectErrors(vm)
+        advanceUntilIdle()
+
+        nav.list shouldBe listOf(NavEvent.Up)
+        errors.list shouldBe emptyList()
+        nav.cancel()
+        errors.cancel()
+    }
+
+    @Test
+    fun `ViewModel teardown during the entry scan does not navigate up`() = runTest2 {
+        val h = harness(filterContents = null)
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            // What teardown looks like from inside the submit: our own job is cancelled. That must
+            // rethrow instead of being read as "the user cancelled the scan" and navigating.
+            currentCoroutineContext().cancel()
+            throw CancellationException("ViewModel cleared")
+        }
+
+        val vm = h.newVm()
+        val nav = collectNavEvents(vm)
+        val stateJob = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        advanceUntilIdle()
+
+        nav.list shouldBe emptyList()
+        // Teardown is not a scan failure, so no empty state is faked either.
+        vm.state.value.rows shouldBe null
+
+        stateJob.cancel()
+        nav.cancel()
+    }
+
+    @Test
+    fun `a declined entry submit is retried after the competing task completes without data`() = runTest2 {
+        val h = harness(filterContents = null)
+        val submitted = mutableListOf<Any>()
+        coEvery { h.taskSubmitter.submitIfToolIdle(any()) } coAnswers {
+            submitted.add(firstArg())
+            if (submitted.size == 1) {
+                // Declined: a competing task registered inside the race window and is now in flight.
+                h.taskStateFlow.value = TaskSubmitter.State(tasks = setOf(managedTask(id = "competing")))
+                null
+            } else {
+                mockk<SDMTool.Task.Result>(relaxed = true)
+            }
+        }
+
+        h.newVm()
+        advanceUntilIdle()
+        submitted.size shouldBe 1
+
+        // The competing task completes normally but never assigns data. Treating the decline as
+        // "someone else will deliver" would leave the screen loading forever.
+        h.taskStateFlow.value = TaskSubmitter.State(
+            tasks = setOf(managedTask(id = "competing", complete = true)),
+        )
+        advanceUntilIdle()
+
+        submitted shouldBe listOf(SystemCleanerScanTask(), SystemCleanerScanTask())
     }
 
     @Test

--- a/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManager.kt
@@ -220,6 +220,26 @@ class TaskManager @Inject constructor(
 
     override suspend fun submit(task: SDMTool.Task, notifyOnFinish: Boolean): SDMTool.Task.Result {
         log(TAG, INFO) { "submit(): $task (notifyOnFinish=$notifyOnFinish)" }
+        return submitInternal(task, notifyOnFinish, declineIfToolBusy = false)!!
+    }
+
+    override suspend fun submitIfToolIdle(task: SDMTool.Task, notifyOnFinish: Boolean): SDMTool.Task.Result? {
+        log(TAG, INFO) { "submitIfToolIdle(): $task (notifyOnFinish=$notifyOnFinish)" }
+        return submitInternal(task, notifyOnFinish, declineIfToolBusy = true)
+    }
+
+    /**
+     * Shared submit implementation. With [declineIfToolBusy] the "does this tool already have an
+     * incomplete task?" check and the registration happen inside a single [updateTasks] block, i.e.
+     * under [managerLock], so two concurrent callers can't both observe an idle tool and both
+     * register a task. Returns null when the submission was declined, which cannot happen while
+     * [declineIfToolBusy] is false.
+     */
+    private suspend fun submitInternal(
+        task: SDMTool.Task,
+        notifyOnFinish: Boolean,
+        declineIfToolBusy: Boolean,
+    ): SDMTool.Task.Result? {
         val taskId = rngString
 
         // The task's outcome is signalled through this deferred, NOT through the task map: a failing
@@ -352,6 +372,8 @@ class TaskManager @Inject constructor(
             }
         }
 
+        var declined = false
+
         withContext(NonCancellable) {
             // Any task causes the taskmanager to stay "alive" and with it any depending resources
             // Only release all resources once all tasks are finished.
@@ -361,6 +383,12 @@ class TaskManager @Inject constructor(
             sharedResource.addChild(tool.sharedResource)
 
             updateTasks {
+                if (declineIfToolBusy && values.any { it.toolType == task.type && !it.isComplete }) {
+                    declined = true
+                    log(TAG, INFO) { "submit(): Declined, ${task.type} already has an incomplete task" }
+                    return@updateTasks
+                }
+
                 val entry = TaskEntry(
                     id = taskId,
                     task = task,
@@ -374,7 +402,17 @@ class TaskManager @Inject constructor(
 
                 log(TAG) { "submit(): Queued: $entry" }
             }
+
+            if (declined) {
+                // The job is LAZY and was never registered, so nothing would ever start it.
+                // Cancelling it completes the outcome deferred, and the safety net above no-ops on
+                // the missing entry; the keep-alive taken for it has to go back here.
+                job.cancel()
+                runCatching { keepAlive.close() }
+            }
         }
+
+        if (declined) return null
 
         job.join()
 

--- a/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManager.kt
@@ -289,10 +289,66 @@ class TaskManager @Inject constructor(
 
         job.invokeOnCompletion { log(TAG, VERBOSE) { "Task completion: ${taskEntries.value[taskId]}" } }
         // Safety net for a LAZY job that is cancelled before its body (and with it the finally above)
-        // ever ran — nothing else would ever complete the deferred.
+        // ever ran — nothing else would ever complete the deferred, and nothing would run the entry's
+        // bookkeeping either. A stranded entry is not merely stale: completedAt stays null forever, so
+        // isComplete never turns true and anything waiting for the tool to fall idle waits forever.
         job.invokeOnCompletion { cause ->
             if (!outcome.isCompleted) {
                 outcome.complete(Result.failure(cause ?: IllegalStateException("Task job completed without outcome")))
+            }
+            // Cheap pre-check only; the authoritative one runs under managerLock below. A missing
+            // entry means cancellation beat registration, which leaves nothing to clean up.
+            val pending = taskEntries.value[taskId]
+            if (pending == null || pending.isComplete) return@invokeOnCompletion
+            // updateTasks() is suspend and takes managerLock, so it can't run in this handler.
+            appScope.launch {
+                try {
+                    updateTasks {
+                        // The normal finally may have completed the entry while we waited for the lock.
+                        val entry = this[taskId] ?: return@updateTasks
+                        if (entry.isComplete) return@updateTasks
+                        runCatching {
+                            log(TAG, WARN) { "Completing entry whose body never ran: ${task.type}-$taskId" }
+                        }
+                        // Progress is tool-wide, not per-task, and this cleanup runs asynchronously
+                        // (updateTasks is suspend), so a newer task for the same tool may have taken
+                        // over the progress in the meantime — clearing it would drop the dashboard's
+                        // running state and Cancel action for work that is still going. Registration
+                        // takes managerLock too, so any such task is visible here. The rest of the
+                        // cleanup below is entry-specific and always safe to run.
+                        val hasOtherIncompleteTask = values.any {
+                            it.id != taskId &&
+                                    it.toolType == entry.toolType &&
+                                    !it.isComplete
+                        }
+                        if (!hasOtherIncompleteTask) {
+                            // Throwable, not Exception: an Error from a tool's progress reset must
+                            // not skip the resource lock release or the completion publish below.
+                            try {
+                                entry.tool.updateProgress { null }
+                            } catch (e: Throwable) {
+                                runCatching {
+                                    log(TAG, WARN) { "Failed to reset progress for ${task.type}-$taskId: ${e.asLog()}" }
+                                }
+                            }
+                        }
+                        try {
+                            entry.resourceLock?.close()
+                        } catch (e: Throwable) {
+                            runCatching {
+                                log(TAG, WARN) { "Failed to release resource lock for ${task.type}-$taskId: ${e.asLog()}" }
+                            }
+                        }
+                        this[taskId] = entry.copy(
+                            completedAt = Instant.now(),
+                            error = cause,
+                        )
+                    }
+                } catch (e: Throwable) {
+                    runCatching {
+                        log(TAG, ERROR) { "Safety-net bookkeeping failed for ${task.type}-$taskId: ${e.asLog()}" }
+                    }
+                }
             }
         }
 

--- a/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/TaskManagerTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/TaskManagerTest.kt
@@ -1,30 +1,44 @@
 package eu.darken.sdmse.main.core.taskmanager
 
 import eu.darken.sdmse.common.backup.BackupOperationGate
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.sharedresource.KeepAlive
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.main.core.SDMTool
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.selects.select
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
 import java.io.IOException
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.CoroutineContext
 
 class TaskManagerTest : BaseTest() {
 
     private val taskWorkerControl: TaskWorkerControl = mockk(relaxed = true)
 
     private val task: SDMTool.Task = mockk<SDMTool.Task>(relaxed = true).apply {
+        every { type } returns SDMTool.Type.APPCLEANER
+    }
+    private val otherTask: SDMTool.Task = mockk<SDMTool.Task>(relaxed = true).apply {
         every { type } returns SDMTool.Type.APPCLEANER
     }
     private val taskResult: SDMTool.Task.Result = mockk<SDMTool.Task.Result>(relaxed = true).apply {
@@ -34,14 +48,86 @@ class TaskManagerTest : BaseTest() {
     /**
      * The shared resources close their leases through `runBlocking`, which would deadlock against a
      * virtual-time-only scope, so every test scope is combined with [Dispatchers.IO].
+     *
+     * Passing [progress] makes the mock hold real progress state, so tests can observe whether a
+     * cleanup path actually reset the tool's (tool-wide, not per-task) progress.
      */
-    private fun createTool(scope: CoroutineScope): SDMTool = mockk<SDMTool>(relaxed = true).apply {
+    private fun createTool(
+        scope: CoroutineScope,
+        progress: AtomicReference<Progress.Data?>? = null,
+    ): SDMTool = mockk<SDMTool>(relaxed = true).apply {
         every { type } returns SDMTool.Type.APPCLEANER
         every { sharedResource } returns SharedResource.createKeepAlive("test-tool", scope)
         coEvery { useRes<SDMTool.Task.Result>(any()) } coAnswers {
             firstArg<suspend (Any) -> SDMTool.Task.Result>().invoke(Unit)
         }
+        if (progress != null) {
+            every { updateProgress(any()) } answers {
+                val update = firstArg<(Progress.Data?) -> Progress.Data?>()
+                progress.set(update(progress.get()))
+            }
+        }
     }
+
+    /**
+     * Parks dispatched coroutine bodies per [Job] instead of running them. A LAZY task job whose
+     * first dispatch is parked is guaranteed to be cancelled BEFORE its body - and with it the
+     * `finally` that does the entry bookkeeping - ever ran. That is exactly the state the safety net
+     * exists for; racing a live dispatcher would only hit that window by luck.
+     */
+    private class ParkingDispatcher : CoroutineDispatcher() {
+        private val parked = mutableListOf<Pair<Job?, Runnable>>()
+        private var parking = false
+
+        fun park() {
+            synchronized(parked) { parking = true }
+        }
+
+        fun release(job: Job) = drain { it === job }
+
+        fun releaseAll() {
+            synchronized(parked) { parking = false }
+            drain { true }
+        }
+
+        private fun drain(matches: (Job?) -> Boolean) {
+            val due = synchronized(parked) {
+                val hits = parked.filter { matches(it.first) }
+                parked.removeAll(hits)
+                hits
+            }
+            due.forEach { (_, block) -> block.run() }
+        }
+
+        override fun dispatch(context: CoroutineContext, block: Runnable) {
+            synchronized(parked) {
+                if (parking) {
+                    parked.add(context[Job] to block)
+                    return
+                }
+            }
+            Dispatchers.IO.dispatch(context, block)
+        }
+    }
+
+    /**
+     * The entry map is private and the public `ManagedTask` projection deliberately carries neither
+     * the job nor the resource lease. The safety-net tests need both: the job to cancel exactly this
+     * entry (`cancel(type)` hits every task of the tool and does it from an async launch), and the
+     * lease to assert it was actually released.
+     */
+    private fun TaskManager.rawEntries(): Collection<Any> {
+        val field = TaskManager::class.java.getDeclaredField("taskEntries").apply { isAccessible = true }
+        @Suppress("UNCHECKED_CAST")
+        val entries = field.get(this) as MutableStateFlow<Map<String, Any>>
+        return entries.value.values
+    }
+
+    private fun Any.entryField(name: String): Any? =
+        javaClass.getDeclaredField(name).apply { isAccessible = true }.get(this)
+
+    private fun TaskManager.jobOf(task: SDMTool.Task): Job =
+        rawEntries().single { it.entryField("task") === task }.entryField("job") as Job
 
     /**
      * kotlinx' stacktrace recovery hands a caller that awaited across a suspension point a COPY of
@@ -50,9 +136,13 @@ class TaskManagerTest : BaseTest() {
     private fun Throwable.carries(original: Throwable): Boolean =
         generateSequence(this) { it.cause }.any { it === original }
 
-    private fun createManager(scope: CoroutineScope, tool: SDMTool) = TaskManager(
+    private fun createManager(
+        scope: CoroutineScope,
+        tool: SDMTool,
+        dispatcher: CoroutineDispatcher? = null,
+    ) = TaskManager(
         appScope = scope,
-        dispatcherProvider = TestDispatcherProvider(),
+        dispatcherProvider = TestDispatcherProvider(dispatcher),
         tools = setOf(tool),
         taskWorkerControl = taskWorkerControl,
         backupGate = BackupOperationGate(),
@@ -113,6 +203,177 @@ class TaskManagerTest : BaseTest() {
                 it.isComplete shouldBe true
                 it.result shouldBeSameInstanceAs taskResult
             }
+        }
+
+    @Test fun `a task cancelled before its body ran is still stamped complete`() =
+        runTest2(autoCancel = true) {
+            val scope = this + Dispatchers.IO
+            val tool = createTool(scope)
+            val dispatcher = ParkingDispatcher()
+            val manager = createManager(scope, tool, dispatcher)
+
+            dispatcher.park()
+            val caller = async(Dispatchers.IO) { runCatching { manager.submit(task) } }
+            manager.state.first { it.tasks.isNotEmpty() }
+
+            // Cancelled while the body sits parked: the finally that normally does the bookkeeping
+            // never runs, so without the safety net completedAt would stay null forever.
+            val job = manager.jobOf(task)
+            job.cancel()
+            dispatcher.releaseAll()
+
+            manager.state.first { it.tasks.single().isComplete }.tasks.single().let {
+                it.completedAt.shouldNotBeNull()
+                it.isComplete shouldBe true
+            }
+            // ...and the submit() caller is released instead of waiting on a job that never
+            // publishes anything.
+            caller.await().isFailure shouldBe true
+            // Guards the setup itself: if the body had run, the normal finally would have done the
+            // bookkeeping and this test would pass without ever exercising the safety net.
+            coVerify(exactly = 0) { tool.submit(any()) }
+        }
+
+    @Test fun `the safety net keeps the progress of another incomplete task for the same tool`() =
+        runTest2(autoCancel = true) {
+            val scope = this + Dispatchers.IO
+            val progress = AtomicReference<Progress.Data?>(null)
+            val tool = createTool(scope, progress)
+            val dispatcher = ParkingDispatcher()
+            val manager = createManager(scope, tool, dispatcher)
+
+            dispatcher.park()
+            val first = async(Dispatchers.IO) { runCatching { manager.submit(task) } }
+            manager.state.first { it.tasks.size == 1 }
+            val second = async(Dispatchers.IO) { runCatching { manager.submit(otherTask) } }
+            manager.state.first { it.tasks.size == 2 }
+
+            // Progress is tool-wide, not per-task. This stands in for what the still-incomplete
+            // first task owns; clearing it would drop the dashboard's running state for live work.
+            val owned = Progress.Data(extra = "owned-by-the-other-task")
+            progress.set(owned)
+
+            val secondJob = manager.jobOf(otherTask)
+            secondJob.cancel()
+            dispatcher.release(secondJob)
+
+            manager.state.first { st -> st.tasks.single { it.task === otherTask }.isComplete }
+            progress.get() shouldBe owned
+            coVerify(exactly = 0) { tool.submit(any()) }
+
+            val firstJob = manager.jobOf(task)
+            firstJob.cancel()
+            dispatcher.releaseAll()
+            manager.state.first { st -> st.tasks.all { it.isComplete } }
+            first.await()
+            second.await()
+        }
+
+    @Test fun `the safety net clears tool progress when nothing else is running for that tool`() =
+        runTest2(autoCancel = true) {
+            val scope = this + Dispatchers.IO
+            val progress = AtomicReference<Progress.Data?>(null)
+            val tool = createTool(scope, progress)
+            val dispatcher = ParkingDispatcher()
+            val manager = createManager(scope, tool, dispatcher)
+
+            dispatcher.park()
+            val caller = async(Dispatchers.IO) { runCatching { manager.submit(task) } }
+            manager.state.first { it.tasks.isNotEmpty() }
+            progress.set(Progress.Data(extra = "stale"))
+
+            val job = manager.jobOf(task)
+            job.cancel()
+            dispatcher.releaseAll()
+
+            manager.state.first { it.tasks.single().isComplete }
+            progress.get() shouldBe null
+            coVerify(exactly = 0) { tool.submit(any()) }
+            caller.await()
+        }
+
+    @Test fun `the safety net releases the resource lock even when the progress reset throws`() =
+        runTest2(autoCancel = true) {
+            val scope = this + Dispatchers.IO
+            val tool = createTool(scope)
+            val dispatcher = ParkingDispatcher()
+            val manager = createManager(scope, tool, dispatcher)
+
+            dispatcher.park()
+            val caller = async(Dispatchers.IO) { runCatching { manager.submit(task) } }
+            manager.state.first { it.tasks.isNotEmpty() }
+            every { tool.updateProgress(any()) } throws IllegalStateException("Progress is broken")
+
+            val job = manager.jobOf(task)
+            job.cancel()
+            dispatcher.releaseAll()
+
+            manager.state.first { it.tasks.single().isComplete }
+            // A throwing progress reset must not skip the two steps after it: leaking the lease
+            // would keep the TaskManager's shared resources alive for the rest of the process.
+            val entry = manager.rawEntries().single()
+            (entry.entryField("resourceLock") as KeepAlive).isClosed shouldBe true
+            coVerify(exactly = 0) { tool.submit(any()) }
+            caller.await()
+        }
+
+    @Test fun `submitIfToolIdle runs the task when the tool has nothing in flight`() =
+        runTest2(autoCancel = true) {
+            val scope = this + Dispatchers.IO
+            val tool = createTool(scope)
+            coEvery { tool.submit(task) } returns taskResult
+
+            val manager = createManager(scope, tool)
+
+            manager.submitIfToolIdle(task) shouldBeSameInstanceAs taskResult
+        }
+
+    @Test fun `submitIfToolIdle declines while the tool has an incomplete task`() =
+        runTest2(autoCancel = true) {
+            val scope = this + Dispatchers.IO
+            val tool = createTool(scope)
+            val dispatcher = ParkingDispatcher()
+            val manager = createManager(scope, tool, dispatcher)
+
+            dispatcher.park()
+            val caller = async(Dispatchers.IO) { runCatching { manager.submit(task) } }
+            manager.state.first { it.tasks.isNotEmpty() }
+
+            manager.submitIfToolIdle(otherTask) shouldBe null
+            manager.state.first().tasks.size shouldBe 1
+
+            val job = manager.jobOf(task)
+            job.cancel()
+            dispatcher.releaseAll()
+            caller.await()
+        }
+
+    @Test fun `two concurrent submitIfToolIdle calls register exactly one task`() =
+        runTest2(autoCancel = true) {
+            val scope = this + Dispatchers.IO
+            val tool = createTool(scope)
+            val dispatcher = ParkingDispatcher()
+            val manager = createManager(scope, tool, dispatcher)
+
+            // The winner's body stays parked, so it is incomplete for the whole race: whichever
+            // caller takes managerLock second MUST see it and decline. A check that ran outside the
+            // registration's lock could let both through.
+            dispatcher.park()
+            val racers = listOf(task, otherTask).map { candidate ->
+                async(Dispatchers.IO) { runCatching { manager.submitIfToolIdle(candidate) } }
+            }
+
+            // The decliner returns immediately; the winner is stuck on its parked job.
+            val declined = select { racers.forEach { racer -> racer.onAwait { it } } }
+            declined.isSuccess shouldBe true
+            declined.getOrNull() shouldBe null
+            manager.state.first().tasks.size shouldBe 1
+
+            val winner = manager.rawEntries().single().entryField("job") as Job
+            winner.cancel()
+            dispatcher.releaseAll()
+            racers.forEach { it.await() }
+            manager.state.first().tasks.size shouldBe 1
         }
 
     @Test fun `an error from the progress reset during cleanup does not strand the caller`() =


### PR DESCRIPTION
## What changed

Opening a cleaning tool's list could leave you staring at a loading spinner that never finished. That happened whenever the screen was reached without the dashboard having scanned first, most commonly when Android killed the app in the background and you came back to it later: the app remembers which screen you were on, but not the results. Those screens now scan by themselves when they come back with nothing to show.

Cancelling a scan used to be ignored, too. If you opened a tool's list while it was already scanning and then pressed Cancel, a fresh scan started immediately, so Cancel looked broken. Cancelling now takes you back to the dashboard instead. And if a scan fails outright, you stay on the list with the error and an empty list rather than an endless spinner.

## Technical Context

- Root cause: the navigation back stack is saved-state backed and survives process death, while each tool's results are a plain in-memory `MutableStateFlow` and do not. The restored screen came back with `data == null`, which the row pipelines render as the loading placeholder, and nothing ever submitted a scan.
- The entry logic is a loop rather than a one-shot because `submitIfToolIdle` can decline when another trigger wins the race. Treating a decline as done would strand the screen whenever that winner produced no data, which the uninstall watcher does by design.
- A failed entry scan deliberately does not navigate away. `navEvents` and `errorEvents` are separate `SingleEventFlow`s with separate host handlers, so navigating first disposes the host before the error dialog renders and the user sees nothing at all. It sets a failure flag that turns the placeholder into the empty state instead.
- CorpseFinder's navigate-away-when-empty pipeline dedupes on its corpse collection rather than the whole `Data`, because only its `Data` carries a second field (`lastResult`) that a cold scan writes twice with differing values.
- `TaskManager` deserves the closest review here: it is shared by every tool and receives two independent changes. A completion safety net for a job cancelled before its body ran (such an entry previously never got `completedAt`, so anything awaiting tool idleness waited forever), and a new atomic `submitIfToolIdle` whose busy-check and registration happen inside a single `updateTasks` block under the manager lock.
