### PR TITLE
General: Add a way to clear results from the dashboard cards

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManagerExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManagerExtensions.kt
@@ -17,6 +17,14 @@ fun TaskSubmitter.State.getLatestResult(tool: SDMTool.Type): SDMTool.Task.Result
 }
 
 /**
+ * Whether [tool] currently has an unfinished task.
+ *
+ * Deliberately per-tool rather than [TaskSubmitter.State.isIdle]: an action scoped to one tool must not
+ * silently do nothing just because an unrelated tool happens to be running.
+ */
+fun TaskSubmitter.State.isBusy(tool: SDMTool.Type): Boolean = tasks.any { it.toolType == tool && !it.isComplete }
+
+/**
  * Cold flow of completed [R] task results for [toolType], deduplicated by task id and limited to
  * tasks that finished after the flow was assembled (so we don't replay results that fired before
  * the subscribing screen existed).

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -156,18 +156,21 @@ internal fun DashboardViewModel.buildCorpseFinderItem(): Flow<ToolDashboardCardI
     // background uninstall watcher overwrite it. Prefer that over TaskManager, whose newest entry for this
     // tool may be a watcher event — which would otherwise surface on the card as the user's last action.
     val lastResult = data?.lastResult
-    val lastResultIsScan = lastResult is CorpseFinderScanTask.Success
+    // The single value the card renders: a frozen cleanup receipt, or a summary rebuilt from live
+    // scan findings. Gating the discard on this rather than on its inputs keeps "there is something on
+    // the card" and "there is something to clear" from ever drifting apart.
+    val cardResult = resolveScanCardResult(
+        isInitializing = state == null,
+        isWorking = state?.progress != null,
+        data = data,
+        hasData = data.hasData,
+        lastResult = lastResult,
+        lastResultIsScan = lastResult is CorpseFinderScanTask.Success,
+    ) { it.toScanSuccess() }
     ToolDashboardCardItem(
         toolType = SDMTool.Type.CORPSEFINDER,
         isInitializing = state == null,
-        result = resolveScanCardResult(
-            isInitializing = state == null,
-            isWorking = state?.progress != null,
-            data = data,
-            hasData = data.hasData,
-            lastResult = lastResult,
-            lastResultIsScan = lastResultIsScan,
-        ) { it.toScanSuccess() },
+        result = cardResult,
         progress = state?.progress,
         showProRequirement = false,
         onScan = {
@@ -198,7 +201,7 @@ internal fun DashboardViewModel.buildCorpseFinderItem(): Flow<ToolDashboardCardI
                 corpseFinder.discardScanData()
                 taskManager.forgetCompleted(SDMTool.Type.CORPSEFINDER)
             }
-        }.takeIf { lastResult != null && !lastResultIsScan },
+        }.takeIf { cardResult != null && state?.progress == null },
     )
 }
 
@@ -207,18 +210,21 @@ internal fun DashboardViewModel.buildSystemCleanerItem(): Flow<ToolDashboardCard
     taskManager.state.map { it.getLatestResult(SDMTool.Type.SYSTEMCLEANER) },
 ) { state, lastResult ->
     val data = state?.data
-    val lastResultIsScan = lastResult is SystemCleanerScanTask.Success
+    // The single value the card renders: a frozen cleanup receipt, or a summary rebuilt from live
+    // scan findings. Gating the discard on this rather than on its inputs keeps "there is something on
+    // the card" and "there is something to clear" from ever drifting apart.
+    val cardResult = resolveScanCardResult(
+        isInitializing = state == null,
+        isWorking = state?.progress != null,
+        data = data,
+        hasData = data.hasData,
+        lastResult = lastResult,
+        lastResultIsScan = lastResult is SystemCleanerScanTask.Success,
+    ) { it.toScanSuccess() }
     ToolDashboardCardItem(
         toolType = SDMTool.Type.SYSTEMCLEANER,
         isInitializing = state == null,
-        result = resolveScanCardResult(
-            isInitializing = state == null,
-            isWorking = state?.progress != null,
-            data = data,
-            hasData = data.hasData,
-            lastResult = lastResult,
-            lastResultIsScan = lastResultIsScan,
-        ) { it.toScanSuccess() },
+        result = cardResult,
         progress = state?.progress,
         showProRequirement = false,
         onScan = {
@@ -243,7 +249,7 @@ internal fun DashboardViewModel.buildSystemCleanerItem(): Flow<ToolDashboardCard
                 systemCleaner.discardScanData()
                 taskManager.forgetCompleted(SDMTool.Type.SYSTEMCLEANER)
             }
-        }.takeIf { lastResult != null && !lastResultIsScan },
+        }.takeIf { cardResult != null && state?.progress == null },
     )
 }
 
@@ -253,18 +259,21 @@ internal fun DashboardViewModel.buildAppCleanerItem(): Flow<ToolDashboardCardIte
     upgradeInfo.map { it?.isPro ?: false },
 ) { state, lastResult, isPro ->
     val data = state?.data
-    val lastResultIsScan = lastResult is AppCleanerScanTask.Success
+    // The single value the card renders: a frozen cleanup receipt, or a summary rebuilt from live
+    // scan findings. Gating the discard on this rather than on its inputs keeps "there is something on
+    // the card" and "there is something to clear" from ever drifting apart.
+    val cardResult = resolveScanCardResult(
+        isInitializing = state == null,
+        isWorking = state?.progress != null,
+        data = data,
+        hasData = data.hasData,
+        lastResult = lastResult,
+        lastResultIsScan = lastResult is AppCleanerScanTask.Success,
+    ) { it.toScanSuccess() }
     ToolDashboardCardItem(
         toolType = SDMTool.Type.APPCLEANER,
         isInitializing = state == null,
-        result = resolveScanCardResult(
-            isInitializing = state == null,
-            isWorking = state?.progress != null,
-            data = data,
-            hasData = data.hasData,
-            lastResult = lastResult,
-            lastResultIsScan = lastResultIsScan,
-        ) { it.toScanSuccess() },
+        result = cardResult,
         progress = state?.progress,
         showProRequirement = !isPro,
         onScan = {
@@ -289,7 +298,7 @@ internal fun DashboardViewModel.buildAppCleanerItem(): Flow<ToolDashboardCardIte
                 appCleaner.discardScanData()
                 taskManager.forgetCompleted(SDMTool.Type.APPCLEANER)
             }
-        }.takeIf { lastResult != null && !lastResultIsScan },
+        }.takeIf { cardResult != null && state?.progress == null },
     )
 }
 
@@ -299,18 +308,21 @@ internal fun DashboardViewModel.buildDeduplicatorItem(): Flow<ToolDashboardCardI
     upgradeInfo.map { it?.isPro ?: false },
 ) { state, lastResult, isPro ->
     val data = state?.data
-    val lastResultIsScan = lastResult is DeduplicatorScanTask.Success
+    // The single value the card renders: a frozen cleanup receipt, or a summary rebuilt from live
+    // scan findings. Gating the discard on this rather than on its inputs keeps "there is something on
+    // the card" and "there is something to clear" from ever drifting apart.
+    val cardResult = resolveScanCardResult(
+        isInitializing = state == null,
+        isWorking = state?.progress != null,
+        data = data,
+        hasData = data.hasData,
+        lastResult = lastResult,
+        lastResultIsScan = lastResult is DeduplicatorScanTask.Success,
+    ) { it.toScanSuccess() }
     ToolDashboardCardItem(
         toolType = SDMTool.Type.DEDUPLICATOR,
         isInitializing = state == null,
-        result = resolveScanCardResult(
-            isInitializing = state == null,
-            isWorking = state?.progress != null,
-            data = data,
-            hasData = data.hasData,
-            lastResult = lastResult,
-            lastResultIsScan = lastResultIsScan,
-        ) { it.toScanSuccess() },
+        result = cardResult,
         progress = state?.progress,
         showProRequirement = !isPro,
         onScan = {
@@ -340,7 +352,7 @@ internal fun DashboardViewModel.buildDeduplicatorItem(): Flow<ToolDashboardCardI
                 deduplicator.discardScanData()
                 taskManager.forgetCompleted(SDMTool.Type.DEDUPLICATOR)
             }
-        }.takeIf { lastResult != null && !lastResultIsScan },
+        }.takeIf { cardResult != null && state?.progress == null },
     )
 }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardCardFlows.kt
@@ -30,6 +30,7 @@ import eu.darken.sdmse.deduplicator.core.tasks.DeduplicatorScanTask
 import eu.darken.sdmse.deduplicator.ui.DeduplicatorDetailsRoute
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.getLatestResult
+import eu.darken.sdmse.main.core.taskmanager.isBusy
 import eu.darken.sdmse.main.ui.dashboard.cards.AnalyzerDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.AppControlDashboardCardItem
 import eu.darken.sdmse.main.ui.dashboard.cards.MotdDashboardCardItem
@@ -155,6 +156,7 @@ internal fun DashboardViewModel.buildCorpseFinderItem(): Flow<ToolDashboardCardI
     // background uninstall watcher overwrite it. Prefer that over TaskManager, whose newest entry for this
     // tool may be a watcher event — which would otherwise surface on the card as the user's last action.
     val lastResult = data?.lastResult
+    val lastResultIsScan = lastResult is CorpseFinderScanTask.Success
     ToolDashboardCardItem(
         toolType = SDMTool.Type.CORPSEFINDER,
         isInitializing = state == null,
@@ -164,7 +166,7 @@ internal fun DashboardViewModel.buildCorpseFinderItem(): Flow<ToolDashboardCardI
             data = data,
             hasData = data.hasData,
             lastResult = lastResult,
-            lastResultIsScan = lastResult is CorpseFinderScanTask.Success,
+            lastResultIsScan = lastResultIsScan,
         ) { it.toScanSuccess() },
         progress = state?.progress,
         showProRequirement = false,
@@ -182,6 +184,21 @@ internal fun DashboardViewModel.buildCorpseFinderItem(): Flow<ToolDashboardCardI
         onViewDetails = {
             navTo(CorpseDetailsRoute())
         },
+        onDismissResult = {
+            launch {
+                // A task can start between the composition that rendered this control and the click
+                // landing here (scheduler, widget, the uninstall watcher), and discardScanData()
+                // waits on the same tool lock the task holds — without this we would clear the data
+                // that task just produced.
+                if (taskManager.state.first().isBusy(SDMTool.Type.CORPSEFINDER)) return@launch
+                // Data first, then the recorded result: the reverse order lets the card rebuild from
+                // the surviving residue for a frame and flash a "can be freed" figure. This card reads
+                // Data.lastResult rather than TaskManager (see above), so dropping the tool's data is
+                // what actually clears it.
+                corpseFinder.discardScanData()
+                taskManager.forgetCompleted(SDMTool.Type.CORPSEFINDER)
+            }
+        }.takeIf { lastResult != null && !lastResultIsScan },
     )
 }
 
@@ -190,6 +207,7 @@ internal fun DashboardViewModel.buildSystemCleanerItem(): Flow<ToolDashboardCard
     taskManager.state.map { it.getLatestResult(SDMTool.Type.SYSTEMCLEANER) },
 ) { state, lastResult ->
     val data = state?.data
+    val lastResultIsScan = lastResult is SystemCleanerScanTask.Success
     ToolDashboardCardItem(
         toolType = SDMTool.Type.SYSTEMCLEANER,
         isInitializing = state == null,
@@ -199,7 +217,7 @@ internal fun DashboardViewModel.buildSystemCleanerItem(): Flow<ToolDashboardCard
             data = data,
             hasData = data.hasData,
             lastResult = lastResult,
-            lastResultIsScan = lastResult is SystemCleanerScanTask.Success,
+            lastResultIsScan = lastResultIsScan,
         ) { it.toScanSuccess() },
         progress = state?.progress,
         showProRequirement = false,
@@ -217,6 +235,15 @@ internal fun DashboardViewModel.buildSystemCleanerItem(): Flow<ToolDashboardCard
         onViewDetails = {
             navTo(FilterContentDetailsRoute())
         },
+        onDismissResult = {
+            launch {
+                // See buildCorpseFinderItem: bail if a task started since composition, and clear the
+                // live data before the recorded result so the card can't flash the leftover figure.
+                if (taskManager.state.first().isBusy(SDMTool.Type.SYSTEMCLEANER)) return@launch
+                systemCleaner.discardScanData()
+                taskManager.forgetCompleted(SDMTool.Type.SYSTEMCLEANER)
+            }
+        }.takeIf { lastResult != null && !lastResultIsScan },
     )
 }
 
@@ -226,6 +253,7 @@ internal fun DashboardViewModel.buildAppCleanerItem(): Flow<ToolDashboardCardIte
     upgradeInfo.map { it?.isPro ?: false },
 ) { state, lastResult, isPro ->
     val data = state?.data
+    val lastResultIsScan = lastResult is AppCleanerScanTask.Success
     ToolDashboardCardItem(
         toolType = SDMTool.Type.APPCLEANER,
         isInitializing = state == null,
@@ -235,7 +263,7 @@ internal fun DashboardViewModel.buildAppCleanerItem(): Flow<ToolDashboardCardIte
             data = data,
             hasData = data.hasData,
             lastResult = lastResult,
-            lastResultIsScan = lastResult is AppCleanerScanTask.Success,
+            lastResultIsScan = lastResultIsScan,
         ) { it.toScanSuccess() },
         progress = state?.progress,
         showProRequirement = !isPro,
@@ -253,6 +281,15 @@ internal fun DashboardViewModel.buildAppCleanerItem(): Flow<ToolDashboardCardIte
         onViewDetails = {
             navTo(AppJunkDetailsRoute())
         },
+        onDismissResult = {
+            launch {
+                // See buildCorpseFinderItem: bail if a task started since composition, and clear the
+                // live data before the recorded result so the card can't flash the leftover figure.
+                if (taskManager.state.first().isBusy(SDMTool.Type.APPCLEANER)) return@launch
+                appCleaner.discardScanData()
+                taskManager.forgetCompleted(SDMTool.Type.APPCLEANER)
+            }
+        }.takeIf { lastResult != null && !lastResultIsScan },
     )
 }
 
@@ -262,6 +299,7 @@ internal fun DashboardViewModel.buildDeduplicatorItem(): Flow<ToolDashboardCardI
     upgradeInfo.map { it?.isPro ?: false },
 ) { state, lastResult, isPro ->
     val data = state?.data
+    val lastResultIsScan = lastResult is DeduplicatorScanTask.Success
     ToolDashboardCardItem(
         toolType = SDMTool.Type.DEDUPLICATOR,
         isInitializing = state == null,
@@ -271,7 +309,7 @@ internal fun DashboardViewModel.buildDeduplicatorItem(): Flow<ToolDashboardCardI
             data = data,
             hasData = data.hasData,
             lastResult = lastResult,
-            lastResultIsScan = lastResult is DeduplicatorScanTask.Success,
+            lastResultIsScan = lastResultIsScan,
         ) { it.toScanSuccess() },
         progress = state?.progress,
         showProRequirement = !isPro,
@@ -294,6 +332,15 @@ internal fun DashboardViewModel.buildDeduplicatorItem(): Flow<ToolDashboardCardI
         onViewDetails = {
             navTo(DeduplicatorDetailsRoute())
         },
+        onDismissResult = {
+            launch {
+                // See buildCorpseFinderItem: bail if a task started since composition, and clear the
+                // live data before the recorded result so the card can't flash the leftover figure.
+                if (taskManager.state.first().isBusy(SDMTool.Type.DEDUPLICATOR)) return@launch
+                deduplicator.discardScanData()
+                taskManager.forgetCompleted(SDMTool.Type.DEDUPLICATOR)
+            }
+        }.takeIf { lastResult != null && !lastResultIsScan },
     )
 }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardBottomBar.kt
@@ -295,10 +295,11 @@ internal fun BottomBar(
                 summary = heroSummary,
                 now = state?.now ?: Instant.EPOCH,
                 onDismiss = onDismissHero,
-                // Discarding only makes sense while there's still pending data; a FREED summary is
-                // already just an after-the-fact report the X can hide.
-                onDiscard = onDiscardResults
-                    .takeIf { heroSummary.mode == HeroSummary.Mode.FREEABLE },
+                // Offered in every mode. A FREED summary was once treated as an after-the-fact report
+                // the X could hide, but the X only collapses the hero into the bar's size chip, which
+                // has no dismiss of its own — so that state had no way out at all. Discard always has
+                // something to clear here: freedResult for a report, live findings for a scan.
+                onDiscard = onDiscardResults,
                 onToolClick = onToolClick,
                 onLockedToolClick = onLockedToolClick,
                 onUpgrade = onUpgrade,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/ToolDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/ToolDashboardCard.kt
@@ -28,6 +28,7 @@ import eu.darken.sdmse.common.compose.icons.SdmIcons
 import eu.darken.sdmse.common.compose.icons.icon
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderDeleteTask
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.main.core.SDMTool
 
@@ -50,6 +51,8 @@ data class ToolDashboardCardItem(
     val onViewTool: () -> Unit,
     val onViewDetails: () -> Unit,
     val onCancel: () -> Unit,
+    /** Clears a frozen post-cleanup result; null while one is not on screen. See DashboardCardFlows. */
+    val onDismissResult: (() -> Unit)?,
 ) : DashboardItem, MainActionItem {
     override val stableId: Long = toolType.hashCode().toLong()
 }
