### PR TITLE
AppCleaner: Stop offering to free space that's already been freed

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -19,6 +19,7 @@ import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
@@ -51,6 +52,7 @@ import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.setup.IncompleteSetupException
 import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.isComplete
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -302,19 +304,40 @@ class AppCleaner @Inject constructor(
         }
 
 
-        val acsResult = if (task.includeInaccessible) {
-            inaccessibleDeleterProvider.get().withProgress(
-                this,
-                onCompletion = { it }
-            ) {
-                deleteInaccessible(
-                    snapshot = snapshot,
-                    targetPkgs = task.targetPkgs,
-                    useAutomation = task.useAutomation,
-                    isBackground = task.isBackground
-                )
+        // The accessible deletions above already hit the disk, but `internalData` is only rewritten
+        // below. If the ACS stage throws (automation unavailable, screen locked, compatibility
+        // give-up, ...) an early return would strand that rewrite, and the card would keep listing
+        // files that are gone and advertise space that is already free. So capture the failure,
+        // let the bookkeeping run with a null `acsResult` (which folds in the accessible deletions
+        // and leaves the inaccessible caches untouched), and only then propagate.
+        var acsResult: InaccessibleDeleter.InaccDelResult? = null
+        var acsFailure: Exception? = null
+        if (task.includeInaccessible) {
+            try {
+                acsResult = inaccessibleDeleterProvider.get().withProgress(
+                    this,
+                    onCompletion = { it }
+                ) {
+                    deleteInaccessible(
+                        snapshot = snapshot,
+                        targetPkgs = task.targetPkgs,
+                        useAutomation = task.useAutomation,
+                        isBackground = task.isBackground,
+                        // Caches it managed to clear before failing are gone for real; take them so
+                        // the reconciliation below drops them instead of re-advertising them.
+                        onPartialResult = { acsResult = it },
+                    )
+                }
+            } catch (e: Exception) {
+                // Deliberately includes CancellationException: a cancel landing mid-ACS strands the
+                // accessible deletions exactly like any other failure does, and the reconciliation
+                // below contains no suspension points, so it is safe to run on a cancelled
+                // coroutine. The original exception is rethrown unchanged afterwards, so a cancel
+                // is still recorded as a cancel.
+                log(TAG, WARN) { "Inaccessible deletion failed, salvaging accessible results: ${e.asLog()}" }
+                acsFailure = e
             }
-        } else null
+        }
 
         updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_filtering)
         updateProgressSecondary(CaString.EMPTY)
@@ -378,6 +401,11 @@ class AppCleaner @Inject constructor(
                 )
             }.filter { !it.isEmpty() }
         )
+
+        // `internalData` now reflects the accessible deletions plus whatever the ACS stage reported
+        // before failing, so the failure can surface. The task still fails with the original
+        // exception, exactly as it did before this salvage existed.
+        acsFailure?.let { throw it }
 
         // Force check via !! because we should not have ran automation for any junk without inaccessible data
         val automationSize = acsResult?.succesful

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -83,6 +83,12 @@ class InaccessibleDeleter @Inject constructor(
         targetPkgs: Collection<InstallId>?,
         useAutomation: Boolean,
         isBackground: Boolean,
+        /**
+         * Invoked with whatever was already cleared when this call is about to fail. Caches cleared
+         * before a terminal automation error are genuinely gone, so the caller still has to fold
+         * them into its state instead of discarding them along with the exception.
+         */
+        onPartialResult: (InaccDelResult) -> Unit = {},
     ): InaccDelResult {
         log(TAG, INFO) { "deleteInaccessible() targetPkgs=${targetPkgs?.size}, $useAutomation" }
 
@@ -113,6 +119,7 @@ class InaccessibleDeleter @Inject constructor(
             isAllApps = targetPkgs == null,
             useAutomation = useAutomation,
             isBackground = isBackground,
+            onPartialResult = onPartialResult,
         )
     }
 
@@ -121,6 +128,7 @@ class InaccessibleDeleter @Inject constructor(
         isAllApps: Boolean,
         useAutomation: Boolean,
         isBackground: Boolean,
+        onPartialResult: (InaccDelResult) -> Unit,
     ): InaccDelResult {
         log(TAG) { "${targets.size} inaccessible caches to delete." }
         if (targets.isEmpty()) return InaccDelResult()
@@ -187,11 +195,7 @@ class InaccessibleDeleter @Inject constructor(
                     } catch (e: UserCancelledAutomationException) {
                         log(TAG, WARN) { "User cancelled during force-stop; skipping cache clear." }
                         // Honor the cancel as a full stop: don't proceed to clear cache.
-                        successTargets.forEach { failedTargets.remove(it) }
-                        return InaccDelResult(
-                            succesful = successTargets.toSet(),
-                            failed = failedTargets,
-                        )
+                        return buildResult(successTargets, failedTargets)
                     }
                 }
 
