### PR TITLE
Fix: Stop animations staying switched off after a cleanup

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationProcessor.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationProcessor.kt
@@ -3,7 +3,6 @@ package eu.darken.sdmse.automation.core
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
-import eu.darken.sdmse.automation.core.animation.AnimationState
 import eu.darken.sdmse.automation.core.animation.AnimationTool
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
@@ -16,7 +15,6 @@ import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.progress.updateProgressPrimary
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.sync.Mutex
@@ -60,25 +58,25 @@ class AutomationProcessor @AssistedInject constructor(
                 AnimationTool.RestoreResult.FAILED
             }
 
-            var prevAnimState: AnimationState? = null
+            val runModule: suspend () -> AutomationTask.Result = {
+                log(TAG, INFO) { "process(): Current animation state: ${animationTool.getState()}" }
+                log(TAG, VERBOSE) { "process(): Processing $task via $module" }
+                withContext(dispatcherProvider.IO) { module.process(task) }
+            }
 
             val result = try {
                 when {
-                    restoreResult == AnimationTool.RestoreResult.FAILED -> log(TAG, WARN) {
-                        "process(): Not touching animations, a pending restore is still outstanding"
+                    restoreResult == AnimationTool.RestoreResult.FAILED -> {
+                        log(TAG, WARN) { "process(): Not touching animations, a pending restore is still outstanding" }
+                        runModule()
                     }
 
                     animationTool.canChangeState() -> {
                         log(TAG) { "process(): Disabling animations" }
-                        prevAnimState = animationTool.captureAndDisable()
+                        animationTool.withAnimationsDisabled { runModule() }
                     }
-                }
 
-                log(TAG, INFO) { "process(): Current animation state: ${animationTool.getState()}" }
-
-                log(TAG, VERBOSE) { "process(): Processing $task via $module" }
-                withContext(dispatcherProvider.IO) {
-                    module.process(task)
+                    else -> runModule()
                 }
             } catch (e: CancellationException) {
                 log(TAG, INFO) { "process(): Task cancelled: $task ($e)" }
@@ -86,26 +84,6 @@ class AutomationProcessor @AssistedInject constructor(
             } catch (e: Exception) {
                 log(TAG, ERROR) { "process(): Task failed: $task\n${e.asLog()}" }
                 throw e
-            } finally {
-                if (prevAnimState != null) {
-                    log(TAG) { "process(): Restoring previous animation state" }
-                    withContext(NonCancellable) {
-                        var restored = false
-                        try {
-                            animationTool.setState(prevAnimState)
-                            restored = true
-                        } catch (e: Exception) {
-                            log(TAG, ERROR) { "process(): Failed to restore animation state: ${e.asLog()}" }
-                        }
-                        if (restored) {
-                            try {
-                                animationTool.clearPendingState()
-                            } catch (e: Exception) {
-                                log(TAG, ERROR) { "process(): Failed to clear pending state: ${e.asLog()}" }
-                            }
-                        }
-                    }
-                }
             }
 
             log(TAG) { "process(): Result is $result" }

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationProcessor.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationProcessor.kt
@@ -36,72 +36,86 @@ class AutomationProcessor @AssistedInject constructor(
 
     suspend fun process(task: AutomationTask): AutomationTask.Result = execLock.withLock {
         hasTask = true
-        log(TAG) { "process(): $task" }
-        automationHost.updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_loading)
 
-        val factory: AutomationModule.Factory = moduleFactories.singleOrNull { it.isResponsible(task) }
-            ?: throw IllegalStateException("No module found for $task")
-
-        val moduleScope = CoroutineScope(dispatcherProvider.IO + SupervisorJob())
-
-        val module = factory.create(automationHost, moduleScope)
+        var moduleScope: CoroutineScope? = null
 
         try {
-            animationTool.restorePendingState()
-        } catch (e: Exception) {
-            log(TAG, WARN) { "process(): Failed to restore pending animation state: ${e.asLog()}" }
-        }
+            log(TAG) { "process(): $task" }
+            automationHost.updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_loading)
 
-        var prevAnimState: AnimationState? = null
+            val factory: AutomationModule.Factory = moduleFactories.singleOrNull { it.isResponsible(task) }
+                ?: throw IllegalStateException("No module found for $task")
 
-        val result = try {
-            if (animationTool.canChangeState()) {
-                log(TAG) { "process(): Disabling animations" }
-                prevAnimState = animationTool.getState()
-                animationTool.persistPendingState(prevAnimState)
-                animationTool.setState(AnimationState.DISABLED)
+            val scope = CoroutineScope(dispatcherProvider.IO + SupervisorJob())
+            moduleScope = scope
+
+            val module = factory.create(automationHost, scope)
+
+            val restoreResult = try {
+                animationTool.restorePendingState()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "process(): Failed to restore pending animation state: ${e.asLog()}" }
+                AnimationTool.RestoreResult.FAILED
             }
 
-            log(TAG, INFO) { "process(): Current animation state: ${animationTool.getState()}" }
+            var prevAnimState: AnimationState? = null
 
-            log(TAG, VERBOSE) { "process(): Processing $task via $module" }
-            withContext(dispatcherProvider.IO) {
-                module.process(task)
-            }
-        } catch (e: CancellationException) {
-            log(TAG, INFO) { "process(): Task cancelled: $task ($e)" }
-            throw e
-        } catch (e: Exception) {
-            log(TAG, ERROR) { "process(): Task failed: $task\n${e.asLog()}" }
-            throw e
-        } finally {
-            if (prevAnimState != null) {
-                log(TAG) { "process(): Restoring previous animation state" }
-                withContext(NonCancellable) {
-                    var restored = false
-                    try {
-                        animationTool.setState(prevAnimState)
-                        restored = true
-                    } catch (e: Exception) {
-                        log(TAG, ERROR) { "process(): Failed to restore animation state: ${e.asLog()}" }
+            val result = try {
+                when {
+                    restoreResult == AnimationTool.RestoreResult.FAILED -> log(TAG, WARN) {
+                        "process(): Not touching animations, a pending restore is still outstanding"
                     }
-                    if (restored) {
+
+                    animationTool.canChangeState() -> {
+                        log(TAG) { "process(): Disabling animations" }
+                        prevAnimState = animationTool.captureAndDisable()
+                    }
+                }
+
+                log(TAG, INFO) { "process(): Current animation state: ${animationTool.getState()}" }
+
+                log(TAG, VERBOSE) { "process(): Processing $task via $module" }
+                withContext(dispatcherProvider.IO) {
+                    module.process(task)
+                }
+            } catch (e: CancellationException) {
+                log(TAG, INFO) { "process(): Task cancelled: $task ($e)" }
+                throw e
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "process(): Task failed: $task\n${e.asLog()}" }
+                throw e
+            } finally {
+                if (prevAnimState != null) {
+                    log(TAG) { "process(): Restoring previous animation state" }
+                    withContext(NonCancellable) {
+                        var restored = false
                         try {
-                            animationTool.clearPendingState()
+                            animationTool.setState(prevAnimState)
+                            restored = true
                         } catch (e: Exception) {
-                            log(TAG, ERROR) { "process(): Failed to clear pending state: ${e.asLog()}" }
+                            log(TAG, ERROR) { "process(): Failed to restore animation state: ${e.asLog()}" }
+                        }
+                        if (restored) {
+                            try {
+                                animationTool.clearPendingState()
+                            } catch (e: Exception) {
+                                log(TAG, ERROR) { "process(): Failed to clear pending state: ${e.asLog()}" }
+                            }
                         }
                     }
                 }
             }
+
+            log(TAG) { "process(): Result is $result" }
+
+            result
+        } finally {
             log(TAG, VERBOSE) { "process(): Canceling module scope..." }
-            moduleScope.cancel()
+            moduleScope?.cancel()
             hasTask = false
         }
-
-        log(TAG) { "process(): Result is $result" }
-
-        result
     }
 
     @AssistedFactory

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationTool.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationTool.kt
@@ -1,7 +1,9 @@
 package eu.darken.sdmse.automation.core.animation
 
 import android.content.Context
+import android.content.res.Resources
 import android.provider.Settings
+import android.util.TypedValue
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.automation.core.AutomationSettings
 import eu.darken.sdmse.common.adb.AdbManager
@@ -18,6 +20,9 @@ import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -29,6 +34,9 @@ class AnimationTool @Inject constructor(
     private val shellOps: ShellOps,
     private val animationSettings: AutomationSettings,
 ) {
+
+    private val txLock = Mutex()
+
     suspend fun canChangeState(): Boolean {
         val adb = adbManager.canUseAdbNow()
         val root = rootManager.canUseRootNow()
@@ -47,20 +55,65 @@ class AnimationTool @Inject constructor(
 
     private fun getCommand(key: String, value: Float): String = "settings put global $key $value"
 
+    /**
+     * The framework's own default for the transition scale, used when the setting row is absent.
+     * [WINDOW_ANIMATION_SCALE] and [ANIMATOR_DURATION_SCALE] have no such resource, they default to [DEFAULT_SCALE].
+     */
+    private fun defaultTransitionScale(): Float = try {
+        val resources = Resources.getSystem()
+        val id = resources.getIdentifier(FRAMEWORK_TRANSITION_SCALE_DEFAULT, "dimen", "android")
+        if (id == 0) {
+            log(TAG) { "defaultTransitionScale(): No framework resource, using $DEFAULT_SCALE" }
+            DEFAULT_SCALE
+        } else {
+            val typedValue = TypedValue()
+            resources.getValue(id, typedValue, true)
+            val frameworkValue = typedValue.float
+            if (!frameworkValue.isFinite() || frameworkValue <= 0f) {
+                log(TAG) { "defaultTransitionScale(): Unusable framework value ($frameworkValue), using $DEFAULT_SCALE" }
+                DEFAULT_SCALE
+            } else {
+                log(TAG) { "defaultTransitionScale(): Using framework value $frameworkValue" }
+                frameworkValue
+            }
+        }
+    } catch (e: Exception) {
+        log(TAG, WARN) { "defaultTransitionScale(): Lookup failed, using $DEFAULT_SCALE: ${e.asLog()}" }
+        DEFAULT_SCALE
+    }
+
+    /**
+     * Writes all three scales, substituting framework defaults for absent (null) values.
+     * A null field means the setting row doesn't exist, so writing only the non-null fields would make
+     * restoring an absent row a silent no-op. The write is verified by reading the values back.
+     */
     suspend fun setState(state: AnimationState) {
-        val cmds = mutableListOf<String>()
-        state.windowAnimationScale?.let { cmds.add(getCommand(WINDOW_ANIMATION_SCALE, it)) }
-        state.globalTransitionAnimationScale?.let { cmds.add(getCommand(TRANSITION_ANIMATION_SCALE, it)) }
-        state.globalAnimatorDurationscale?.let { cmds.add(getCommand(ANIMATOR_DURATION_SCALE, it)) }
+        val intended = mapOf(
+            WINDOW_ANIMATION_SCALE to (state.windowAnimationScale ?: DEFAULT_SCALE),
+            TRANSITION_ANIMATION_SCALE to (state.globalTransitionAnimationScale ?: defaultTransitionScale()),
+            ANIMATOR_DURATION_SCALE to (state.globalAnimatorDurationscale ?: DEFAULT_SCALE),
+        )
         val result = shellOps.execute(
-            ShellOpsCmd(cmds),
+            ShellOpsCmd(intended.map { (key, value) -> getCommand(key, value) }),
             when {
                 adbManager.canUseAdbNow() -> ShellOps.Mode.ADB
                 rootManager.canUseRootNow() -> ShellOps.Mode.ROOT
                 else -> throw IllegalStateException("No ShellOps Mode available to set animation state")
             }
         )
-        log(TAG) { "setState($state) result: $result" }
+        log(TAG) { "setState($state) intended=$intended result: $result" }
+
+        val readback = getState()
+        val actual = mapOf(
+            WINDOW_ANIMATION_SCALE to readback.windowAnimationScale,
+            TRANSITION_ANIMATION_SCALE to readback.globalTransitionAnimationScale,
+            ANIMATOR_DURATION_SCALE to readback.globalAnimatorDurationscale,
+        )
+        val mismatches = intended.filter { (key, value) -> actual[key] != value }
+        if (mismatches.isNotEmpty()) {
+            val details = mismatches.keys.joinToString { "$it (wanted ${intended[it]}, got ${actual[it]})" }
+            throw IllegalStateException("Animation state was not applied: $details")
+        }
     }
 
     suspend fun persistPendingState(state: AnimationState) {
@@ -73,31 +126,63 @@ class AnimationTool @Inject constructor(
         animationSettings.animationPendingRestoreState.value(null)
     }
 
-    suspend fun restorePendingState(): Boolean {
-        val pending = animationSettings.animationPendingRestoreState.value() ?: return false
+    enum class RestoreResult {
+        NOTHING_PENDING,
+        RESTORED,
+        FAILED,
+        ;
+    }
+
+    suspend fun restorePendingState(): RestoreResult = txLock.withLock {
+        val pending = animationSettings.animationPendingRestoreState.value()
+        if (pending == null) {
+            log(TAG, VERBOSE) { "restorePendingState(): No pending animation state" }
+            return@withLock RestoreResult.NOTHING_PENDING
+        }
 
         log(TAG, INFO) { "Found pending animation state to restore: $pending" }
 
         if (!canChangeState()) {
             log(TAG, WARN) { "Cannot restore pending animation state: no shell access available" }
-            return false
+            return@withLock RestoreResult.FAILED
         }
 
-        return try {
+        try {
             setState(pending)
             clearPendingState()
             log(TAG, INFO) { "Successfully restored pending animation state" }
-            true
+            RestoreResult.RESTORED
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(TAG, ERROR) { "Failed to restore pending animation state: ${e.asLog()}" }
-            false
+            RestoreResult.FAILED
         }
+    }
+
+    /**
+     * Captures the current state, persists it as pending restore state and then disables animations.
+     * Shares [txLock] with [restorePendingState] so a concurrent restore can't clear the record we just wrote.
+     */
+    suspend fun captureAndDisable(): AnimationState = txLock.withLock {
+        val previous = getState()
+        persistPendingState(previous)
+        try {
+            setState(AnimationState.DISABLED)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "captureAndDisable(): Failed to disable animations: ${e.asLog()}" }
+        }
+        previous
     }
 
     companion object {
         private const val WINDOW_ANIMATION_SCALE = "window_animation_scale"
         private const val TRANSITION_ANIMATION_SCALE = "transition_animation_scale"
         private const val ANIMATOR_DURATION_SCALE = "animator_duration_scale"
+        private const val FRAMEWORK_TRANSITION_SCALE_DEFAULT = "config_appTransitionAnimationDurationScaleDefault"
+        private const val DEFAULT_SCALE = 1.0f
         val TAG: String = logTag("Automation", "AnimationTool")
     }
 }

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationTool.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/animation/AnimationTool.kt
@@ -21,8 +21,10 @@ import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -68,13 +70,19 @@ class AnimationTool @Inject constructor(
         } else {
             val typedValue = TypedValue()
             resources.getValue(id, typedValue, true)
-            val frameworkValue = typedValue.float
-            if (!frameworkValue.isFinite() || frameworkValue <= 0f) {
-                log(TAG) { "defaultTransitionScale(): Unusable framework value ($frameworkValue), using $DEFAULT_SCALE" }
+            if (typedValue.type != TypedValue.TYPE_FLOAT) {
+                // TypedValue.getFloat() reinterprets the raw data bits, that's only meaningful for TYPE_FLOAT
+                log(TAG) { "defaultTransitionScale(): Not a float (type=${typedValue.type}), using $DEFAULT_SCALE" }
                 DEFAULT_SCALE
             } else {
-                log(TAG) { "defaultTransitionScale(): Using framework value $frameworkValue" }
-                frameworkValue
+                val frameworkValue = typedValue.float
+                if (!frameworkValue.isFinite() || frameworkValue <= 0f) {
+                    log(TAG) { "defaultTransitionScale(): Unusable framework value ($frameworkValue), using $DEFAULT_SCALE" }
+                    DEFAULT_SCALE
+                } else {
+                    log(TAG) { "defaultTransitionScale(): Using framework value $frameworkValue" }
+                    frameworkValue
+                }
             }
         }
     } catch (e: Exception) {
@@ -161,20 +169,47 @@ class AnimationTool @Inject constructor(
     }
 
     /**
-     * Captures the current state, persists it as pending restore state and then disables animations.
-     * Shares [txLock] with [restorePendingState] so a concurrent restore can't clear the record we just wrote.
+     * Captures the current state, persists it as pending restore state, disables animations, runs [block] and
+     * restores the captured state afterwards, no matter how [block] ends.
+     *
+     * [txLock] is held for the whole duration, including [block]. That's what keeps a concurrent
+     * [restorePendingState] from re-enabling animations mid-task or clearing the pending record while we still
+     * need it. Consequently nothing inside [block] may call a [txLock]-guarded method ([restorePendingState],
+     * [withAnimationsDisabled]), a [Mutex] is not reentrant and would deadlock. [getState] is unguarded and safe.
+     *
+     * Failing to disable animations is not fatal, [block] runs regardless. The restore runs [NonCancellable] so a
+     * cancellation, including one hitting the disable write itself, still leaves the device with its original state.
      */
-    suspend fun captureAndDisable(): AnimationState = txLock.withLock {
+    suspend fun <R> withAnimationsDisabled(block: suspend () -> R): R = txLock.withLock {
         val previous = getState()
         persistPendingState(previous)
         try {
-            setState(AnimationState.DISABLED)
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            log(TAG, WARN) { "captureAndDisable(): Failed to disable animations: ${e.asLog()}" }
+            try {
+                setState(AnimationState.DISABLED)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                log(TAG, WARN) { "withAnimationsDisabled(): Failed to disable animations: ${e.asLog()}" }
+            }
+            block()
+        } finally {
+            withContext(NonCancellable) {
+                var restored = false
+                try {
+                    setState(previous)
+                    restored = true
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "withAnimationsDisabled(): Failed to restore animation state: ${e.asLog()}" }
+                }
+                if (restored) {
+                    try {
+                        clearPendingState()
+                    } catch (e: Exception) {
+                        log(TAG, ERROR) { "withAnimationsDisabled(): Failed to clear pending state: ${e.asLog()}" }
+                    }
+                }
+            }
         }
-        previous
     }
 
     companion object {

--- a/app/src/test/java/eu/darken/sdmse/automation/core/AutomationProcessorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/AutomationProcessorTest.kt
@@ -33,10 +33,11 @@ class AutomationProcessorTest : BaseTest() {
     fun setup() {
         coEvery { animationTool.restorePendingState() } returns AnimationTool.RestoreResult.NOTHING_PENDING
         coEvery { animationTool.canChangeState() } returns true
-        coEvery { animationTool.captureAndDisable() } returns originalState
         coEvery { animationTool.getState() } returns originalState
-        coEvery { animationTool.setState(any()) } returns Unit
-        coEvery { animationTool.clearPendingState() } returns Unit
+        // The real implementation runs the block inside its transaction, the stub has to do the same
+        coEvery { animationTool.withAnimationsDisabled<AutomationTask.Result>(any()) } coAnswers {
+            firstArg<suspend () -> AutomationTask.Result>().invoke()
+        }
 
         coEvery { moduleFactory.isResponsible(any()) } returns true
         coEvery { moduleFactory.create(any(), any()) } returns module
@@ -51,7 +52,7 @@ class AutomationProcessorTest : BaseTest() {
     )
 
     @Test
-    fun `animations are disabled before processing and restored after`() = runTest {
+    fun `the task runs inside the animation transaction`() = runTest {
         val processor = createProcessor()
         val result = processor.process(task)
 
@@ -60,25 +61,19 @@ class AutomationProcessorTest : BaseTest() {
         coVerifyOrder {
             animationTool.restorePendingState()
             animationTool.canChangeState()
-            animationTool.captureAndDisable()
+            animationTool.withAnimationsDisabled<AutomationTask.Result>(any())
             module.process(task)
-            animationTool.setState(originalState)
-            animationTool.clearPendingState()
         }
     }
 
     @Test
-    fun `animations are restored even when task fails`() = runTest {
+    fun `a failing task still goes through the animation transaction`() = runTest {
         coEvery { module.process(any()) } throws RuntimeException("Task failed")
 
         val processor = createProcessor()
         shouldThrow<RuntimeException> { processor.process(task) }
 
-        coVerify {
-            animationTool.captureAndDisable()
-            animationTool.setState(originalState)
-            animationTool.clearPendingState()
-        }
+        coVerify { animationTool.withAnimationsDisabled<AutomationTask.Result>(any()) }
     }
 
     @Test
@@ -86,33 +81,24 @@ class AutomationProcessorTest : BaseTest() {
         coEvery { animationTool.canChangeState() } returns false
 
         val processor = createProcessor()
-        processor.process(task)
+        val result = processor.process(task)
 
-        coVerify(exactly = 0) { animationTool.captureAndDisable() }
+        result shouldBe taskResult
+        coVerify { module.process(task) }
+        coVerify(exactly = 0) { animationTool.withAnimationsDisabled<AutomationTask.Result>(any()) }
         coVerify(exactly = 0) { animationTool.setState(any()) }
         coVerify(exactly = 0) { animationTool.clearPendingState() }
     }
 
     @Test
-    fun `clearPendingState not called when restore fails`() = runTest {
-        coEvery { animationTool.setState(originalState) } throws RuntimeException("Shell lost")
-
-        val processor = createProcessor()
-        processor.process(task)
-
-        coVerify { animationTool.setState(originalState) }
-        coVerify(exactly = 0) { animationTool.clearPendingState() }
-    }
-
-    @Test
-    fun `does not capture or disable when the restore failed`() = runTest {
+    fun `does not disable animations when the restore failed`() = runTest {
         coEvery { animationTool.restorePendingState() } returns AnimationTool.RestoreResult.FAILED
 
         val processor = createProcessor()
         val result = processor.process(task)
 
         result shouldBe taskResult
-        coVerify(exactly = 0) { animationTool.captureAndDisable() }
+        coVerify(exactly = 0) { animationTool.withAnimationsDisabled<AutomationTask.Result>(any()) }
         coVerify(exactly = 0) { animationTool.setState(any()) }
         coVerify(exactly = 0) { animationTool.clearPendingState() }
     }
@@ -124,8 +110,7 @@ class AutomationProcessorTest : BaseTest() {
         val processor = createProcessor()
         processor.process(task)
 
-        coVerify { animationTool.captureAndDisable() }
-        coVerify { animationTool.setState(originalState) }
+        coVerify { animationTool.withAnimationsDisabled<AutomationTask.Result>(any()) }
     }
 
     @Test
@@ -137,21 +122,8 @@ class AutomationProcessorTest : BaseTest() {
 
         result shouldBe taskResult
         coVerify { module.process(task) }
-        coVerify(exactly = 0) { animationTool.captureAndDisable() }
+        coVerify(exactly = 0) { animationTool.withAnimationsDisabled<AutomationTask.Result>(any()) }
         coVerify(exactly = 0) { animationTool.setState(any()) }
-    }
-
-    @Test
-    fun `disable failure does not fail the task`() = runTest {
-        // captureAndDisable swallows a failed disable internally and still returns the captured state
-        coEvery { animationTool.captureAndDisable() } returns originalState
-
-        val processor = createProcessor()
-        val result = processor.process(task)
-
-        result shouldBe taskResult
-        coVerify { animationTool.setState(originalState) }
-        coVerify { animationTool.clearPendingState() }
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/automation/core/AutomationProcessorTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/AutomationProcessorTest.kt
@@ -31,11 +31,11 @@ class AutomationProcessorTest : BaseTest() {
 
     @BeforeEach
     fun setup() {
-        coEvery { animationTool.restorePendingState() } returns false
+        coEvery { animationTool.restorePendingState() } returns AnimationTool.RestoreResult.NOTHING_PENDING
         coEvery { animationTool.canChangeState() } returns true
+        coEvery { animationTool.captureAndDisable() } returns originalState
         coEvery { animationTool.getState() } returns originalState
         coEvery { animationTool.setState(any()) } returns Unit
-        coEvery { animationTool.persistPendingState(any()) } returns Unit
         coEvery { animationTool.clearPendingState() } returns Unit
 
         coEvery { moduleFactory.isResponsible(any()) } returns true
@@ -60,9 +60,7 @@ class AutomationProcessorTest : BaseTest() {
         coVerifyOrder {
             animationTool.restorePendingState()
             animationTool.canChangeState()
-            animationTool.getState()
-            animationTool.persistPendingState(originalState)
-            animationTool.setState(AnimationState.DISABLED)
+            animationTool.captureAndDisable()
             module.process(task)
             animationTool.setState(originalState)
             animationTool.clearPendingState()
@@ -77,7 +75,7 @@ class AutomationProcessorTest : BaseTest() {
         shouldThrow<RuntimeException> { processor.process(task) }
 
         coVerify {
-            animationTool.setState(AnimationState.DISABLED)
+            animationTool.captureAndDisable()
             animationTool.setState(originalState)
             animationTool.clearPendingState()
         }
@@ -90,8 +88,8 @@ class AutomationProcessorTest : BaseTest() {
         val processor = createProcessor()
         processor.process(task)
 
+        coVerify(exactly = 0) { animationTool.captureAndDisable() }
         coVerify(exactly = 0) { animationTool.setState(any()) }
-        coVerify(exactly = 0) { animationTool.persistPendingState(any()) }
         coVerify(exactly = 0) { animationTool.clearPendingState() }
     }
 
@@ -107,6 +105,30 @@ class AutomationProcessorTest : BaseTest() {
     }
 
     @Test
+    fun `does not capture or disable when the restore failed`() = runTest {
+        coEvery { animationTool.restorePendingState() } returns AnimationTool.RestoreResult.FAILED
+
+        val processor = createProcessor()
+        val result = processor.process(task)
+
+        result shouldBe taskResult
+        coVerify(exactly = 0) { animationTool.captureAndDisable() }
+        coVerify(exactly = 0) { animationTool.setState(any()) }
+        coVerify(exactly = 0) { animationTool.clearPendingState() }
+    }
+
+    @Test
+    fun `RESTORED allows the normal disable path`() = runTest {
+        coEvery { animationTool.restorePendingState() } returns AnimationTool.RestoreResult.RESTORED
+
+        val processor = createProcessor()
+        processor.process(task)
+
+        coVerify { animationTool.captureAndDisable() }
+        coVerify { animationTool.setState(originalState) }
+    }
+
+    @Test
     fun `restorePendingState failure does not block processing`() = runTest {
         coEvery { animationTool.restorePendingState() } throws RuntimeException("DataStore corrupted")
 
@@ -115,6 +137,21 @@ class AutomationProcessorTest : BaseTest() {
 
         result shouldBe taskResult
         coVerify { module.process(task) }
+        coVerify(exactly = 0) { animationTool.captureAndDisable() }
+        coVerify(exactly = 0) { animationTool.setState(any()) }
+    }
+
+    @Test
+    fun `disable failure does not fail the task`() = runTest {
+        // captureAndDisable swallows a failed disable internally and still returns the captured state
+        coEvery { animationTool.captureAndDisable() } returns originalState
+
+        val processor = createProcessor()
+        val result = processor.process(task)
+
+        result shouldBe taskResult
+        coVerify { animationTool.setState(originalState) }
+        coVerify { animationTool.clearPendingState() }
     }
 
     @Test
@@ -133,6 +170,16 @@ class AutomationProcessorTest : BaseTest() {
 
         val processor = createProcessor()
         shouldThrow<RuntimeException> { processor.process(task) }
+
+        processor.hasTask shouldBe false
+    }
+
+    @Test
+    fun `hasTask is reset when module resolution fails`() = runTest {
+        coEvery { moduleFactory.isResponsible(any()) } returns false
+
+        val processor = createProcessor()
+        shouldThrow<IllegalStateException> { processor.process(task) }
 
         processor.hasTask shouldBe false
     }

--- a/app/src/test/java/eu/darken/sdmse/automation/core/animation/AnimationToolTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/animation/AnimationToolTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.automation.core.animation
 
 import android.content.Context
+import android.provider.Settings
 import eu.darken.sdmse.automation.core.AutomationSettings
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.adb.canUseAdbNow
@@ -11,12 +12,16 @@ import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.shell.ShellOps
 import eu.darken.sdmse.common.shell.ipc.ShellOpsCmd
 import eu.darken.sdmse.common.shell.ipc.ShellOpsResult
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.mockk.CapturingSlot
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.slot
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -42,8 +47,39 @@ class AnimationToolTest : BaseTest() {
         mockkStatic("eu.darken.sdmse.common.adb.AdbExtensionsKt")
         mockkStatic("eu.darken.sdmse.common.root.RootExtensionsKt")
         mockkStatic("eu.darken.sdmse.common.datastore.DataStoreValueKt")
+        mockkStatic(Settings.Global::class)
 
         every { animationSettings.animationPendingRestoreState } returns pendingRestoreState
+
+        // setState() verifies its writes by reading them back, so every setState path needs these
+        stubReadback(1.0f, 1.0f, 1.0f)
+    }
+
+    /**
+     * Stubs what the system reads back for the three animation scales, `null` meaning the row doesn't exist.
+     */
+    private fun stubReadback(window: Float?, transition: Float?, animator: Float?) {
+        every {
+            Settings.Global.getFloat(any(), WINDOW_ANIMATION_SCALE, any())
+        } returns (window ?: Float.MIN_VALUE)
+        every {
+            Settings.Global.getFloat(any(), TRANSITION_ANIMATION_SCALE, any())
+        } returns (transition ?: Float.MIN_VALUE)
+        every {
+            Settings.Global.getFloat(any(), ANIMATOR_DURATION_SCALE, any())
+        } returns (animator ?: Float.MIN_VALUE)
+    }
+
+    private fun stubShell(exitCode: Int = 0): CapturingSlot<ShellOpsCmd> {
+        val cmdSlot = slot<ShellOpsCmd>()
+        coEvery { adbManager.canUseAdbNow() } returns true
+        coEvery { rootManager.canUseRootNow() } returns false
+        coEvery { shellOps.execute(capture(cmdSlot), any()) } returns ShellOpsResult(
+            exitCode = exitCode,
+            output = emptyList(),
+            errors = emptyList(),
+        )
+        return cmdSlot
     }
 
     private fun createTool() = AnimationTool(
@@ -55,52 +91,181 @@ class AnimationToolTest : BaseTest() {
     )
 
     @Test
-    fun `restorePendingState returns false when nothing pending`() = runTest {
+    fun `setState with an all-null state writes all three keys`() = runTest {
+        val cmdSlot = stubShell()
+
+        val tool = createTool()
+        tool.setState(AnimationState(null, null, null))
+
+        cmdSlot.captured.cmds shouldBe listOf(
+            "settings put global window_animation_scale 1.0",
+            "settings put global transition_animation_scale 1.0",
+            "settings put global animator_duration_scale 1.0",
+        )
+    }
+
+    @Test
+    fun `setState writes all three keys for a partially-null state`() = runTest {
+        val cmdSlot = stubShell()
+
+        val tool = createTool()
+        tool.setState(
+            AnimationState(
+                windowAnimationScale = 1.0f,
+                globalTransitionAnimationScale = 1.0f,
+                globalAnimatorDurationscale = null,
+            )
+        )
+
+        cmdSlot.captured.cmds shouldBe listOf(
+            "settings put global window_animation_scale 1.0",
+            "settings put global transition_animation_scale 1.0",
+            "settings put global animator_duration_scale 1.0",
+        )
+    }
+
+    @Test
+    fun `setState succeeds when the readback matches`() = runTest {
+        stubReadback(0.0f, 0.0f, 0.0f)
+        stubShell()
+
+        val tool = createTool()
+        tool.setState(AnimationState.DISABLED)
+    }
+
+    @Test
+    fun `setState throws when the readback does not match`() = runTest {
+        stubReadback(0.0f, 0.0f, 0.0f)
+        stubShell()
+
+        val tool = createTool()
+        shouldThrow<IllegalStateException> { tool.setState(testState) }
+    }
+
+    @Test
+    fun `setState throws when a key is still absent after writing`() = runTest {
+        stubReadback(1.0f, 1.0f, null)
+        stubShell()
+
+        val tool = createTool()
+        shouldThrow<IllegalStateException> { tool.setState(AnimationState(null, null, null)) }
+    }
+
+    @Test
+    fun `setState succeeds when the shell result is non-zero but the readback matches`() = runTest {
+        stubShell(exitCode = 1)
+
+        val tool = createTool()
+        tool.setState(testState)
+    }
+
+    @Test
+    fun `restorePendingState returns NOTHING_PENDING when nothing pending`() = runTest {
         coEvery { pendingRestoreState.value() } returns null
 
         val tool = createTool()
-        tool.restorePendingState() shouldBe false
+        tool.restorePendingState() shouldBe AnimationTool.RestoreResult.NOTHING_PENDING
     }
 
     @Test
     fun `restorePendingState restores and clears state on success`() = runTest {
         coEvery { pendingRestoreState.value() } returns testState
-        coEvery { adbManager.canUseAdbNow() } returns true
-        coEvery { rootManager.canUseRootNow() } returns false
-        coEvery { shellOps.execute(any<ShellOpsCmd>(), any()) } returns ShellOpsResult(
-            exitCode = 0,
-            output = emptyList(),
-            errors = emptyList(),
-        )
+        stubShell()
         coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(testState, null)
 
         val tool = createTool()
-        tool.restorePendingState() shouldBe true
+        tool.restorePendingState() shouldBe AnimationTool.RestoreResult.RESTORED
 
         coVerify { shellOps.execute(any<ShellOpsCmd>(), ShellOps.Mode.ADB) }
+        coVerify { pendingRestoreState.update(any()) }
     }
 
     @Test
-    fun `restorePendingState returns false when canChangeState is false`() = runTest {
+    fun `restorePendingState with an all-null pending state writes all three keys`() = runTest {
+        coEvery { pendingRestoreState.value() } returns AnimationState(null, null, null)
+        val cmdSlot = stubShell()
+        coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(testState, null)
+
+        val tool = createTool()
+        tool.restorePendingState() shouldBe AnimationTool.RestoreResult.RESTORED
+
+        cmdSlot.captured.cmds shouldBe listOf(
+            "settings put global window_animation_scale 1.0",
+            "settings put global transition_animation_scale 1.0",
+            "settings put global animator_duration_scale 1.0",
+        )
+    }
+
+    @Test
+    fun `restorePendingState returns FAILED when canChangeState is false`() = runTest {
         coEvery { pendingRestoreState.value() } returns testState
         coEvery { adbManager.canUseAdbNow() } returns false
         coEvery { rootManager.canUseRootNow() } returns false
 
         val tool = createTool()
-        tool.restorePendingState() shouldBe false
+        tool.restorePendingState() shouldBe AnimationTool.RestoreResult.FAILED
 
         coVerify(exactly = 0) { shellOps.execute(any<ShellOpsCmd>(), any()) }
+        coVerify(exactly = 0) { pendingRestoreState.update(any()) }
     }
 
     @Test
-    fun `restorePendingState catches exception and returns false on failure`() = runTest {
+    fun `restorePendingState catches exception and returns FAILED on failure`() = runTest {
         coEvery { pendingRestoreState.value() } returns testState
         coEvery { adbManager.canUseAdbNow() } returns true
         coEvery { rootManager.canUseRootNow() } returns false
         coEvery { shellOps.execute(any<ShellOpsCmd>(), any()) } throws RuntimeException("Shell failed")
 
         val tool = createTool()
-        tool.restorePendingState() shouldBe false
+        tool.restorePendingState() shouldBe AnimationTool.RestoreResult.FAILED
+    }
+
+    @Test
+    fun `restorePendingState does not clear the pending state when the readback fails`() = runTest {
+        coEvery { pendingRestoreState.value() } returns testState
+        stubReadback(0.0f, 0.0f, 0.0f)
+        stubShell()
+
+        val tool = createTool()
+        tool.restorePendingState() shouldBe AnimationTool.RestoreResult.FAILED
+
+        coVerify(exactly = 0) { pendingRestoreState.update(any()) }
+    }
+
+    @Test
+    fun `restorePendingState rethrows CancellationException`() = runTest {
+        coEvery { pendingRestoreState.value() } returns testState
+        coEvery { adbManager.canUseAdbNow() } returns true
+        coEvery { rootManager.canUseRootNow() } returns false
+        coEvery { shellOps.execute(any<ShellOpsCmd>(), any()) } throws CancellationException("Cancelled")
+
+        val tool = createTool()
+        shouldThrow<CancellationException> { tool.restorePendingState() }
+
+        coVerify(exactly = 0) { pendingRestoreState.update(any()) }
+    }
+
+    @Test
+    fun `captureAndDisable returns the captured state even when the disable write fails`() = runTest {
+        coEvery { adbManager.canUseAdbNow() } returns true
+        coEvery { rootManager.canUseRootNow() } returns false
+        coEvery { shellOps.execute(any<ShellOpsCmd>(), any()) } throws RuntimeException("Shell failed")
+        coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(null, testState)
+
+        val tool = createTool()
+        tool.captureAndDisable() shouldBe testState
+
+        coVerify { pendingRestoreState.update(any()) }
+    }
+
+    @Test
+    fun `captureAndDisable propagates a persist failure and does not disable`() = runTest {
+        coEvery { pendingRestoreState.update(any()) } throws RuntimeException("DataStore failed")
+
+        val tool = createTool()
+        shouldThrow<RuntimeException> { tool.captureAndDisable() }
+
+        coVerify(exactly = 0) { shellOps.execute(any<ShellOpsCmd>(), any()) }
     }
 
     @Test
@@ -121,5 +286,11 @@ class AnimationToolTest : BaseTest() {
         tool.clearPendingState()
 
         coVerify { pendingRestoreState.update(any()) }
+    }
+
+    companion object {
+        private const val WINDOW_ANIMATION_SCALE = "window_animation_scale"
+        private const val TRANSITION_ANIMATION_SCALE = "transition_animation_scale"
+        private const val ANIMATOR_DURATION_SCALE = "animator_duration_scale"
     }
 }

--- a/app/src/test/java/eu/darken/sdmse/automation/core/animation/AnimationToolTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/animation/AnimationToolTest.kt
@@ -25,6 +25,9 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.unmockkStatic
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -380,6 +383,32 @@ class AnimationToolTest : BaseTest() {
 
         // Only the initial persist, the pending record has to survive a failed restore
         coVerify(exactly = 1) { pendingRestoreState.update(any()) }
+    }
+
+    @Test
+    fun `withAnimationsDisabled blocks a concurrent restore until the block is done`() = runTest {
+        stubWritableSystem()
+        coEvery { pendingRestoreState.value() } returns testState
+        coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(null, testState)
+
+        val tool = createTool()
+        val blockGate = CompletableDeferred<Unit>()
+        val txJob = launch { tool.withAnimationsDisabled { blockGate.await() } }
+        runCurrent()
+
+        var restoreResult: AnimationTool.RestoreResult? = null
+        val restoreJob = launch { restoreResult = tool.restorePendingState() }
+        runCurrent()
+
+        // The transaction still holds the lock, so the restore can't re-enable animations or clear the record yet
+        restoreJob.isCompleted shouldBe false
+        restoreResult shouldBe null
+
+        blockGate.complete(Unit)
+        txJob.join()
+        restoreJob.join()
+
+        restoreResult shouldBe AnimationTool.RestoreResult.RESTORED
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/automation/core/animation/AnimationToolTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/automation/core/animation/AnimationToolTest.kt
@@ -1,7 +1,9 @@
 package eu.darken.sdmse.automation.core.animation
 
 import android.content.Context
+import android.content.res.Resources
 import android.provider.Settings
+import android.util.TypedValue
 import eu.darken.sdmse.automation.core.AutomationSettings
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.adb.canUseAdbNow
@@ -21,6 +23,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -80,6 +83,34 @@ class AnimationToolTest : BaseTest() {
             errors = emptyList(),
         )
         return cmdSlot
+    }
+
+    /**
+     * Stubs a system where shell writes actually take effect, so [AnimationTool.setState] readback checks pass.
+     * [onExecute] receives the 1-based shell call count and can throw to simulate a failing write.
+     */
+    private fun stubWritableSystem(onExecute: (Int) -> Unit = {}): MutableList<ShellOpsCmd> {
+        val current = mutableMapOf(
+            WINDOW_ANIMATION_SCALE to 1.0f,
+            TRANSITION_ANIMATION_SCALE to 1.0f,
+            ANIMATOR_DURATION_SCALE to 1.0f,
+        )
+        every { Settings.Global.getFloat(any(), any(), any()) } answers {
+            current[secondArg<String>()] ?: Float.MIN_VALUE
+        }
+
+        val cmds = mutableListOf<ShellOpsCmd>()
+        coEvery { adbManager.canUseAdbNow() } returns true
+        coEvery { rootManager.canUseRootNow() } returns false
+        coEvery { shellOps.execute(capture(cmds), any()) } answers {
+            onExecute(cmds.size)
+            firstArg<ShellOpsCmd>().cmds.forEach { cmd ->
+                val (key, value) = cmd.removePrefix("settings put global ").split(" ")
+                current[key] = value.toFloat()
+            }
+            ShellOpsResult(exitCode = 0, output = emptyList(), errors = emptyList())
+        }
+        return cmds
     }
 
     private fun createTool() = AnimationTool(
@@ -246,26 +277,140 @@ class AnimationToolTest : BaseTest() {
     }
 
     @Test
-    fun `captureAndDisable returns the captured state even when the disable write fails`() = runTest {
-        coEvery { adbManager.canUseAdbNow() } returns true
-        coEvery { rootManager.canUseRootNow() } returns false
-        coEvery { shellOps.execute(any<ShellOpsCmd>(), any()) } throws RuntimeException("Shell failed")
+    fun `withAnimationsDisabled runs the block with animations off and restores afterwards`() = runTest {
+        val cmds = stubWritableSystem()
         coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(null, testState)
 
         val tool = createTool()
-        tool.captureAndDisable() shouldBe testState
+        var stateDuringBlock: AnimationState? = null
+        val result = tool.withAnimationsDisabled {
+            stateDuringBlock = tool.getState()
+            "block-result"
+        }
 
-        coVerify { pendingRestoreState.update(any()) }
+        result shouldBe "block-result"
+        stateDuringBlock shouldBe AnimationState.DISABLED
+
+        cmds.map { it.cmds } shouldBe listOf(
+            listOf(
+                "settings put global window_animation_scale 0.0",
+                "settings put global transition_animation_scale 0.0",
+                "settings put global animator_duration_scale 0.0",
+            ),
+            listOf(
+                "settings put global window_animation_scale 1.0",
+                "settings put global transition_animation_scale 1.0",
+                "settings put global animator_duration_scale 1.0",
+            ),
+        )
+        // Persisted before disabling, cleared after restoring
+        coVerify(exactly = 2) { pendingRestoreState.update(any()) }
     }
 
     @Test
-    fun `captureAndDisable propagates a persist failure and does not disable`() = runTest {
+    fun `withAnimationsDisabled restores the previous state when the block throws`() = runTest {
+        val cmds = stubWritableSystem()
+        coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(null, testState)
+
+        val tool = createTool()
+        shouldThrow<IllegalArgumentException> {
+            tool.withAnimationsDisabled<Unit> { throw IllegalArgumentException("Block failed") }
+        }
+
+        cmds.last().cmds shouldBe listOf(
+            "settings put global window_animation_scale 1.0",
+            "settings put global transition_animation_scale 1.0",
+            "settings put global animator_duration_scale 1.0",
+        )
+        coVerify(exactly = 2) { pendingRestoreState.update(any()) }
+    }
+
+    @Test
+    fun `withAnimationsDisabled runs the block even when the disable write fails`() = runTest {
+        stubWritableSystem { callCount -> if (callCount == 1) throw RuntimeException("Shell failed") }
+        coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(null, testState)
+
+        val tool = createTool()
+        var blockRan = false
+        tool.withAnimationsDisabled { blockRan = true }
+
+        blockRan shouldBe true
+        coVerify(exactly = 2) { pendingRestoreState.update(any()) }
+    }
+
+    @Test
+    fun `withAnimationsDisabled restores the previous state when the disable write is cancelled`() = runTest {
+        val cmds = stubWritableSystem { callCount ->
+            if (callCount == 1) throw CancellationException("Cancelled")
+        }
+        coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(null, testState)
+
+        val tool = createTool()
+        var blockRan = false
+        shouldThrow<CancellationException> { tool.withAnimationsDisabled { blockRan = true } }
+
+        blockRan shouldBe false
+        cmds.last().cmds shouldBe listOf(
+            "settings put global window_animation_scale 1.0",
+            "settings put global transition_animation_scale 1.0",
+            "settings put global animator_duration_scale 1.0",
+        )
+        coVerify(exactly = 2) { pendingRestoreState.update(any()) }
+    }
+
+    @Test
+    fun `withAnimationsDisabled propagates a persist failure and does not disable`() = runTest {
         coEvery { pendingRestoreState.update(any()) } throws RuntimeException("DataStore failed")
 
         val tool = createTool()
-        shouldThrow<RuntimeException> { tool.captureAndDisable() }
+        var blockRan = false
+        shouldThrow<RuntimeException> { tool.withAnimationsDisabled { blockRan = true } }
 
+        blockRan shouldBe false
         coVerify(exactly = 0) { shellOps.execute(any<ShellOpsCmd>(), any()) }
+    }
+
+    @Test
+    fun `withAnimationsDisabled does not clear the pending state when the restore write fails`() = runTest {
+        stubWritableSystem { callCount -> if (callCount == 2) throw RuntimeException("Shell lost") }
+        coEvery { pendingRestoreState.update(any()) } returns DataStoreValue.Updated(null, testState)
+
+        val tool = createTool()
+        tool.withAnimationsDisabled { }
+
+        // Only the initial persist, the pending record has to survive a failed restore
+        coVerify(exactly = 1) { pendingRestoreState.update(any()) }
+    }
+
+    @Test
+    fun `defaultTransitionScale falls back when the framework resource is not a float`() = runTest {
+        val cmdSlot = stubShell()
+        mockkStatic(Resources::class)
+        val systemResources: Resources = mockk()
+        every { Resources.getSystem() } returns systemResources
+        every { systemResources.getIdentifier(any(), any(), any()) } returns 42
+        every { systemResources.getValue(any<Int>(), any(), any()) } answers {
+            secondArg<TypedValue>().type = TypedValue.TYPE_DIMENSION
+        }
+
+        try {
+            val tool = createTool()
+            tool.setState(
+                AnimationState(
+                    windowAnimationScale = 1.0f,
+                    globalTransitionAnimationScale = null,
+                    globalAnimatorDurationscale = 1.0f,
+                )
+            )
+        } finally {
+            unmockkStatic(Resources::class)
+        }
+
+        cmdSlot.captured.cmds shouldBe listOf(
+            "settings put global window_animation_scale 1.0",
+            "settings put global transition_animation_scale 1.0",
+            "settings put global animator_duration_scale 1.0",
+        )
     }
 
     @Test


### PR DESCRIPTION
## What changed

While clearing app caches through the accessibility service, SD Maid briefly switches your phone's animations off so the automated tapping runs faster, then switches them back on when it's finished.

On most phones one of the three animation settings has never actually been written to, and in exactly that case SD Maid switched it off but never switched it back on. Animations stayed off afterwards, and because SD Maid also threw away its own backup of the previous values at that moment, restarting the app could not repair it either. Every later cleanup then saw the switched-off state as "how the user likes it", so there was no way out short of changing the setting by hand.

Two smaller problems in the same area are fixed alongside it: opening the app and immediately starting a cleanup could let the app's own recovery step switch animations back on in the middle of that cleanup, and cancelling a cleanup at the wrong moment could leave the app in a state where it never cleaned up after itself.

Refs #1799

## Technical Context

- Root cause: `AnimationTool.setState()` emitted one `settings put` per non-null field, while the disable path wrote all three scales unconditionally. Restoring a state with an absent row produced an empty `ShellOpsCmd`, which still reports exit code 0, so the caller treated the no-op as a successful restore and cleared the persisted recovery record. Verified on hardware that `animator_duration_scale` has no settings row by default, both on a stock Android 13 image and on LineageOS, so this is the common case rather than an edge case.
- The write is now verified by reading the values back rather than by the shell exit code. The exit code was never sufficient: `ShellOpsResult.exitCode` carries only the status of the *last* instruction in a batch, and the empty-command case returns 0 regardless.
- Restoring absence via `settings delete global` was considered and rejected. `WindowManagerService`'s settings observer re-reads with its *current field value* as the default, so deleting a zeroed row leaves the runtime scale at zero until reboot while the persisted rows look clean. Writing `1.0` back is behaviourally equivalent because those backing fields default to `1.0f`; `transition_animation_scale` uses the ROM's own `config_appTransitionAnimationDurationScaleDefault` when it resolves to a usable positive float.
- The mutex now spans the entire disabled interval rather than just the capture. Deliberate consequence worth knowing: the lock is held across the caller's whole task, so nothing invoked inside `withAnimationsDisabled` may call a lock-guarded method on the same object — `Mutex` is not reentrant. This is stated in the method's KDoc.
- Worth a close read: the `try`/`finally` nesting inside `withAnimationsDisabled`. The disable write sits inside the `try` whose `finally` restores, which is what makes a cancellation arriving during that write still run the restore before propagating. Flattening it would silently reintroduce the case where a cancelled cleanup leaves animations off.