@@ -105,6 +108,7 @@ internal fun ToolDashboardCard(
                 progress = item.progress,
                 resultPrimary = item.result?.primaryInfo?.asComposable(),
                 resultSecondary = item.result?.secondaryInfo?.asComposable()?.takeUnless { it.isBlank() },
+                onDismissResult = item.onDismissResult,
             )
         }
 
@@ -193,6 +197,32 @@ private fun ToolDashboardCardPreview() {
                 onViewTool = {},
                 onViewDetails = {},
                 onCancel = {},
+                onDismissResult = null,
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun ToolDashboardCardDismissableResultPreview() {
+    PreviewWrapper {
+        ToolDashboardCard(
+            item = ToolDashboardCardItem(
+                toolType = SDMTool.Type.CORPSEFINDER,
+                isInitializing = false,
+                result = CorpseFinderDeleteTask.Success(
+                    affectedSpace = 2_100_000_000L,
+                    affectedPaths = emptySet(),
+                ),
+                progress = null,
+                showProRequirement = false,
+                onScan = {},
+                onDelete = null,
+                onViewTool = {},
+                onViewDetails = {},
+                onCancel = {},
+                onDismissResult = {},
             ),
         )
     }

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/common/DashboardProgress.kt
@@ -8,7 +8,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Close
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -16,6 +20,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -25,6 +30,7 @@ import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.determinateFraction
+import eu.darken.sdmse.common.R as CommonR
 
 @Composable
 internal fun ProgressContainer(
@@ -32,32 +38,64 @@ internal fun ProgressContainer(
     progress: Progress.Data?,
     resultPrimary: String?,
     resultSecondary: String?,
+    onDismissResult: (() -> Unit)? = null,
 ) {
     Surface(
         modifier = modifier,
         color = MaterialTheme.colorScheme.secondaryContainer,
         shape = RoundedCornerShape(12.dp),
     ) {
-        Column(modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)) {
-            when {
-                progress != null -> DashboardProgress(progress)
-                else -> {
-                    resultPrimary?.takeUnless { it.isBlank() }?.let {
-                        Text(
-                            text = it,
-                            style = MaterialTheme.typography.bodyMedium,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
+        // The dismiss lives inside the tinted result block, not on the card's edge: an X out there
+        // reads as "close the card" (and the hero card's X already means hide-but-keep-state), while
+        // one sitting on the result itself can only mean "clear this result".
+        val dismiss = onDismissResult?.takeIf { progress == null }
+        Row(
+            modifier = Modifier.padding(
+                start = 12.dp,
+                // The icon button carries its own touch-target padding, so keep the block from
+                // growing a second inset on that side.
+                end = if (dismiss != null) 4.dp else 12.dp,
+            ),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            // Vertical padding sits on the text, not the Row: on the Row it would stack on top of the
+            // icon button's 48dp touch target and pad the whole block out to 68dp.
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .padding(vertical = 10.dp),
+            ) {
+                when {
+                    progress != null -> DashboardProgress(progress)
+                    else -> {
+                        resultPrimary?.takeUnless { it.isBlank() }?.let {
+                            Text(
+                                text = it,
+                                style = MaterialTheme.typography.bodyMedium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        resultSecondary?.let {
+                            Text(
+                                text = it,
+                                style = MaterialTheme.typography.bodySmall,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
                     }
-                    resultSecondary?.let {
-                        Text(
-                            text = it,
-                            style = MaterialTheme.typography.bodySmall,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                    }
+                }
+            }
+            if (dismiss != null) {
+                IconButton(onClick = dismiss) {
+                    Icon(
+                        imageVector = Icons.TwoTone.Close,
+                        // "Discard", not "Dismiss": this drops the tool's live scan data along with
+                        // the receipt, so any residue needs a fresh scan afterwards. Same wording as
+                        // the hero card's button, which performs the same two operations.
+                        contentDescription = stringResource(CommonR.string.general_discard_action),
+                    )
                 }
             }
         }
@@ -274,6 +312,20 @@ private fun ProgressContainerResultPreview() {
             progress = null,
             resultPrimary = "Found 12 corpses (2.4 GB)",
             resultSecondary = "Last scan completed 5 minutes ago",
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun ProgressContainerResultDismissablePreview() {
+    PreviewWrapper {
+        ProgressContainer(
+            modifier = Modifier.width(280.dp),
+            progress = null,
+            resultPrimary = "1,234 expendable items deleted",
+            resultSecondary = "Freed 2.1 GB",
+            onDismissResult = {},
         )
     }
 }

--- a/app/src/screenshotTest/kotlin/eu/darken/sdmse/screenshots/DashboardScreenshots.kt
+++ b/app/src/screenshotTest/kotlin/eu/darken/sdmse/screenshots/DashboardScreenshots.kt
@@ -34,6 +34,7 @@ private fun toolCard(
     onViewTool = {},
     onViewDetails = {},
     onCancel = {},
+    onDismissResult = null,
 )
 
 @PreviewTest

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
@@ -278,9 +278,9 @@ internal class DashboardDiscardTest : BaseTest() {
     }
 
     @Test
-    fun `a scan result offers no dismiss`() = runTest2 {
-        // A scan is live, actionable data, not an after-the-fact report; forgetting it would only
-        // have the card rebuild the same figure from live data on the next emission.
+    fun `a scan result is discardable too, not just a cleanup receipt`() = runTest2 {
+        // Discarding is offered whenever the card is showing something, matching the hero's Discard
+        // button, whose own rationale is that discarding makes sense while there is pending data.
         val h = harness(
             taskState = completedTask(AppCleanerScanTask.Success(itemCount = 3, recoverableSpace = 500L)),
             appCleanerState = appCleanerState(
@@ -288,11 +288,26 @@ internal class DashboardDiscardTest : BaseTest() {
             ),
         )
 
-        h.appCleanerCard().onDismissResult shouldBe null
+        h.appCleanerCard().onDismissResult shouldNotBe null
     }
 
     @Test
-    fun `no recorded result means no dismiss`() = runTest2 {
+    fun `live findings with no recorded task are discardable`() = runTest2 {
+        // Data can outlive its task result (exclusions applied from a details screen submit no task),
+        // so the offer has to follow what the card renders, not whether TaskManager remembers a run.
+        val h = harness(
+            appCleanerState = appCleanerState(
+                junks = listOf(mockk { every { size } returns 500L; every { itemCount } returns 3 }),
+            ),
+        )
+
+        h.appCleanerCard().onDismissResult shouldNotBe null
+    }
+
+    @Test
+    fun `an untouched card offers nothing to discard`() = runTest2 {
+        // No result and no findings: the card is showing its plain description, so there is nothing
+        // for the control to clear and it must not appear.
         val h = harness(appCleanerState = appCleanerState(junks = emptyList()))
 
         h.appCleanerCard().onDismissResult shouldBe null

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDiscardTest.kt
@@ -3,6 +3,9 @@ package eu.darken.sdmse.main.ui.dashboard
 import eu.darken.sdmse.analyzer.core.Analyzer
 import eu.darken.sdmse.analyzer.core.AnalyzerSettings
 import eu.darken.sdmse.appcleaner.core.AppCleaner
+import eu.darken.sdmse.appcleaner.core.AppJunk
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcontrol.core.AppControl
 import eu.darken.sdmse.common.WebpageTool
 import eu.darken.sdmse.common.areas.DataAreaManager
@@ -13,6 +16,7 @@ import eu.darken.sdmse.common.review.ReviewTool
 import eu.darken.sdmse.common.updater.UpdateService
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
+import eu.darken.sdmse.corpsefinder.core.tasks.CorpseFinderDeleteTask
 import eu.darken.sdmse.deduplicator.core.Deduplicator
 import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.GeneralSettings
@@ -21,6 +25,7 @@ import eu.darken.sdmse.main.core.motd.MotdRepo
 import eu.darken.sdmse.main.core.release.ReleaseManager
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.main.ui.dashboard.cards.ToolDashboardCardItem
 import eu.darken.sdmse.scheduler.core.SchedulerManager
 import eu.darken.sdmse.setup.SetupManager
 import eu.darken.sdmse.squeezer.core.Squeezer
@@ -31,12 +36,16 @@ import eu.darken.sdmse.stats.core.StatsSettings
 import eu.darken.sdmse.swiper.core.Swiper
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
@@ -59,13 +68,21 @@ internal class DashboardDiscardTest : BaseTest() {
 
     private fun TestScope.harness(
         taskState: TaskSubmitter.State = TaskSubmitter.State(),
+        appCleanerState: AppCleaner.State? = null,
+        corpseFinderState: CorpseFinder.State? = null,
     ): Harness {
         val taskManager = mockk<TaskManager>(relaxed = true).apply {
             every { state } returns MutableStateFlow(taskState)
         }
-        val corpseFinder = mockk<CorpseFinder>(relaxed = true).apply { every { state } returns emptyFlow() }
+        val corpseFinderFlow: Flow<CorpseFinder.State> =
+            corpseFinderState?.let { flowOf(it) } ?: emptyFlow()
+        val corpseFinder = mockk<CorpseFinder>(relaxed = true).apply { every { state } returns corpseFinderFlow }
         val systemCleaner = mockk<SystemCleaner>(relaxed = true).apply { every { state } returns emptyFlow() }
-        val appCleaner = mockk<AppCleaner>(relaxed = true).apply { every { state } returns emptyFlow() }
+        val appCleanerFlow: Flow<AppCleaner.State> =
+            appCleanerState?.let { flowOf(it) } ?: emptyFlow()
+        val appCleaner = mockk<AppCleaner>(relaxed = true).apply {
+            every { state } returns appCleanerFlow
+        }
         val deduplicator = mockk<Deduplicator>(relaxed = true).apply { every { state } returns emptyFlow() }
         val squeezer = mockk<Squeezer>(relaxed = true).apply { every { state } returns emptyFlow() }
         val appControl = mockk<AppControl>(relaxed = true).apply { every { state } returns emptyFlow() }
@@ -196,5 +213,191 @@ internal class DashboardDiscardTest : BaseTest() {
         coVerify(exactly = 0) { h.appCleaner.discardScanData() }
         coVerify(exactly = 0) { h.deduplicator.discardScanData() }
         coVerify(exactly = 0) { h.taskManager.forgetCompleted(any()) }
+    }
+
+    // --- Per-card result dismiss --------------------------------------------------------------
+
+    private fun completedTask(result: SDMTool.Task.Result) = TaskSubmitter.State(
+        tasks = listOf(
+            TaskSubmitter.ManagedTask(
+                id = "done",
+                toolType = SDMTool.Type.APPCLEANER,
+                task = mockk(),
+                completedAt = Instant.now(),
+                result = result,
+            ),
+        ),
+    )
+
+    private fun appCleanerState(junks: List<AppJunk>) = AppCleaner.State(
+        data = AppCleaner.Data(junks = junks),
+        progress = null,
+        isOtherUsersAvailable = false,
+        isRunningAppsDetectionAvailable = false,
+        isInaccessibleCacheAvailable = false,
+        isAcsRequired = false,
+    )
+
+    // Every card builder opens with onStart { emit(null) } as its loading state. Take the first
+    // resolved emission instead of the first emission, or the assertions read the loading card.
+    private suspend fun Harness.appCleanerCard(): ToolDashboardCardItem =
+        vm.buildAppCleanerItem().first { !it.isInitializing }
+
+    private suspend fun Harness.corpseFinderCard(): ToolDashboardCardItem =
+        vm.buildCorpseFinderItem().first { !it.isInitializing }
+
+    @Test
+    fun `a frozen delete result offers a dismiss even when residue survives it`() = runTest2 {
+        // The common case: a run frees most of it but a locked cache (com.google.android.gms) stays
+        // behind. Gating the dismiss on empty live data would hide it exactly here.
+        val residue = mockk<AppJunk> { every { size } returns 5_000L; every { itemCount } returns 1 }
+        val h = harness(
+            taskState = completedTask(
+                AppCleanerProcessingTask.Success(affectedSpace = 2_100_000_000L, affectedPaths = emptySet()),
+            ),
+            appCleanerState = appCleanerState(junks = listOf(residue)),
+        )
+
+        h.appCleanerCard().onDismissResult shouldNotBe null
+    }
+
+    @Test
+    fun `dismissing a card result drops both the frozen result and the leftover scan data`() = runTest2 {
+        val h = harness(
+            taskState = completedTask(
+                AppCleanerProcessingTask.Success(affectedSpace = 2_100_000_000L, affectedPaths = emptySet()),
+            ),
+            appCleanerState = appCleanerState(junks = emptyList()),
+        )
+
+        h.appCleanerCard().onDismissResult!!.invoke()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.taskManager.forgetCompleted(SDMTool.Type.APPCLEANER) }
+        coVerify(exactly = 1) { h.appCleaner.discardScanData() }
+    }
+
+    @Test
+    fun `a scan result offers no dismiss`() = runTest2 {
+        // A scan is live, actionable data, not an after-the-fact report; forgetting it would only
+        // have the card rebuild the same figure from live data on the next emission.
+        val h = harness(
+            taskState = completedTask(AppCleanerScanTask.Success(itemCount = 3, recoverableSpace = 500L)),
+            appCleanerState = appCleanerState(
+                junks = listOf(mockk { every { size } returns 500L; every { itemCount } returns 3 }),
+            ),
+        )
+
+        h.appCleanerCard().onDismissResult shouldBe null
+    }
+
+    @Test
+    fun `no recorded result means no dismiss`() = runTest2 {
+        val h = harness(appCleanerState = appCleanerState(junks = emptyList()))
+
+        h.appCleanerCard().onDismissResult shouldBe null
+    }
+
+    @Test
+    fun `dismissing clears live data before the recorded result so no residue figure can surface`() = runTest2 {
+        // Reversing these two lets resolveScanCardResult rebuild from the surviving residue for a
+        // frame, flashing "5 MB can be freed" over a run that actually freed 2.1 GB.
+        val residue = mockk<AppJunk> { every { size } returns 5_000L; every { itemCount } returns 1 }
+        val h = harness(
+            taskState = completedTask(
+                AppCleanerProcessingTask.Success(affectedSpace = 2_100_000_000L, affectedPaths = emptySet()),
+            ),
+            appCleanerState = appCleanerState(junks = listOf(residue)),
+        )
+
+        h.appCleanerCard().onDismissResult!!.invoke()
+        advanceUntilIdle()
+
+        coVerifyOrder {
+            h.appCleaner.discardScanData()
+            h.taskManager.forgetCompleted(SDMTool.Type.APPCLEANER)
+        }
+    }
+
+    @Test
+    fun `dismissing does nothing once a task for that tool is running`() = runTest2 {
+        // The control is hidden while a task runs, but a scheduler or widget can start one between
+        // the composition that rendered it and the click landing.
+        val busy = TaskSubmitter.State(
+            tasks = listOf(
+                TaskSubmitter.ManagedTask(
+                    id = "done",
+                    toolType = SDMTool.Type.APPCLEANER,
+                    task = mockk(),
+                    completedAt = Instant.now(),
+                    result = AppCleanerProcessingTask.Success(
+                        affectedSpace = 2_100_000_000L,
+                        affectedPaths = emptySet(),
+                    ),
+                ),
+                TaskSubmitter.ManagedTask(
+                    id = "running",
+                    toolType = SDMTool.Type.APPCLEANER,
+                    task = mockk(),
+                    startedAt = Instant.now(),
+                ),
+            ),
+        )
+        val h = harness(taskState = busy, appCleanerState = appCleanerState(junks = emptyList()))
+
+        h.appCleanerCard().onDismissResult!!.invoke()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { h.appCleaner.discardScanData() }
+        coVerify(exactly = 0) { h.taskManager.forgetCompleted(SDMTool.Type.APPCLEANER) }
+    }
+
+    @Test
+    fun `a running task for another tool does not block this card's dismiss`() = runTest2 {
+        val otherToolBusy = TaskSubmitter.State(
+            tasks = completedTask(
+                AppCleanerProcessingTask.Success(affectedSpace = 2_100_000_000L, affectedPaths = emptySet()),
+            ).tasks + TaskSubmitter.ManagedTask(
+                id = "analyzer",
+                toolType = SDMTool.Type.ANALYZER,
+                task = mockk(),
+                startedAt = Instant.now(),
+            ),
+        )
+        val h = harness(taskState = otherToolBusy, appCleanerState = appCleanerState(junks = emptyList()))
+
+        h.appCleanerCard().onDismissResult!!.invoke()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.appCleaner.discardScanData() }
+    }
+
+    @Test
+    fun `corpsefinder dismisses via its own Data lastResult rather than TaskManager`() = runTest2 {
+        // This card ignores TaskManager entirely, so an empty task state must still offer a dismiss.
+        val h = harness(
+            corpseFinderState = CorpseFinder.State(
+                data = CorpseFinder.Data(
+                    corpses = emptyList(),
+                    lastResult = CorpseFinderDeleteTask.Success(affectedSpace = 500L, affectedPaths = emptySet()),
+                ),
+                progress = null,
+                isFilterPrivateDataAvailable = false,
+                isFilterDalvikCacheAvailable = false,
+                isFilterArtProfilesAvailable = false,
+                isFilterAppLibrariesAvailable = false,
+                isFilterAppSourcesAvailable = false,
+                isFilterPrivateAppSourcesAvailable = false,
+                isFilterEncryptedAppResourcesAvailable = false,
+            ),
+        )
+
+        val card = h.corpseFinderCard()
+        card.onDismissResult shouldNotBe null
+
+        card.onDismissResult!!.invoke()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { h.corpseFinder.discardScanData() }
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDockPinTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardDockPinTest.kt
@@ -70,6 +70,7 @@ class DashboardDockPinTest : BaseComposeRobolectricTest() {
         onViewTool = {},
         onViewDetails = {},
         onCancel = {},
+        onDismissResult = null,
     )
 
     private fun setDashboard(

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardLockedMainActionTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardLockedMainActionTest.kt
@@ -46,6 +46,7 @@ class DashboardLockedMainActionTest : BaseComposeRobolectricTest() {
             onViewTool = {},
             onViewDetails = {},
             onCancel = {},
+            onDismissResult = null,
         ),
     )
 

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreenDpadWrapTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreenDpadWrapTest.kt
@@ -332,14 +332,19 @@ class DashboardScreenDpadWrapTest : BaseComposeRobolectricTest() {
     }
 
     @Test
-    fun `UP reaches Dismiss when the FREED hero has no Discard button`() {
+    fun `UP climbs the FREED hero the same way, since it now offers Discard too`() {
+        // Discard used to be gated to FREEABLE, so this mode had one fewer stop on the way up. It is
+        // offered in every mode now, which makes the traversal identical to the FREEABLE case above.
         composeRule.setDashboardContent(
             listState = DashboardViewModel.ListState(items = defaultItems()),
             bottomBarState = bottomBarState(heroSummary = heroSummary(mode = HeroSummary.Mode.FREED)),
         )
-        composeRule.onAllNodesWithText(discardLabel).assertCountEquals(0)
+        composeRule.onAllNodesWithText(discardLabel).assertCountEquals(1)
         composeRule.onNodeWithContentDescription(settingsLabel).requestFocus()
         composeRule.waitForIdle()
+
+        composeRule.pressKey(NativeKeyEvent.KEYCODE_DPAD_UP)
+        composeRule.assertFocusedWithin(hasText(discardLabel))
 
         composeRule.pressKey(NativeKeyEvent.KEYCODE_DPAD_UP)
         composeRule.assertFocusedWithin(hasContentDescription(dismissLabel))

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreenDpadWrapTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreenDpadWrapTest.kt
@@ -70,6 +70,7 @@ class DashboardScreenDpadWrapTest : BaseComposeRobolectricTest() {
         onViewTool = {},
         onViewDetails = {},
         onCancel = {},
+        onDismissResult = null,
     )
 
     private fun bottomBarState(

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreenTourIntegrationTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardScreenTourIntegrationTest.kt
@@ -45,6 +45,7 @@ class DashboardScreenTourIntegrationTest : BaseComposeRobolectricTest() {
         onViewTool = {},
         onViewDetails = {},
         onCancel = {},
+        onDismissResult = null,
     )
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/bottom/DashboardHeroCardTest.kt
@@ -485,7 +485,8 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
     }
 
     @Test
-    fun `freed-mode hero has no discard button`() {
+    fun `freed-mode hero offers discard too, since its X only collapses it into the bar chip`() {
+        var discarded = 0
         val freed = HeroSummary(
             mode = HeroSummary.Mode.FREED,
             totalSize = 1L * 1024 * 1024 * 1024,
@@ -504,11 +505,14 @@ class DashboardHeroCardTest : BaseComposeRobolectricTest() {
                     onSettings = {},
                     onUpgrade = {},
                     onDismissHero = {},
-                    onDiscardResults = {},
+                    onDiscardResults = { discarded++ },
                 )
             }
         }
-        composeRule.onNodeWithText(context.getString(CommonR.string.general_discard_action)).assertDoesNotExist()
+        composeRule.onNodeWithText(context.getString(CommonR.string.general_discard_action))
+            .assertHasClickAction()
+            .performSemanticsAction(SemanticsActions.OnClick)
+        composeRule.runOnIdle { assertEquals(1, discarded) }
     }
 
     @Test


### PR DESCRIPTION
## What changed

After a cleaning run finishes, the tool's card on the dashboard reports what was deleted and how much space it freed. There was no way to get rid of that report: no button, no swipe, and it never timed out. It stayed on screen until the app's process was killed. The only thing that cleared it was starting a scan and immediately cancelling it, which is what a user wrote in to ask about.

Tool cards now carry a discard button on whatever they are showing, and pressing it puts the card back to its normal description. That covers a finished cleanup, and equally a scan you have looked at and decided not to act on. Until now a single tool's scan could only be cleared by scanning again, or by the big Discard button, which wipes all four tools at once.

The big summary card at the bottom gets the same treatment. Its Discard button used to disappear once a cleanup had run, leaving only the X, which just collapses the card into a small size chip in the bottom bar that has no way to dismiss it either. Discard is now offered there in every state.

Discarding clears the tool's findings along with the report, so a fresh scan is needed before that tool can be acted on again. If a clean left something behind (locked caches usually survive one), that residue goes with it. This is why the button reads Discard rather than Dismiss.

## Technical Context

- Root cause: `resolveScanCardResult` deliberately pins a completed delete result so it outranks live data, because a partial clean rebuilt from its own residue would report "5 MB can be freed" after freeing a gigabyte. Nothing ever cleared that state again. `forgetCompleted`'s only caller was `discardResults()`, reachable solely from the hero's Discard button, which was gated to `Mode.FREEABLE`; after a clean the mode is FREED, so it was unreachable. A card-triggered delete builds no hero at all (`accumulateFreed` runs only from `runCleanup`, only from the one-tap action), leaving the card as the sole surface reporting the outcome.
- The card control is offered whenever the card renders a result and no task is running, gated on the resolved `cardResult` rather than on its inputs so "something is on the card" and "something is clearable" cannot drift apart. That also covers findings which outlive their task result, as when exclusions applied from a details screen mutate live data without submitting a task. Gating on live data being empty was rejected: residue routinely survives a clean, so it would hide the control in the common case.
- The hero gate was removed rather than widened. Its rationale was that the X could hide a FREED report, but `dismissHero()` only sets `heroExpanded = false`, which collapses it into the bar's compact chip — so that mode was the one with no way out. Two tests were coupled to the old gating and now assert the new behaviour, including a D-pad traversal test whose case (Discard absent) no longer exists.
- The card control is not the same mechanism as the hero's: it shares the two primitives and their order, but is per-tool, guards on a new per-tool `TaskSubmitter.State.isBusy(tool)` rather than global `isIdle`, and deliberately leaves `freedResult` and the hero's presentation state alone. A run receipt should not shrink because one tool's card was cleared.
- Worth close review: hiding the card control while a task runs is not synchronization, since a scheduler, widget, or the uninstall watcher can start one between composition and the click while `discardScanData()` waits on the same tool lock — hence the runtime re-check. CorpseFinder's builder also differs from the other three, reading `Data.lastResult` instead of TaskManager, so there it is `discardScanData()` that clears the card.