@@ -207,6 +211,10 @@ class InaccessibleDeleter @Inject constructor(
                 val result = try {
                     automationManager.submit(acsTask) as ClearCacheTask.Result
                 } catch (e: AutomationUnavailableException) {
+                    // Nothing ran, but fold anyway so the partial-result contract holds uniformly.
+                    successTargets.addAll(successLive)
+                    failedTargets.putAll(failedLive)
+                    onPartialResult(buildResult(successTargets, failedTargets))
                     throw InaccessibleDeletionException(e)
                 } catch (e: UserCancelledAutomationException) {
                     log(TAG, WARN) { "User has cancelled ($e), forwarding live progress: $successLive" }
@@ -214,6 +222,16 @@ class InaccessibleDeleter @Inject constructor(
                         successful = successLive,
                         failed = failedLive,
                     )
+                } catch (e: Exception) {
+                    // Any other terminal automation failure: a compatibility give-up, a locked
+                    // screen, an overlay error, or the caller being cancelled. Caches cleared
+                    // before that point are really cleared, so hand them back before the exception
+                    // travels on, otherwise the next scan still lists them as freeable.
+                    log(TAG, WARN) { "ACS clearing failed, forwarding live progress: $successLive" }
+                    successTargets.addAll(successLive)
+                    failedTargets.putAll(failedLive)
+                    onPartialResult(buildResult(successTargets, failedTargets))
+                    throw e
                 }
 
                 successTargets.addAll(result.successful)
@@ -223,12 +241,22 @@ class InaccessibleDeleter @Inject constructor(
             log(TAG, INFO) { "useAutomation=false" }
         }
 
-        // Clean up contradictory bookkeeping: if an app failed earlier but succeeded later, remove from failed
-        successTargets.forEach { failedTargets.remove(it) }
+        return buildResult(successTargets, failedTargets)
+    }
 
+    /**
+     * Snapshots the accumulated per-app outcomes. Also cleans up contradictory bookkeeping: an app
+     * that failed earlier but succeeded later must not stay in [InaccDelResult.failed], or it would
+     * be recorded as a permanent ACS failure and marked unclearable.
+     */
+    private fun buildResult(
+        successTargets: Collection<InstallId>,
+        failedTargets: Map<InstallId, Exception>,
+    ): InaccDelResult {
+        val successful = successTargets.toSet()
         return InaccDelResult(
-            succesful = successTargets.toSet(),
-            failed = failedTargets,
+            succesful = successful,
+            failed = failedTargets.filterKeys { !successful.contains(it) },
         )
     }
 

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -1,11 +1,13 @@
 package eu.darken.sdmse.appcleaner.core
 
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPublicFilter
 import eu.darken.sdmse.appcleaner.core.scanner.AppScanner
 import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
+import eu.darken.sdmse.appcleaner.ui.preview.previewInaccessibleCache
 import eu.darken.sdmse.automation.core.errors.InvalidSystemStateException
 import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
 import eu.darken.sdmse.appcleaner.ui.preview.previewExpendables
@@ -43,6 +45,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -467,7 +470,7 @@ class AppCleanerTest : BaseTest() {
             every { progress } returns MutableStateFlow<Progress.Data?>(null)
             every { updateProgress(any()) } just Runs
             coEvery {
-                deleteInaccessible(any(), any(), any(), any())
+                deleteInaccessible(any(), any(), any(), any(), any())
             } returns InaccessibleDeleter.InaccDelResult(succesful = emptySet(), failed = emptyMap())
         }
         // Replace the cleaner's deleter provider by rebuilding from scratch with the stubbed
@@ -489,7 +492,7 @@ class AppCleanerTest : BaseTest() {
             every { progress } returns MutableStateFlow<Progress.Data?>(null)
             every { updateProgress(any()) } just Runs
             coEvery {
-                deleteInaccessible(any(), any(), any(), any())
+                deleteInaccessible(any(), any(), any(), any(), any())
             } returns InaccessibleDeleter.InaccDelResult(succesful = emptySet(), failed = emptyMap())
         }
         val rebuilt = rebuildWithDeleter(setup, deleter)
