### PR TITLE
AppCleaner: Stop reporting space that wasn't actually freed

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -407,10 +407,18 @@ class AppCleaner @Inject constructor(
         // exception, exactly as it did before this salvage existed.
         acsFailure?.let { throw it }
 
+        // `acsResult` is a var (the partial-result callback writes to it), so it won't smart-cast.
+        val acsOutcome = acsResult
+        // Prefer what the deleter actually observed disappearing. The pre-clear size is only a
+        // claim: an app can report a successful cache clear and still hold every byte, which used
+        // to be reported as freed space the user never got back. Apps the deleter could not
+        // measure fall back to the pre-clear size, i.e. the previous behaviour.
         // Force check via !! because we should not have ran automation for any junk without inaccessible data
-        val automationSize = acsResult?.succesful
-            ?.map { inaccessible -> snapshot.junks.single { it.identifier == inaccessible }.inaccessibleCache!! }
-            ?.sumOf { it.totalSize }
+        val automationSize = acsOutcome?.succesful
+            ?.sumOf { inaccessible ->
+                acsOutcome.freedBytes[inaccessible]
+                    ?: snapshot.junks.single { it.identifier == inaccessible }.inaccessibleCache!!.totalSize
+            }
             ?: 0L
         // Count items the same way the scan reported them ("X expendable items found"): the difference between
         // the pre- and post-deletion scan totals. Deriving it from the snapshot avoids re-deriving the

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -286,6 +286,9 @@ class InaccessibleDeleter @Inject constructor(
 
         val minObserved = mutableMapOf<InstallId, Long>()
         val lastSample = mutableMapOf<InstallId, Long>()
+        // A read that failed after an earlier one succeeded must not let that earlier value pass as
+        // the final measurement, or a 100MB cache read as 90MB and then unreadable reports 10MB.
+        val failedReads = mutableSetOf<InstallId>()
 
         // Track the MINIMUM, not the first decrease. A 100MB cache sampled as 90MB and then 0MB
         // freed 100MB; stopping at the first decrease would report 10MB, which is exactly the kind
@@ -296,13 +299,18 @@ class InaccessibleDeleter @Inject constructor(
             if (current == null) {
                 // A failed query won't get better by asking again in a tight loop.
                 log(TAG, WARN) { "Freed-byte sample failed for $id" }
+                failedReads.add(id)
                 return true
             }
             val size = current.totalSize
             minObserved[id] = minOf(minObserved[id] ?: Long.MAX_VALUE, size)
             val previous = lastSample.put(id, size)
-            // Zero is the end state. Otherwise the number has to stop moving before we trust it.
-            return size == 0L || previous == size
+            val baseline = baselines[id] ?: junk.inaccessibleCache!!.totalSize
+            // Zero is the end state. Otherwise the number has to move off the pre-clear size AND
+            // stop moving before we trust it: StorageStatsManager lags behind a clear, so two reads
+            // 500ms apart can both still report the stale pre-clear size. A target still sitting at
+            // its baseline keeps polling until the budget runs out.
+            return size == 0L || (previous == size && size < baseline)
         }
 
         // First pass outside the budget: on a large batch a global timeout can expire mid-round and
@@ -328,11 +336,14 @@ class InaccessibleDeleter @Inject constructor(
         return targets.associate { junk ->
             val id = junk.identifier
             val baseline = baselines[id] ?: junk.inaccessibleCache!!.totalSize
-            when (val min = minObserved[id]) {
-                // Never got a single reading. Reporting 0 here would tell a user who really did get
-                // their space back that nothing happened, so fall back to the pre-clear size and
-                // make the failed measurement visible instead of letting it pass as a real one.
-                null -> {
+            val min = minObserved[id]
+            when {
+                // Never got a single reading, or a reading failed part-way through. Reporting 0
+                // here would tell a user who really did get their space back that nothing happened,
+                // and crediting a half-finished walk-down would under-report just as badly, so fall
+                // back to the pre-clear size and make the failed measurement visible instead of
+                // letting it pass as a real one.
+                id in failedReads || min == null -> {
                     log(TAG, WARN) { "Freed-byte read failed, falling back to pre-clear size for $id" }
                     id to baseline
                 }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -135,6 +135,14 @@ class InaccessibleDeleter @Inject constructor(
 
         val successTargets = mutableListOf<InstallId>()
         val failedTargets = mutableMapOf<InstallId, Exception>()
+        // What each target held before we touched it. The scan-time size is the right baseline for
+        // the ADB backend, which runs first. Targets that survive to the ACS stage are re-based on
+        // the pre-ACS re-query below, so ACS is not credited with what ADB already freed.
+        val baselines = targets.associate { it.identifier to it.inaccessibleCache!!.totalSize }.toMutableMap()
+        val freedBytes = mutableMapOf<InstallId, Long>()
+        // Already empty before any backend ran: a success with nothing to measure. Excluded from
+        // the observation so it keeps contributing its scan-time size, exactly as before.
+        val zeroCacheSkips = mutableSetOf<InstallId>()
 
         if (adbManager.canUseAdbNow() && isAllApps) {
             val adbResult = trimCachesWithAdb(targets)
@@ -149,8 +157,12 @@ class InaccessibleDeleter @Inject constructor(
                 if (currentCache != null && currentCache.totalSize == 0L) {
                     log(TAG) { "Cache now zero, skipping automation: ${junk.identifier}" }
                     successTargets.add(junk.identifier)
+                    zeroCacheSkips.add(junk.identifier)
                     false
                 } else {
+                    // Free re-baseline: this query is made anyway, we just stopped throwing the
+                    // value away. A failed query leaves the scan-time baseline in place.
+                    if (currentCache != null) baselines[junk.identifier] = currentCache.totalSize
                     true
                 }
             }
@@ -241,7 +253,97 @@ class InaccessibleDeleter @Inject constructor(
             log(TAG, INFO) { "useAutomation=false" }
         }
 
-        return buildResult(successTargets, failedTargets)
+        val observationTargets = targets.filter {
+            successTargets.contains(it.identifier) && !zeroCacheSkips.contains(it.identifier)
+        }
+        if (observationTargets.isNotEmpty()) {
+            try {
+                freedBytes.putAll(observeFreedBytes(observationTargets, baselines))
+            } catch (e: Exception) {
+                // This suspends for up to ACS_SETTLE_TIMEOUT, so a cancel landing inside it is not
+                // unlikely. Without this the caller would receive no result at all and would keep
+                // advertising caches that are genuinely gone.
+                log(TAG, WARN) { "Freed-byte observation failed, forwarding what was cleared: ${e.asLog()}" }
+                onPartialResult(buildResult(successTargets, failedTargets, freedBytes))
+                throw e
+            }
+        }
+
+        return buildResult(successTargets, failedTargets, freedBytes)
+    }
+
+    /**
+     * Measures how many bytes each cleared target actually gave up. "Cache cleared" is what a
+     * backend reports, not what StorageStatsManager confirms: an app can report a successful clear
+     * and still hold every byte, and a real clear needs a moment for the numbers to catch up. The
+     * outcome is a number only, no target is reclassified based on what is observed here.
+     */
+    private suspend fun observeFreedBytes(
+        targets: Collection<AppJunk>,
+        baselines: Map<InstallId, Long>,
+    ): Map<InstallId, Long> {
+        log(TAG) { "Observing freed bytes for ${targets.size} targets" }
+
+        val minObserved = mutableMapOf<InstallId, Long>()
+        val lastSample = mutableMapOf<InstallId, Long>()
+
+        // Track the MINIMUM, not the first decrease. A 100MB cache sampled as 90MB and then 0MB
+        // freed 100MB; stopping at the first decrease would report 10MB, which is exactly the kind
+        // of wrong number this observation exists to eliminate.
+        suspend fun sample(junk: AppJunk): Boolean {
+            val id = junk.identifier
+            val current = inaccessibleCacheProvider.determineCache(junk.pkg)
+            if (current == null) {
+                // A failed query won't get better by asking again in a tight loop.
+                log(TAG, WARN) { "Freed-byte sample failed for $id" }
+                return true
+            }
+            val size = current.totalSize
+            minObserved[id] = minOf(minObserved[id] ?: Long.MAX_VALUE, size)
+            val previous = lastSample.put(id, size)
+            // Zero is the end state. Otherwise the number has to stop moving before we trust it.
+            return size == 0L || previous == size
+        }
+
+        // First pass outside the budget: on a large batch a global timeout can expire mid-round and
+        // leave late targets unsampled, silently back on the optimistic pre-clear figure. Every
+        // target is sampled at least once, always.
+        val pending = mutableListOf<AppJunk>()
+        targets.forEach { if (!sample(it)) pending.add(it) }
+
+        if (pending.isNotEmpty()) {
+            // Rounds rather than one coroutine per target, like the system app re-check above: no
+            // target can be starved of polling by targets that never settle.
+            withTimeoutOrNull(ACS_SETTLE_TIMEOUT) {
+                while (pending.isNotEmpty()) {
+                    log(TAG, VERBOSE) { "Waiting on ${pending.size} cache sizes to settle" }
+                    delay(500)
+                    pending.removeAll(pending.filter { sample(it) })
+                }
+            } ?: log(TAG, WARN) {
+                "Freed-byte observation timed out after $ACS_SETTLE_TIMEOUT for: ${pending.map { it.identifier }}"
+            }
+        }
+
+        return targets.associate { junk ->
+            val id = junk.identifier
+            val baseline = baselines[id] ?: junk.inaccessibleCache!!.totalSize
+            when (val min = minObserved[id]) {
+                // Never got a single reading. Reporting 0 here would tell a user who really did get
+                // their space back that nothing happened, so fall back to the pre-clear size and
+                // make the failed measurement visible instead of letting it pass as a real one.
+                null -> {
+                    log(TAG, WARN) { "Freed-byte read failed, falling back to pre-clear size for $id" }
+                    id to baseline
+                }
+
+                else -> {
+                    val freed = (baseline - min).coerceAtLeast(0L)
+                    log(TAG) { "Freed $freed of $baseline bytes (smallest observed: $min) for $id" }
+                    id to freed
+                }
+            }
+        }
     }
 
     /**
@@ -252,11 +354,13 @@ class InaccessibleDeleter @Inject constructor(
     private fun buildResult(
         successTargets: Collection<InstallId>,
         failedTargets: Map<InstallId, Exception>,
+        freedBytes: Map<InstallId, Long> = emptyMap(),
     ): InaccDelResult {
         val successful = successTargets.toSet()
         return InaccDelResult(
             succesful = successful,
             failed = failedTargets.filterKeys { !successful.contains(it) },
+            freedBytes = freedBytes.filterKeys { successful.contains(it) },
         )
     }
 
@@ -460,6 +564,12 @@ class InaccessibleDeleter @Inject constructor(
     data class InaccDelResult(
         val succesful: Set<InstallId> = emptySet(),
         val failed: Map<InstallId, Exception> = emptyMap(),
+        /**
+         * Bytes that were observed to actually disappear, per app. A missing entry means the
+         * clear was not measured; the caller then falls back to the pre-clear size, which is
+         * what it reported unconditionally before this existed.
+         */
+        val freedBytes: Map<InstallId, Long> = emptyMap(),
     )
 
     companion object {
@@ -467,5 +577,8 @@ class InaccessibleDeleter @Inject constructor(
 
         /** Wall-clock budget for waiting on StorageStatsManager to catch up after a trim. */
         private val SYSTEM_RECHECK_TIMEOUT = 10.seconds
+
+        /** Wall-clock budget for the whole post-clear settle poll that measures freed bytes. */
+        private val ACS_SETTLE_TIMEOUT = 10.seconds
     }
 }

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -633,13 +633,20 @@ class AppCleanerTest : BaseTest() {
         }
     }
 
-    private fun acsDeleter(succesful: Set<InstallId>): InaccessibleDeleter =
+    private fun acsDeleter(
+        succesful: Set<InstallId>,
+        freedBytes: Map<InstallId, Long> = emptyMap(),
+    ): InaccessibleDeleter =
         mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
             every { progress } returns MutableStateFlow<Progress.Data?>(null)
             every { updateProgress(any()) } just Runs
             coEvery {
                 deleteInaccessible(any(), any(), any(), any(), any())
-            } returns InaccessibleDeleter.InaccDelResult(succesful = succesful, failed = emptyMap())
+            } returns InaccessibleDeleter.InaccDelResult(
+                succesful = succesful,
+                failed = emptyMap(),
+                freedBytes = freedBytes,
+            )
         }
 
     @Test
@@ -657,6 +664,46 @@ class AppCleanerTest : BaseTest() {
         result.affectedCount shouldBe 12
         // …but only the 2 synthetic dir paths are individually recordable.
         result.affectedPaths.size shouldBe 2
+    }
+
+    @Test
+    fun `ProcessingTask reports the bytes the deleter measured, not the pre-clear size`() = runTest2 {
+        // The pre-clear size is only what the cache claimed to hold. An app can report a
+        // successful clear and keep every byte, and reporting that as freed space is how a
+        // 411MB headline ended up with 212MB of it never leaving the device.
+        val junk = inaccJunk("com.example.measured", itemCount = 12, theoreticalPaths = emptySet())
+        val setup = setupCleaner(scanResults = listOf(junk))
+        val rebuilt = rebuildWithDeleter(
+            setup,
+            acsDeleter(
+                succesful = setOf(installId("com.example.measured")),
+                freedBytes = mapOf(installId("com.example.measured") to 1L * 1024 * 1024),
+            ),
+        )
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        val result = rebuilt.cleaner.submit(AppCleanerProcessingTask(onlyInaccessible = true))
+
+        result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        // 1MB observed out of the 24MB the scan saw.
+        result.affectedSpace shouldBe 1L * 1024 * 1024
+        // Still a full success at scan scale: measuring bytes must not change what was cleared.
+        result.affectedCount shouldBe 12
+    }
+
+    @Test
+    fun `ProcessingTask falls back to the pre-clear size when nothing was measured`() = runTest2 {
+        val junk = inaccJunk("com.example.unmeasured", itemCount = 12, theoreticalPaths = emptySet())
+        val setup = setupCleaner(scanResults = listOf(junk))
+        // No freedBytes entry: the deleter could not measure this one (query failure, cancelled
+        // observation, a backend that never got there). The reported figure stays as it was.
+        val rebuilt = rebuildWithDeleter(setup, acsDeleter(succesful = setOf(installId("com.example.unmeasured"))))
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        val result = rebuilt.cleaner.submit(AppCleanerProcessingTask(onlyInaccessible = true))
+
+        result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        result.affectedSpace shouldBe 24L * 1024 * 1024
     }
 
     @Test

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
@@ -24,6 +24,7 @@ import eu.darken.sdmse.common.user.UserProfile2
 import eu.darken.sdmse.setup.SetupModule
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.maps.shouldBeEmpty
@@ -45,6 +46,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -854,11 +856,43 @@ class InaccessibleDeleterTest : BaseTest() {
     }
 
     @Test
-    fun `a cache that never shrinks settles instead of burning the whole budget`() = runTest {
+    fun `a cache still at its pre-clear size keeps polling until the budget runs out`() = runTest {
+        // Two identical reads are not proof of a settled number while the size still equals what it
+        // was before the clear: StorageStatsManager lags, so both can be the same stale value.
+        // Accepting that would report 0 freed for a cache that did clear.
         val junk = createAppJunk("com.example.unchanged", cacheSize = 100000)
         val snapshot = createSnapshot(junk)
 
         scriptCacheSizes(junk to listOf(100000L))
+        acsClears(junk)
+
+        val logs = collectLogs()
+        val startedAt = currentTime
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        // Virtual time, so this costs no wall-clock: the poll ran for the full settle budget and
+        // then gave up instead of hanging.
+        (currentTime - startedAt) shouldBeGreaterThanOrEqual 10_000L
+        logs.any { it.contains("Freed-byte observation timed out") } shouldBe true
+        result.freedBytes[junk.identifier] shouldBe 0L
+        result.succesful shouldContain junk.identifier
+        result.failed.shouldBeEmpty()
+    }
+
+    @Test
+    fun `a size that only drops after two stale reads still reports the full baseline`() = runTest {
+        // The pre-ACS re-query plus two post-clear reads all return the pre-clear size, then the
+        // number finally catches up. Settling on the repeated stale value would report 0 freed for
+        // a cache that gave up every byte.
+        val junk = createAppJunk("com.example.laggy", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        scriptCacheSizes(junk to listOf(100000L, 100000L, 100000L, 0L))
         acsClears(junk)
 
         val result = deleter.deleteInaccessible(
@@ -868,9 +902,31 @@ class InaccessibleDeleterTest : BaseTest() {
             isBackground = false,
         )
 
-        result.freedBytes[junk.identifier] shouldBe 0L
+        result.freedBytes[junk.identifier] shouldBe 100000L
         result.succesful shouldContain junk.identifier
-        result.failed.shouldBeEmpty()
+    }
+
+    @Test
+    fun `a read that fails after a successful one falls back to the pre-clear size`() = runTest {
+        // 100000 -> 90000 -> unreadable. The 90000 was a number on the way down, not a result, so
+        // crediting it would report 10000 freed for a cache we can no longer measure.
+        val junk = createAppJunk("com.example.halfread", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        scriptCacheSizes(junk to listOf(100000L, 90000L, null))
+        acsClears(junk)
+
+        val logs = collectLogs()
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.freedBytes[junk.identifier] shouldBe 100000L
+        result.succesful shouldContain junk.identifier
+        logs.any { it.contains("Freed-byte read failed, falling back to pre-clear size") } shouldBe true
     }
 
     @Test

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.debug.logging.Logging
 import eu.darken.sdmse.common.pkgs.NoSettingsDetector
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.features.InstallDetails
@@ -39,13 +40,18 @@ import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.mockDataStoreValue
+import java.util.Collections
 
 class InaccessibleDeleterTest : BaseTest() {
 
@@ -94,6 +100,36 @@ class InaccessibleDeleterTest : BaseTest() {
             automationSetupModule = automationSetupModule,
             noSettingsDetector = noSettingsDetector,
         )
+    }
+
+    private var logCollector: Logging.Logger? = null
+
+    @AfterEach
+    fun removeLogCollector() {
+        logCollector?.let { Logging.remove(it) }
+        logCollector = null
+    }
+
+    /**
+     * Captures log output for tests that assert a specific diagnostic was emitted. A number that
+     * could not be measured has to be recognisable as such in a debug log, so the line saying so
+     * is part of the contract, not decoration.
+     */
+    private fun collectLogs(): List<String> {
+        val lines = Collections.synchronizedList(mutableListOf<String>())
+        val logger = object : Logging.Logger {
+            override fun log(
+                priority: Logging.Priority,
+                tag: String,
+                message: String,
+                metaData: Map<String, Any>?,
+            ) {
+                lines.add("${priority.shortLabel}/$tag: $message")
+            }
+        }
+        Logging.install(logger)
+        logCollector = logger
+        return lines
     }
 
     private fun createAppJunk(
@@ -725,5 +761,261 @@ class InaccessibleDeleterTest : BaseTest() {
 
         coVerify(exactly = 1) { automationManager.submit(match { it is ClearCacheTask }) }
         result.succesful shouldContain junk.identifier
+    }
+
+    // ─────────────────────────── freed-byte measurement ───────────────────────────
+    // A backend reporting "cache cleared" is a claim, not a measurement: the app in the report
+    // that started this said success three runs in a row and never gave up a single byte. These
+    // cover what the settle poll reports, and that it never reclassifies anything.
+
+    /**
+     * Feeds `determineCache` a per-package script of sizes, one entry per read. The last entry
+     * repeats forever, so a test only spells out the reads that differ. A `null` entry is a
+     * failed query.
+     */
+    private fun scriptCacheSizes(vararg scripts: Pair<AppJunk, List<Long?>>) {
+        val reads = mutableMapOf<String, Int>()
+        scripts.forEach { (junk, sizes) ->
+            coEvery { inaccessibleCacheProvider.determineCache(junk.pkg) } answers {
+                val index = reads.merge(junk.identifier.pkgId.name, 1, Int::plus)!! - 1
+                sizes[minOf(index, sizes.lastIndex)]?.let { size ->
+                    InaccessibleCache(
+                        identifier = junk.identifier,
+                        isSystemApp = false,
+                        itemCount = if (size == 0L) 0 else 1,
+                        totalSize = size,
+                        publicSize = 0L,
+                        theoreticalPaths = emptySet(),
+                    )
+                }
+            }
+        }
+    }
+
+    /** Lets the ACS stage run and report every given target as cleared. */
+    private fun acsClears(vararg targets: AppJunk) {
+        every { settings.forceStopBeforeClearing } returns mockDataStoreValue(false)
+        coEvery { automationManager.submit(match { it is ClearCacheTask }) } returns ClearCacheTask.Result(
+            successful = targets.map { it.identifier }.toSet(),
+            failed = emptyMap(),
+        )
+    }
+
+    @Test
+    fun `freed bytes are measured per app, an app that kept its cache reports zero`() = runTest {
+        val dropped = createAppJunk("com.example.dropped", cacheSize = 100000)
+        val stubborn = createAppJunk("com.example.stubborn", cacheSize = 200000)
+        val snapshot = createSnapshot(dropped, stubborn)
+
+        // First read each is the pre-ACS re-query, everything after it is the observation.
+        scriptCacheSizes(
+            dropped to listOf(100000L, 0L),
+            stubborn to listOf(200000L),
+        )
+        acsClears(dropped, stubborn)
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.freedBytes[dropped.identifier] shouldBe 100000L
+        result.freedBytes[stubborn.identifier] shouldBe 0L
+        // Number-only: an app that gave up nothing is still a success and gains no error.
+        result.succesful shouldContain dropped.identifier
+        result.succesful shouldContain stubborn.identifier
+        result.failed.shouldBeEmpty()
+    }
+
+    @Test
+    fun `an unreadable cache falls back to the pre-clear size and says so`() = runTest {
+        val junk = createAppJunk("com.example.unreadable", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        // Cleared fine, but every size read after that fails.
+        scriptCacheSizes(junk to listOf(100000L, null))
+        acsClears(junk)
+
+        val logs = collectLogs()
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        // Reporting 0 would tell a user who really did get their space back that nothing happened.
+        result.freedBytes[junk.identifier] shouldBe 100000L
+        result.succesful shouldContain junk.identifier
+        // An unmeasured number must not pass for a measured one in a debug log.
+        logs.any { it.contains("Freed-byte read failed, falling back to pre-clear size") } shouldBe true
+    }
+
+    @Test
+    fun `a cache that never shrinks settles instead of burning the whole budget`() = runTest {
+        val junk = createAppJunk("com.example.unchanged", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        scriptCacheSizes(junk to listOf(100000L))
+        acsClears(junk)
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.freedBytes[junk.identifier] shouldBe 0L
+        result.succesful shouldContain junk.identifier
+        result.failed.shouldBeEmpty()
+    }
+
+    @Test
+    fun `freed bytes follow the smallest observed size, not the first decrease`() = runTest {
+        // StorageStatsManager walks down towards its final value. Settling on the first decrease
+        // would turn a 100000 -> 90000 -> 0 clear into "10000 freed", the same class of wrong
+        // number this whole measurement exists to remove.
+        val junk = createAppJunk("com.example.stepwise", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        scriptCacheSizes(junk to listOf(100000L, 90000L, 0L))
+        acsClears(junk)
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.freedBytes[junk.identifier] shouldBe 100000L
+    }
+
+    @Test
+    fun `a cancel during the observation forwards the caches that were cleared`() = runTest {
+        // The observation suspends after the ACS successes are already banked but before they are
+        // returned. Without the partial-result hand-off the caller ends up with no result at all
+        // and keeps offering to free caches that are genuinely gone.
+        val junk = createAppJunk("com.example.cleared", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        acsClears(junk)
+
+        var running: Deferred<InaccessibleDeleter.InaccDelResult>? = null
+        var reads = 0
+        coEvery { inaccessibleCacheProvider.determineCache(junk.pkg) } answers {
+            reads++
+            // Read 1 is the pre-ACS re-query. From read 2 we are inside the observation, and a
+            // non-settling size keeps it there long enough to hit the delay between rounds.
+            if (reads >= 2) running!!.cancel()
+            InaccessibleCache(
+                identifier = junk.identifier,
+                isSystemApp = false,
+                itemCount = 1,
+                totalSize = if (reads >= 2) 90000L else 100000L,
+                publicSize = 0L,
+                theoreticalPaths = emptySet(),
+            )
+        }
+
+        var partial: InaccessibleDeleter.InaccDelResult? = null
+        val deferred = async {
+            deleter.deleteInaccessible(
+                snapshot = snapshot,
+                targetPkgs = null,
+                useAutomation = true,
+                isBackground = false,
+                onPartialResult = { partial = it },
+            )
+        }
+        running = deferred
+
+        shouldThrow<CancellationException> { deferred.await() }
+
+        partial.shouldNotBeNull()
+        partial!!.succesful shouldContain junk.identifier
+    }
+
+    @Test
+    fun `every target is sampled at least once even when one pass outlasts the budget`() = runTest {
+        // A budget applied from the very first read would expire part-way through a big batch and
+        // leave the late targets on the optimistic pre-clear figure without anyone noticing.
+        val targets = (1..12).map { createAppJunk("com.example.batch$it", cacheSize = 100000) }
+        val snapshot = createSnapshot(*targets.toTypedArray())
+
+        acsClears(*targets.toTypedArray())
+
+        val reads = mutableMapOf<String, Int>()
+        coEvery { inaccessibleCacheProvider.determineCache(any()) } coAnswers {
+            val pkg = firstArg<Installed>()
+            // 12 targets at 1s of query latency each outlast the settle budget on their own.
+            delay(1000)
+            val seen = reads.merge(pkg.packageName, 1, Int::plus)!!
+            InaccessibleCache(
+                identifier = InstallId(pkg.id, testHandle),
+                isSystemApp = false,
+                itemCount = 1,
+                totalSize = if (seen == 1) 100000L else 25000L,
+                publicSize = 0L,
+                theoreticalPaths = emptySet(),
+            )
+        }
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.freedBytes.size shouldBe 12
+        // 75000, not 100000: an unsampled target would have fallen back to its pre-clear size.
+        targets.forEach { result.freedBytes[it.identifier] shouldBe 75000L }
+    }
+
+    @Test
+    fun `an ADB-cleared target is measured against its scan-time size`() = runTest {
+        val junk = createAppJunk("com.example.adb", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        every { adbManager.useAdb } returns flowOf(true)
+        coEvery { pkgOps.trimCaches(any(), any(), any()) } returns Unit
+        // ADB freed 60000 of the 100000 the scan saw. The pre-ACS re-query never runs for a target
+        // ADB already cleared, so the scan-time size stays the baseline.
+        scriptCacheSizes(junk to listOf(40000L))
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = false,
+            isBackground = false,
+        )
+
+        result.succesful shouldContain junk.identifier
+        result.freedBytes[junk.identifier] shouldBe 60000L
+    }
+
+    @Test
+    fun `a cache that was already empty is not measured and keeps its scan-time size`() = runTest {
+        val junk = createAppJunk("com.example.alreadyempty", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        scriptCacheSizes(junk to listOf(0L))
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.succesful shouldContain junk.identifier
+        // No entry means the caller falls back to the scan-time size, i.e. unchanged behaviour.
+        result.freedBytes shouldNotContainKey junk.identifier
+        // Only the pre-ACS re-query, no observation reads on top of it.
+        coVerify(exactly = 1) { inaccessibleCacheProvider.determineCache(junk.pkg) }
     }
 }


### PR DESCRIPTION
## What changed

AppCleaner could report freeing more space than it actually freed.

When AppCleaner clears an app's cache through the accessibility service, it presses that app's "Clear cache" button in Android's own settings. Until now, a successful button press was treated as proof the space came back, and the app was credited with its full cache size. Some apps report a successful clear and keep every byte anyway, so the "freed X MB" figure could be substantially larger than what the device actually gained.

AppCleaner now re-checks each app's cache size after clearing it and reports the bytes that actually disappeared. An app that keeps its cache is shown as freeing nothing instead of inflating the total, and an app that only partially clears is counted for the part it really gave up. Apps whose size can't be re-read still report their previous figure, so nobody who genuinely got their space back is told otherwise.

Both the accessibility-service and the Shizuku/ADB cache-clearing paths are measured this way.

## Technical Context

- Root cause: the accessibility branch of `InaccessibleDeleter` folded its results in with no read-back, and `AppCleaner.performProcessing` summed `automationSize` from the pre-clear snapshot. The ADB branch in the same class already read back, so the two backends disagreed about what "cleared" meant.
- The measurement is a single bounded settle pass over every successful target from both backends, with per-target baselines: the scan-time size for ADB targets, and a pre-ACS re-query for accessibility targets. That re-query already happened and was being discarded, so it costs nothing extra and stops the accessibility path being credited with what an ADB trim already freed.
- It reports `baseline - min(observed)` and only accepts a repeated reading as settled once the size has moved off its baseline. `StorageStatsManager` lags behind a clear, so two equal readings alone cannot distinguish "finished" from "not updated yet"; treating them as final reported a genuinely cleared cache as zero.
- Classification is deliberately untouched. Nothing is demoted to failed and no `acsError` is set from what the measurement sees, because a settle-latency miss must never put a visible error on an app that was cleaned. For the same reason a failed size re-read contributes the full pre-clear size rather than zero, with its own WARN so an unmeasured number is not mistaken for a measured one in a debug log.
- Worth close review: the cancellation guard around the observation. It suspends for up to 10 seconds, and without publishing the partial result before rethrowing, a cancel landing inside it would leave the caller with no result at all and still advertising caches that are genuinely gone.