@@ -534,7 +537,11 @@ class AppCleanerTest : BaseTest() {
      * Re-build a cleaner with the same mocks but a different InaccessibleDeleter. Used by chained-
      * task tests where the OneClick/Scheduler path actually walks the deletion code.
      */
-    private fun rebuildWithDeleter(setup: Setup, deleter: InaccessibleDeleter): Setup {
+    private fun rebuildWithDeleter(
+        setup: Setup,
+        deleter: InaccessibleDeleter,
+        filterFactories: Set<ExpendablesFilter.Factory> = emptySet(),
+    ): Setup {
         // Pull the existing scanner+exclusionManager so the rebuilt cleaner shares behaviour. The
         // simpler approach (passing them to setupCleaner) won't work because setupCleaner builds
         // fresh mocks every call — so we just construct a fresh AppCleaner pointing at the same
@@ -575,7 +582,7 @@ class AppCleanerTest : BaseTest() {
             rootManager = rootManager,
             adbManager = adbManager,
             shellOps = shellOps,
-            filterFactories = emptySet(),
+            filterFactories = filterFactories,
             appInventorySetupModule = inventorySetup,
             upgradeRepo = mockUpgradeRepo(pro = true),
         )
@@ -606,12 +613,32 @@ class AppCleanerTest : BaseTest() {
         ),
     )
 
+    /** A filter that reports every target it is handed as successfully deleted. */
+    private fun deletingFilterFactory(): ExpendablesFilter.Factory {
+        val filter = mockk<ExpendablesFilter>(relaxUnitFun = true).apply {
+            every { identifier } returns DefaultCachesPublicFilter::class
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coJustRun { initialize() }
+            coEvery { process(any(), any()) } answers {
+                ExpendablesFilter.ProcessResult(
+                    success = firstArg<Collection<ExpendablesFilter.Match>>(),
+                    failed = emptyList(),
+                )
+            }
+        }
+        return mockk<ExpendablesFilter.Factory>().apply {
+            coEvery { isEnabled() } returns true
+            coEvery { create() } returns filter
+        }
+    }
+
     private fun acsDeleter(succesful: Set<InstallId>): InaccessibleDeleter =
         mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
             every { progress } returns MutableStateFlow<Progress.Data?>(null)
             every { updateProgress(any()) } just Runs
             coEvery {
-                deleteInaccessible(any(), any(), any(), any())
+                deleteInaccessible(any(), any(), any(), any(), any())
             } returns InaccessibleDeleter.InaccDelResult(succesful = succesful, failed = emptyMap())
         }
 
@@ -648,6 +675,109 @@ class AppCleanerTest : BaseTest() {
     }
 
     @Test
+    fun `a failing ACS stage still records the accessible files it already deleted`() = runTest2 {
+        // The accessible deletions hit the disk before the ACS stage runs, but `internalData` is
+        // only rewritten after it. When the ACS stage throws, that rewrite must still happen or the
+        // dashboard keeps listing files that are gone and advertises space that is already free.
+        val junk = previewAppJunk(
+            pkg = previewInstalled(pkgName = "com.example.mixed", label = "com.example.mixed"),
+            expendables = previewExpendables(),
+            inaccessibleCache = previewInaccessibleCache(pkgName = "com.example.mixed"),
+        )
+        val boom = InvalidSystemStateException("screen went off mid-run")
+        val deleter = mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coEvery { deleteInaccessible(any(), any(), any(), any(), any()) } throws boom
+        }
+        val setup = setupCleaner(scanResults = listOf(junk))
+        val rebuilt = rebuildWithDeleter(setup, deleter, filterFactories = setOf(deletingFilterFactory()))
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        val expendableSize = previewExpendables().values.flatten().sumOf { it.expectedGain }
+
+        // The task still fails, with the original exception: the salvage must not mask the failure.
+        shouldThrow<InvalidSystemStateException> {
+            rebuilt.cleaner.submit(AppCleanerProcessingTask())
+        } shouldBe boom
+
+        val after = rebuilt.cleaner.state.first().data!!.junks.single()
+        // Accessible matches were deleted, so they must be gone from the data the dashboard reads.
+        after.expendables.orEmpty().values.flatten().shouldBe(emptyList())
+        // The inaccessible cache survives untouched apart from the public-cache bytes we did delete.
+        after.inaccessibleCache!!.totalSize shouldBe
+            previewInaccessibleCache(pkgName = "com.example.mixed").totalSize - expendableSize
+        // No ACS attempt completed, so nothing may be recorded as a permanent ACS failure.
+        after.acsError shouldBe null
+        after.isUnclearable shouldBe false
+    }
+
+    @Test
+    fun `a cancel during the ACS stage still records the accessible files it already deleted`() = runTest2 {
+        // Cancelling is the likeliest way to interrupt a one-tap run, and it strands the accessible
+        // deletions exactly like a hard failure does. The cancellation itself must still propagate.
+        val junk = previewAppJunk(
+            pkg = previewInstalled(pkgName = "com.example.mixed", label = "com.example.mixed"),
+            expendables = previewExpendables(),
+            inaccessibleCache = previewInaccessibleCache(pkgName = "com.example.mixed"),
+        )
+        val deleter = mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coEvery {
+                deleteInaccessible(any(), any(), any(), any(), any())
+            } throws CancellationException("cancelled mid-ACS")
+        }
+        val setup = setupCleaner(scanResults = listOf(junk))
+        val rebuilt = rebuildWithDeleter(setup, deleter, filterFactories = setOf(deletingFilterFactory()))
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        shouldThrow<CancellationException> {
+            rebuilt.cleaner.submit(AppCleanerProcessingTask())
+        }
+
+        val after = rebuilt.cleaner.state.first().data!!.junks.single()
+        after.expendables.orEmpty().values.flatten().shouldBe(emptyList())
+        after.acsError shouldBe null
+    }
+
+    @Test
+    fun `caches cleared before a terminal ACS failure are not re-advertised`() = runTest2 {
+        // The ACS stage clears one app, then dies. The cleared cache must drop out of the data even
+        // though the task fails, or the next dashboard render offers to free bytes that are gone.
+        val cleared = installId("com.example.cleared")
+        val setup = setupCleaner(
+            scanResults = listOf(
+                inaccJunk("com.example.cleared", itemCount = 4, theoreticalPaths = emptySet()),
+                inaccJunk("com.example.later", itemCount = 4, theoreticalPaths = emptySet()),
+            ),
+        )
+        val boom = InvalidSystemStateException("screen went off after the first app")
+        val deleter = mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coEvery { deleteInaccessible(any(), any(), any(), any(), any()) } answers {
+                // Report the app that was already cleared, then fail the way the real deleter does.
+                // Index, not lastArg(): this is a suspend function, so the trailing JVM argument is
+                // the Continuation rather than the callback.
+                arg<(InaccessibleDeleter.InaccDelResult) -> Unit>(4)
+                    .invoke(InaccessibleDeleter.InaccDelResult(succesful = setOf(cleared), failed = emptyMap()))
+                throw boom
+            }
+        }
+        val rebuilt = rebuildWithDeleter(setup, deleter)
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        shouldThrow<InvalidSystemStateException> {
+            rebuilt.cleaner.submit(AppCleanerProcessingTask())
+        } shouldBe boom
+
+        // The cleared junk is gone entirely; only the app the run never reached is still listed.
+        val remaining = rebuilt.cleaner.state.first().data!!.junks
+        remaining.map { it.identifier } shouldBe listOf(installId("com.example.later"))
+    }
+
+    @Test
     fun `a junk untouched by a later targeted run keeps its acsError`() = runTest2 {
         val stuck = installId("com.example.stuck")
         val other = installId("com.example.other")
@@ -660,7 +790,7 @@ class AppCleanerTest : BaseTest() {
         val deleter = mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
             every { progress } returns MutableStateFlow<Progress.Data?>(null)
             every { updateProgress(any()) } just Runs
-            coEvery { deleteInaccessible(any(), any(), any(), any()) } returnsMany listOf(
+            coEvery { deleteInaccessible(any(), any(), any(), any(), any()) } returnsMany listOf(
                 // First run: "stuck" fails permanently, "other" is left over.
                 InaccessibleDeleter.InaccDelResult(
                     succesful = emptySet(),
@@ -692,7 +822,7 @@ class AppCleanerTest : BaseTest() {
         val deleter = mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
             every { progress } returns MutableStateFlow<Progress.Data?>(null)
             every { updateProgress(any()) } just Runs
-            coEvery { deleteInaccessible(any(), any(), any(), any()) } returnsMany listOf(
+            coEvery { deleteInaccessible(any(), any(), any(), any(), any()) } returnsMany listOf(
                 InaccessibleDeleter.InaccDelResult(
                     succesful = emptySet(),
                     failed = mapOf(stuck to NoSettingsWindowException("no settings window")),
@@ -724,7 +854,7 @@ class AppCleanerTest : BaseTest() {
         val deleter = mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
             every { progress } returns MutableStateFlow<Progress.Data?>(null)
             every { updateProgress(any()) } just Runs
-            coEvery { deleteInaccessible(any(), any(), any(), any()) } returns InaccessibleDeleter.InaccDelResult(
+            coEvery { deleteInaccessible(any(), any(), any(), any(), any()) } returns InaccessibleDeleter.InaccDelResult(
                 succesful = emptySet(),
                 failed = mapOf(stuck to NoSettingsWindowException("no settings window")),
             )

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
@@ -5,6 +5,7 @@ import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
 import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCacheProvider
 import eu.darken.sdmse.automation.core.AutomationSubmitter
 import eu.darken.sdmse.automation.core.ForceStopAutomationTask
+import eu.darken.sdmse.automation.core.errors.AutomationCompatibilityException
 import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.common.adb.AdbManager
@@ -20,7 +21,9 @@ import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.common.user.UserProfile2
 import eu.darken.sdmse.setup.SetupModule
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.maps.shouldContainKey
@@ -522,6 +525,42 @@ class InaccessibleDeleterTest : BaseTest() {
         result.failed.shouldBeEmpty()
         result.succesful shouldNotContain junk.identifier
         coVerify(exactly = 0) { automationManager.submit(any()) }
+    }
+
+    @Test
+    fun `a terminal ACS failure still reports the caches it already cleared`() = runTest {
+        // The service clears one app and then dies on the next. That first cache is genuinely empty
+        // now, so it has to reach the caller even though the call ends in an exception, or the
+        // dashboard will offer to free those bytes again on the next render.
+        val cleared = createAppJunk("com.example.cleared", cacheSize = 100000)
+        val doomed = createAppJunk("com.example.doomed", cacheSize = 200000)
+        val snapshot = createSnapshot(cleared, doomed)
+
+        coEvery { inaccessibleCacheProvider.determineCache(cleared.pkg) } returns nonZeroCache(cleared)
+        coEvery { inaccessibleCacheProvider.determineCache(doomed.pkg) } returns nonZeroCache(doomed)
+        coEvery { noSettingsDetector.getUnreachableReason(any()) } returns null
+        every { settings.forceStopBeforeClearing } returns mockDataStoreValue(false)
+
+        val boom = AutomationCompatibilityException()
+        coEvery { automationManager.submit(match { it is ClearCacheTask }) } answers {
+            firstArg<ClearCacheTask>().onSuccess(cleared.identifier)
+            throw boom
+        }
+
+        var partial: InaccessibleDeleter.InaccDelResult? = null
+        shouldThrow<AutomationCompatibilityException> {
+            deleter.deleteInaccessible(
+                snapshot = snapshot,
+                targetPkgs = null,
+                useAutomation = true,
+                isBackground = false,
+                onPartialResult = { partial = it },
+            )
+        } shouldBe boom
+
+        partial.shouldNotBeNull()
+        partial!!.succesful shouldContain cleared.identifier
+        partial!!.failed shouldNotContainKey cleared.identifier
     }
 
     @Test


### PR DESCRIPTION
## What changed

When a cleanup run stopped partway, AppCleaner kept listing files it had already deleted. The dashboard went on offering to free space that was already free, and pressing Delete again reported that nothing had been removed.

That happened whenever clearing app caches couldn't finish: the accessibility service wasn't available, the screen locked mid-run, the run was cancelled, or SD Maid gave up on a device it couldn't drive. Files deleted before that point now drop off the list properly, so the size you see is what's actually still there. App caches that were successfully cleared before the run stopped are no longer re-listed either.

The run itself still reports as failed or cancelled exactly as before. This changes what the list shows afterwards, not whether those runs fail.

## Technical Context

- Root cause: accessible junk is deleted first, but the tool's state is only rewritten after the inaccessible/ACS stage returns. Any throw from that stage unwound past the single state write, leaving the pre-deletion snapshot on record while the disk had moved on. The dashboard rebuilds its summary from live data whenever the last task has no result, which is exactly the failed-task case, so the stale snapshot is what got rendered.
- The ACS call is now wrapped: the failure is captured, the existing reconciliation block runs unmodified, and the original exception is rethrown before the result is built. Task bookkeeping and the failure notification are untouched.
- `CancellationException` deliberately takes the same path rather than short-circuiting. A cancel strands deletions identically, and the reconciliation contains no suspension points, so it is safe on a cancelled coroutine. It is rethrown unchanged, so a cancel is still recorded as a cancel rather than a failure.
- `InaccessibleDeleter` already tracked per-app successes for the `ClearCacheTask` callbacks but only surfaced them for a user cancel; every other terminal error dropped them. They now return through an `onPartialResult` callback. Worth the closest review: this widens what can be written into `acsError` on a failed run, and that is the same error path currently under investigation for a separate one-tap report.
- Not addressed here: why those runs fail in the first place. This only makes the list honest once they do.
