### PR TITLE
General: Fix excluding many items at once appearing to do nothing

### DIFF
--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionManager.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/ExclusionManager.kt
@@ -82,8 +82,11 @@ class ExclusionManager @Inject constructor(
                 else newOrUpdated.add(it)
                 !isDupe
             }
+            // Hash the incoming ids once: PathExclusion.id builds a fresh string on every access, so
+            // a nested none{} would be O(existing * new) string concatenations on a bulk exclude.
+            val newIds = newExclusions.mapTo(HashSet()) { it.id }
             this
-                .filter { old -> newExclusions.none { old.id == it.id } }
+                .filter { old -> old.id !in newIds }
                 .plus(newExclusions).toSet()
                 .also { exclusionStorage.save(it) }
         }

--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/ExclusionExtensions.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/ExclusionExtensions.kt
@@ -5,14 +5,22 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
-import eu.darken.sdmse.common.files.isAncestorOf
 
 suspend fun Exclusion.Path.match(candidate: APathLookup<*>): Boolean = match(candidate.lookedUp)
 
 fun Exclusion.hasTags(vararg tags: Exclusion.Tag) = this.tags.contains(Exclusion.Tag.GENERAL)
         || tags.any { this.tags.contains(it) }
 
-suspend fun <P : APath, PL : APathLookup<P>> Exclusion.Path.excludeNestedLookups(paths: Collection<PL>): Set<PL> {
+suspend fun <P : APath, PL : APathLookup<P>> Exclusion.Path.excludeNestedLookups(paths: Collection<PL>): Set<PL> =
+    listOf(this).excludeNestedLookups(paths)
+
+suspend fun <P : APath, PL : APathLookup<P>> Collection<Exclusion.Path>.excludeNestedLookups(
+    paths: Collection<PL>,
+): Set<PL> = PathExclusionIndex(this).excludeNestedLookups(paths)
+
+suspend fun <P : APath, PL : APathLookup<P>> PathExclusionIndex.excludeNestedLookups(
+    paths: Collection<PL>,
+): Set<PL> {
     val pathMap = paths.associateBy { it.lookedUp }
 
     val result = this.excludeNested(pathMap.keys)
@@ -20,42 +28,42 @@ suspend fun <P : APath, PL : APathLookup<P>> Exclusion.Path.excludeNestedLookups
     return result.map { pathMap[it]!! }.toSet()
 }
 
-suspend fun <P : APath, PL : APathLookup<P>> Collection<Exclusion.Path>.excludeNestedLookups(paths: Collection<PL>): Set<PL> {
-    var temp = paths.toSet()
-    this.forEach { temp = it.excludeNestedLookups(temp) }
-    return temp
-}
+suspend fun <T : APath> Exclusion.Path.excludeNested(paths: Collection<T>): Set<T> =
+    listOf(this).excludeNested(paths)
 
-suspend fun <T : APath> Collection<Exclusion.Path>.excludeNested(paths: Collection<T>): Set<T> {
-    var temp = paths.toSet()
-    this.forEach { temp = it.excludeNested(temp) }
-    return temp
-}
+suspend fun <T : APath> Collection<Exclusion.Path>.excludeNested(paths: Collection<T>): Set<T> =
+    PathExclusionIndex(this).excludeNested(paths)
 
-suspend fun <T : APath> Exclusion.Path.excludeNested(paths: Collection<T>): Set<T> {
+/**
+ * Drops every path matched by an exclusion, and then every path that is a strict ancestor of one of
+ * those. The second pass exists because deleting a parent directory would take an excluded child
+ * with it.
+ *
+ * This is a single pass over [paths] where the previous implementation folded the whole set once per
+ * exclusion. The two agree: whenever a fold step removed a path because it was an ancestor of some
+ * excluded `q`, every strict ancestor of that path was also a strict ancestor of `q` and went in the
+ * same step, so a later step matching that path directly could never prune anything new.
+ */
+suspend fun <T : APath> PathExclusionIndex.excludeNested(paths: Collection<T>): Set<T> {
     if (paths.isEmpty()) return emptySet()
 
-    val excluded = mutableSetOf<T>()
-
-    // Files that are left after applying direct exclusions
-    val afterFirstPass = paths.filter { path ->
-        val isExcluded = match(path)
+    val excluded = mutableListOf<T>()
+    val survivors = paths.filter { path ->
+        val isExcluded = matches(path)
         if (isExcluded) excluded.add(path)
         !isExcluded
     }
+    if (excluded.isEmpty()) return survivors.toSet()
 
-    // Files that are left after also checking ancestors, i.e. if we have:
-    // dirA
-    // dirA/dirB/
-    // dirA/dirB/file
-    // and exclude "file", then we also need to exclude all "dirA" and "dirB", otherwise we delete the parent and thus "file"
-    val afterSecondPass = afterFirstPass.filterNot { path ->
-        val reason = excluded.firstOrNull { path.isAncestorOf(it) }
-        if (reason != null) log(TAG, VERBOSE) { "Nested exclusion match: $path <- $reason <- $this" }
-        reason != null
-    }
+    val ancestorIndex = StrictAncestorIndex(excluded)
 
-    return afterSecondPass.toSet()
+    return survivors
+        .filterNot { path ->
+            val isAncestor = ancestorIndex.isStrictAncestorOfIndexed(path)
+            if (isAncestor) log(TAG, VERBOSE) { "Nested exclusion match: $path" }
+            isAncestor
+        }
+        .toSet()
 }
 
 private val TAG = logTag("Exclusion", "Extensions")

--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/ExclusionExtensions.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/ExclusionExtensions.kt
@@ -8,6 +8,8 @@ import eu.darken.sdmse.common.files.APathLookup
 
 suspend fun Exclusion.Path.match(candidate: APathLookup<*>): Boolean = match(candidate.lookedUp)
 
+suspend fun PathExclusionIndex.matches(candidate: APathLookup<*>): Boolean = matches(candidate.lookedUp)
+
 fun Exclusion.hasTags(vararg tags: Exclusion.Tag) = this.tags.contains(Exclusion.Tag.GENERAL)
         || tags.any { this.tags.contains(it) }
 

--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndex.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndex.kt
@@ -29,9 +29,11 @@ import java.io.File
  *   `/` is not an ancestor of `/a`, because `/a` does not start with `//`.
  * - **SAF**: `matches` is `SAFPath.path` string equality (that string already folds in
  *   `treeRootUri.pathSegments`, so the exact half needs no separate tree check). `isAncestorOf` is
- *   same-tree plus a proper `segments` prefix, so a SAF key is the tree URI plus a segment prefix,
- *   joined by NUL. NUL cannot occur in a URI or in a path segment, which makes that encoding
- *   unambiguous.
+ *   same-tree plus a proper `segments` prefix, so a SAF key is the tree URI plus a segment prefix.
+ *   Those components are length-prefixed instead of joined by a delimiter: segment content is
+ *   arbitrary (`SAFGateway` takes display names verbatim from a DocumentsProvider cursor), so no
+ *   character can be reserved as a separator, while a length-prefixed concatenation is injective
+ *   for any content.
  *
  * Exclusions that are not [PathExclusion]s (today: [SegmentExclusion]) cannot be keyed and stay on
  * the linear path.
@@ -117,17 +119,21 @@ internal class StrictAncestorIndex(paths: Collection<APath>) {
         keys[candidate.pathType]?.contains(candidate.exclusionKey()) == true
 }
 
-internal const val KEY_SEPARATOR = '\u0000'
+/**
+ * Appends one key component as `<UTF-16 length>:<value>`. Length-prefixing keeps the concatenation
+ * injective no matter what the component contains, so the key needs no delimiter character.
+ */
+private fun StringBuilder.appendKeyComponent(component: String): StringBuilder =
+    append(component.length).append(':').append(component)
 
 /**
  * The key a path is indexed under, matching what [forEachAncestorKey] emits for its descendants.
  */
 internal fun APath.exclusionKey(): String = when (pathType) {
     APath.PathType.SAF -> (this as SAFPath).let { safPath ->
-        StringBuilder(safPath.treeRootUri.toString())
-            .append(KEY_SEPARATOR)
-            .append(safPath.segments.joinToString(KEY_SEPARATOR.toString()))
-            .toString()
+        val builder = StringBuilder().appendKeyComponent(safPath.treeRootUri.toString())
+        safPath.segments.forEach { builder.appendKeyComponent(it) }
+        builder.toString()
     }
 
     else -> path
@@ -140,11 +146,10 @@ internal inline fun APath.forEachAncestorKey(action: (String) -> Unit) {
     when (pathType) {
         APath.PathType.SAF -> {
             val safPath = this as SAFPath
-            val builder = StringBuilder(safPath.treeRootUri.toString()).append(KEY_SEPARATOR)
+            val builder = StringBuilder().appendKeyComponent(safPath.treeRootUri.toString())
             action(builder.toString())
             for (i in 0 until safPath.segments.size - 1) {
-                if (i > 0) builder.append(KEY_SEPARATOR)
-                builder.append(safPath.segments[i])
+                builder.appendKeyComponent(safPath.segments[i])
                 action(builder.toString())
             }
         }

--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndex.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndex.kt
@@ -73,21 +73,26 @@ class PathExclusionIndex(exclusions: Collection<Exclusion.Path>) {
     }
 
     suspend fun matches(candidate: APath): Boolean {
-        if (matchesIndexed(candidate)) {
-            log(TAG, VERBOSE) { "Exclusion match: $candidate" }
+        val key = matchesIndexed(candidate)
+        if (key != null) {
+            log(TAG, VERBOSE) { "Exclusion match: $candidate <- $key" }
             return true
         }
         return others.any { it.match(candidate) }
     }
 
-    private fun matchesIndexed(candidate: APath): Boolean {
+    /**
+     * The key that matched, or `null` if none did. The key is returned instead of a boolean so the
+     * caller can log which exclusion was responsible.
+     */
+    private fun matchesIndexed(candidate: APath): String? {
         val type = candidate.pathType
-        if (exactKeys[type]?.contains(candidate.path) == true) return true
+        if (exactKeys[type]?.contains(candidate.path) == true) return candidate.path
 
-        val keys = ancestorKeys[type] ?: return false
-        var hit = false
+        val keys = ancestorKeys[type] ?: return null
+        var hit: String? = null
         candidate.forEachAncestorKey { key ->
-            if (!hit && keys.contains(key)) hit = true
+            if (hit == null && keys.contains(key)) hit = key
         }
         return hit
     }

--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndex.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndex.kt
@@ -1,0 +1,169 @@
+package eu.darken.sdmse.exclusion.core.types
+
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.saf.SAFPath
+import java.io.File
+
+/**
+ * Lookup structure that answers "does any of these exclusions match this path?" in time proportional
+ * to the path's own depth instead of the number of exclusions.
+ *
+ * Motivation: a bulk exclude can create tens of thousands of [PathExclusion]s. Testing every
+ * candidate against every exclusion is quadratic and, because [Exclusion.Path.match] is a suspend
+ * function, it is a very expensive kind of quadratic.
+ *
+ * ## Why the index is equivalent to a linear scan over [PathExclusion]s
+ * [PathExclusion.match] is `candidate.matches(path) || path.isAncestorOf(candidate)`. Both halves
+ * are decidable from keys that the candidate alone can produce, so the exclusions can be hashed:
+ * - **LOCAL**: `matches` is `LocalPath.path` string equality. `isAncestorOf` is a proper string
+ *   prefix that ends on a separator boundary, plus an explicit branch that makes the root `/` an
+ *   ancestor of everything below it. The candidate's ancestor keys are therefore its proper
+ *   prefixes cut right before each separator, plus `/` itself.
+ * - **RAW**: `matches` is `path` string equality. The ancestor test is the generic RAW branch of
+ *   `APath.isAncestorOf`, `descendant.path.startsWith(this.path + "/")`. It is NOT
+ *   `RawPath.isAncestorOf`, which absolutizes both sides, so `PathExclusion(RawPath("a"))` does not
+ *   match `RawPath("/cwd/a/b")` and neither does this index. There is no root branch here either:
+ *   `/` is not an ancestor of `/a`, because `/a` does not start with `//`.
+ * - **SAF**: `matches` is `SAFPath.path` string equality (that string already folds in
+ *   `treeRootUri.pathSegments`, so the exact half needs no separate tree check). `isAncestorOf` is
+ *   same-tree plus a proper `segments` prefix, so a SAF key is the tree URI plus a segment prefix,
+ *   joined by NUL. NUL cannot occur in a URI or in a path segment, which makes that encoding
+ *   unambiguous.
+ *
+ * Exclusions that are not [PathExclusion]s (today: [SegmentExclusion]) cannot be keyed and stay on
+ * the linear path.
+ *
+ * ## Documented behaviour change
+ * The index always consults the [PathExclusion]s before the non-indexable exclusions, regardless of
+ * collection order. The previous `any { it.match(candidate) }` was order-dependent in one observable
+ * way: `RawPath.segments` throws `NotImplementedError`, so a [SegmentExclusion] evaluated before a
+ * matching RAW [PathExclusion] threw, while the same set in the other order did not. Evaluation
+ * order was never a defined contract (it already varied with collection order), so the index turns
+ * an order-dependent latent crash into a consistent non-crash.
+ */
+class PathExclusionIndex(exclusions: Collection<Exclusion.Path>) {
+
+    private val exactKeys: Map<APath.PathType, Set<String>>
+    private val ancestorKeys: Map<APath.PathType, Set<String>>
+    private val others: List<Exclusion.Path>
+
+    init {
+        val exact = mutableMapOf<APath.PathType, MutableSet<String>>()
+        val ancestors = mutableMapOf<APath.PathType, MutableSet<String>>()
+        val rest = mutableListOf<Exclusion.Path>()
+
+        exclusions.forEach { exclusion ->
+            if (exclusion !is PathExclusion) {
+                rest.add(exclusion)
+                return@forEach
+            }
+            val path = exclusion.path
+            exact.getOrPut(path.pathType) { mutableSetOf() }.add(path.path)
+            ancestors.getOrPut(path.pathType) { mutableSetOf() }.add(path.exclusionKey())
+        }
+
+        exactKeys = exact
+        ancestorKeys = ancestors
+        others = rest
+    }
+
+    suspend fun matches(candidate: APath): Boolean {
+        if (matchesIndexed(candidate)) {
+            log(TAG, VERBOSE) { "Exclusion match: $candidate" }
+            return true
+        }
+        return others.any { it.match(candidate) }
+    }
+
+    private fun matchesIndexed(candidate: APath): Boolean {
+        val type = candidate.pathType
+        if (exactKeys[type]?.contains(candidate.path) == true) return true
+
+        val keys = ancestorKeys[type] ?: return false
+        var hit = false
+        candidate.forEachAncestorKey { key ->
+            if (!hit && keys.contains(key)) hit = true
+        }
+        return hit
+    }
+
+    companion object {
+        private val TAG = logTag("Exclusion", "Path", "Index")
+    }
+}
+
+/**
+ * Reverse of [PathExclusionIndex]: answers "is this path a strict ancestor of any of the indexed
+ * paths?". Built from the already excluded paths so that a survivor can be checked in O(depth)
+ * instead of being compared against every excluded path.
+ */
+internal class StrictAncestorIndex(paths: Collection<APath>) {
+
+    private val keys: Map<APath.PathType, Set<String>>
+
+    init {
+        val collected = mutableMapOf<APath.PathType, MutableSet<String>>()
+        paths.forEach { path ->
+            val bucket = collected.getOrPut(path.pathType) { mutableSetOf() }
+            path.forEachAncestorKey { bucket.add(it) }
+        }
+        keys = collected
+    }
+
+    fun isStrictAncestorOfIndexed(candidate: APath): Boolean =
+        keys[candidate.pathType]?.contains(candidate.exclusionKey()) == true
+}
+
+internal const val KEY_SEPARATOR = '\u0000'
+
+/**
+ * The key a path is indexed under, matching what [forEachAncestorKey] emits for its descendants.
+ */
+internal fun APath.exclusionKey(): String = when (pathType) {
+    APath.PathType.SAF -> (this as SAFPath).let { safPath ->
+        StringBuilder(safPath.treeRootUri.toString())
+            .append(KEY_SEPARATOR)
+            .append(safPath.segments.joinToString(KEY_SEPARATOR.toString()))
+            .toString()
+    }
+
+    else -> path
+}
+
+/**
+ * Emits the key of every path that would be a strict ancestor of this one.
+ */
+internal inline fun APath.forEachAncestorKey(action: (String) -> Unit) {
+    when (pathType) {
+        APath.PathType.SAF -> {
+            val safPath = this as SAFPath
+            val builder = StringBuilder(safPath.treeRootUri.toString()).append(KEY_SEPARATOR)
+            action(builder.toString())
+            for (i in 0 until safPath.segments.size - 1) {
+                if (i > 0) builder.append(KEY_SEPARATOR)
+                builder.append(safPath.segments[i])
+                action(builder.toString())
+            }
+        }
+
+        APath.PathType.LOCAL -> {
+            val raw = path
+            for (i in raw.indices) {
+                if (raw[i] == File.separatorChar) action(raw.substring(0, i))
+            }
+            // LocalPath.isAncestorOf treats the root as an ancestor of everything below it, and the
+            // prefix walk above never produces the root on its own.
+            if (raw.length > 1 && raw[0] == File.separatorChar) action(File.separator)
+        }
+
+        APath.PathType.RAW -> {
+            val raw = path
+            for (i in raw.indices) {
+                if (raw[i] == '/') action(raw.substring(0, i))
+            }
+        }
+    }
+}

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/ExclusionExtensionsDifferentialTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/ExclusionExtensionsDifferentialTest.kt
@@ -1,0 +1,110 @@
+package eu.darken.sdmse.exclusion.core
+
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.RawPath
+import eu.darken.sdmse.common.files.isAncestorOf
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.segs
+import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.PathExclusion
+import eu.darken.sdmse.exclusion.core.types.SegmentExclusion
+import eu.darken.sdmse.exclusion.core.types.excludeNested
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+
+/**
+ * `Collection<Exclusion.Path>.excludeNested` replaced a fold that ran the whole two-pass removal once
+ * per exclusion with a single pass over the paths. Its KDoc claims the two produce the same fixed
+ * point, and that the single pass therefore no longer depends on the order of the exclusions.
+ *
+ * This test makes that claim differential: the old fold is kept here as an oracle and both are run
+ * over every exclusion subset of size one to three drawn from a small tree, in every order.
+ */
+class ExclusionExtensionsDifferentialTest : BaseTest() {
+
+    @Test
+    fun `local - excludeNested agrees with the pre-index fold in every order`() = runTest {
+        val pool: List<Exclusion.Path> = LOCAL_TREE.map { PathExclusion(it) } +
+                SegmentExclusion(segs("b"), allowPartial = false, ignoreCase = true)
+        assertAgreement(pool, LOCAL_TREE)
+    }
+
+    @Test
+    fun `raw - excludeNested agrees with the pre-index fold in every order`() = runTest {
+        // No SegmentExclusion here: RawPath.segments throws NotImplementedError, and the fold walks
+        // into it while the index answers RAW paths from its own keys first.
+        assertAgreement(RAW_TREE.map { PathExclusion(it) }, RAW_TREE)
+    }
+
+    private suspend fun <T : APath> assertAgreement(pool: List<Exclusion.Path>, paths: Set<T>) {
+        (1..3).forEach { size ->
+            combinations(pool, size).forEach { combination ->
+                val expected = combination.referenceExcludeNested(paths)
+
+                permutations(combination).forEach { ordered ->
+                    withClue({ "exclusions=${ordered.map { it.id }}" }) {
+                        // The oracle has to be order independent as well, otherwise "agrees with the
+                        // fold" would only be a claim about one arbitrary order.
+                        ordered.referenceExcludeNested(paths) shouldBe expected
+                        ordered.excludeNested(paths) shouldBe expected
+                    }
+                }
+            }
+        }
+    }
+
+    /** The pre-index implementation, kept here as the differential oracle. */
+    private suspend fun <T : APath> Collection<Exclusion.Path>.referenceExcludeNested(paths: Collection<T>): Set<T> {
+        var temp = paths.toSet()
+        forEach { exclusion ->
+            if (temp.isEmpty()) return@forEach
+            val excluded = mutableSetOf<T>()
+            val afterFirst = temp.filter { path ->
+                val hit = exclusion.match(path)
+                if (hit) excluded.add(path)
+                !hit
+            }
+            temp = afterFirst.filterNot { path -> excluded.any { path.isAncestorOf(it) } }.toSet()
+        }
+        return temp
+    }
+
+    private fun <T> combinations(items: List<T>, size: Int): List<List<T>> = when {
+        size == 0 -> listOf(emptyList())
+        items.size < size -> emptyList()
+        else -> combinations(items.drop(1), size - 1).map { listOf(items.first()) + it } +
+                combinations(items.drop(1), size)
+    }
+
+    private fun <T> permutations(items: List<T>): List<List<T>> {
+        if (items.size <= 1) return listOf(items)
+        return items.indices.flatMap { index ->
+            val rest = items.toMutableList().apply { removeAt(index) }
+            permutations(rest).map { listOf(items[index]) + it }
+        }
+    }
+
+    companion object {
+        // Every prefix of /a/a, /a/b, /a/b/a, /a/b/b, /b and /b/a.
+        private val LOCAL_TREE: Set<LocalPath> = setOf(
+            "/a",
+            "/a/a",
+            "/a/b",
+            "/a/b/a",
+            "/a/b/b",
+            "/b",
+            "/b/a",
+        ).map { LocalPath(File(it)) }.toSet()
+
+        private val RAW_TREE: Set<RawPath> = setOf(
+            RawPath("/a"),
+            RawPath("/a/b"),
+            RawPath("/a/b/a"),
+            RawPath("/b"),
+        )
+    }
+}

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/ExclusionExtensionsSafTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/ExclusionExtensionsSafTest.kt
@@ -46,4 +46,22 @@ class ExclusionExtensionsSafTest : BaseTest() {
             SAFPath.build(treeB, "root", "test", "item"),
         )
     }
+
+    @Test
+    fun `exclude nested - path - saf segment may contain any character`() = runTest {
+        // The exclusion is a single segment that a delimiter-based key encoding would confuse with
+        // the two segments below, which would drop the file and then prune its parent too.
+        val excls = listOf<Exclusion.Path>(
+            PathExclusion(SAFPath.build(treeA, "a\u0000b")),
+        )
+        val paths = setOf(
+            SAFPath.build(treeA, "a"),
+            SAFPath.build(treeA, "a", "b", "file"),
+        )
+
+        excls.excludeNested(paths) shouldBe setOf(
+            SAFPath.build(treeA, "a"),
+            SAFPath.build(treeA, "a", "b", "file"),
+        )
+    }
 }

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/ExclusionExtensionsSafTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/ExclusionExtensionsSafTest.kt
@@ -1,0 +1,49 @@
+package eu.darken.sdmse.exclusion.core
+
+import eu.darken.sdmse.common.files.saf.SAFPath
+import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.PathExclusion
+import eu.darken.sdmse.exclusion.core.types.excludeNested
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * SAF half of [ExclusionExtensionsTest]. Separate class because `SAFPath` parses its tree URI with
+ * `android.net.Uri`, which needs Robolectric (and therefore JUnit 4).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ExclusionExtensionsSafTest : BaseTest() {
+
+    private val treeA = "content://com.android.externalstorage.documents/tree/primary%3A"
+    private val treeB = "content://com.android.externalstorage.documents/tree/1234-5678%3A"
+
+    @Test
+    fun `exclude nested - path - saf path`() = runTest {
+        val excls = listOf<Exclusion.Path>(
+            PathExclusion(SAFPath.build(treeA, "root", "test", "item", "sub1")),
+        )
+        val paths = setOf(
+            SAFPath.build(treeA, "altroot"),
+            SAFPath.build(treeA, "root"),
+            SAFPath.build(treeA, "root", "test"),
+            SAFPath.build(treeA, "root", "test", "item"),
+            SAFPath.build(treeA, "root", "test", "item", "sub1"),
+            SAFPath.build(treeA, "root", "test", "item", "sub2"),
+            // Same segments, other tree: neither excluded nor pruned as an ancestor.
+            SAFPath.build(treeB, "root", "test", "item"),
+        )
+
+        excls.excludeNested(paths) shouldBe setOf(
+            SAFPath.build(treeA, "altroot"),
+            SAFPath.build(treeA, "root", "test", "item", "sub2"),
+            SAFPath.build(treeB, "root", "test", "item"),
+        )
+    }
+}

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/ExclusionExtensionsTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/ExclusionExtensionsTest.kt
@@ -1,7 +1,9 @@
 package eu.darken.sdmse.exclusion.core
 
+import eu.darken.sdmse.common.files.RawPath
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.segs
+import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
 import eu.darken.sdmse.exclusion.core.types.SegmentExclusion
 import eu.darken.sdmse.exclusion.core.types.excludeNested
@@ -118,5 +120,103 @@ class ExclusionExtensionsTest : BaseTest() {
             LocalPath.build("root", "test", "path", "item", "subitem2"),
             LocalPath.build("root", "alt", "path", "item", "subitem2"),
         )
+    }
+
+    @Test
+    fun `exclude nested - no exclusions returns the input unchanged`() = runTest {
+        val paths = setOf(
+            LocalPath.build("root"),
+            LocalPath.build("root", "test"),
+        )
+
+        emptyList<Exclusion.Path>().excludeNested(paths) shouldBe paths
+    }
+
+    @Test
+    fun `exclude nested - ancestors of every excluded path are pruned`() = runTest {
+        val excls = listOf(
+            PathExclusion(LocalPath.build("root", "test", "path", "item")),
+            PathExclusion(LocalPath.build("other", "deep", "item")),
+        )
+        val paths = setOf(
+            LocalPath.build("altroot"),
+            LocalPath.build("root"),
+            LocalPath.build("root", "test"),
+            LocalPath.build("root", "test", "path"),
+            LocalPath.build("root", "test", "path", "item"),
+            LocalPath.build("root", "test", "sibling"),
+            LocalPath.build("other"),
+            LocalPath.build("other", "deep"),
+            LocalPath.build("other", "deep", "item"),
+        )
+
+        excls.excludeNested(paths) shouldBe setOf(
+            LocalPath.build("altroot"),
+            LocalPath.build("root", "test", "sibling"),
+        )
+    }
+
+    @Test
+    fun `exclude nested - mixed segment and path exclusions`() = runTest {
+        mixedExclusions().excludeNested(mixedPaths()) shouldBe mixedExpectation()
+    }
+
+    @Test
+    fun `exclude nested - the result does not depend on the exclusion order`() = runTest {
+        permutations(mixedExclusions()).forEach { ordered ->
+            ordered.excludeNested(mixedPaths()) shouldBe mixedExpectation()
+        }
+    }
+
+    @Test
+    fun `exclude nested - path - raw path`() = runTest {
+        val excls = listOf(PathExclusion(RawPath("/root/test/item/sub1")))
+        val paths = setOf(
+            RawPath("/altroot"),
+            RawPath("/root"),
+            RawPath("/root/test"),
+            RawPath("/root/test/item"),
+            RawPath("/root/test/item/sub1"),
+            RawPath("/root/test/item/sub2"),
+        )
+
+        excls.excludeNested(paths) shouldBe setOf(
+            RawPath("/altroot"),
+            RawPath("/root/test/item/sub2"),
+        )
+    }
+
+    // Same set in every order. The expectation is the one the previous per-exclusion fold produced.
+    private fun mixedExclusions(): List<Exclusion.Path> = listOf(
+        PathExclusion(LocalPath.build("root", "test", "path", "item", "sub1")),
+        SegmentExclusion(segs("cache"), allowPartial = false, ignoreCase = true),
+        PathExclusion(LocalPath.build("root", "test", "path", "item", "sub2")),
+    )
+
+    private fun mixedPaths(): Set<LocalPath> = setOf(
+        LocalPath.build("altroot"),
+        LocalPath.build("root"),
+        LocalPath.build("root", "test"),
+        LocalPath.build("root", "test", "path"),
+        LocalPath.build("root", "test", "path", "item"),
+        LocalPath.build("root", "test", "path", "item", "sub1"),
+        LocalPath.build("root", "test", "path", "item", "sub2"),
+        LocalPath.build("root", "test", "path", "item", "sub3"),
+        LocalPath.build("root", "alt"),
+        LocalPath.build("root", "alt", "cache"),
+        LocalPath.build("root", "alt", "cache", "file"),
+    )
+
+    private fun mixedExpectation(): Set<LocalPath> = setOf(
+        LocalPath.build("altroot"),
+        LocalPath.build("root", "test", "path", "item", "sub3"),
+    )
+
+    private fun <T> permutations(items: List<T>): List<List<T>> {
+        if (items.size <= 1) return listOf(items)
+        return items.indices.flatMap { index ->
+            val rest = items.toMutableList().apply { removeAt(index) }
+            permutations(rest).map { listOf(items[index]) + it }
+        }
     }
 }

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/ExclusionManagerTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/ExclusionManagerTest.kt
@@ -5,6 +5,7 @@ import eu.darken.sdmse.exclusion.core.types.DefaultExclusion
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.PkgExclusion
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -103,5 +104,21 @@ class ExclusionManagerTest : BaseTest() {
         advanceUntilIdle()
 
         coVerify(exactly = 1) { defaults.remove(setOf(defaultId)) }
+    }
+
+    @Test
+    fun `save replaces an exclusion carrying the same id instead of duplicating it`() = runTest2 {
+        val pkg = "com.other.app".toPkgId()
+        val existing = PkgExclusion(pkg, setOf(Exclusion.Tag.GENERAL))
+        val updated = PkgExclusion(pkg, setOf(Exclusion.Tag.APPCLEANER))
+        existing.id shouldBe updated.id
+        val (manager, storage) = create(backgroundScope, setOf(existing), defaults())
+
+        manager.save(setOf(updated))
+        advanceUntilIdle()
+
+        val saved = slot<Set<Exclusion>>()
+        coVerify { storage.save(capture(saved)) }
+        saved.captured shouldContainExactly setOf(updated)
     }
 }

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndexDifferentialTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndexDifferentialTest.kt
@@ -53,13 +53,17 @@ class PathExclusionIndexDifferentialTest : BaseTest() {
     companion object {
         private val CORPUS: List<String> = run {
             val alphabet = listOf("/", "a", "b")
-            val all = mutableListOf<String>()
+            val all = mutableListOf("")
             var current = listOf("")
             repeat(5) {
                 current = current.flatMap { prefix -> alphabet.map { prefix + it } }
                 all.addAll(current)
             }
             all
+        }
+
+        init {
+            check("" in CORPUS)
         }
     }
 }

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndexDifferentialTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndexDifferentialTest.kt
@@ -1,0 +1,65 @@
+package eu.darken.sdmse.exclusion.core.types
+
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.RawPath
+import eu.darken.sdmse.common.files.local.LocalPath
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+
+/**
+ * The hand-written cases in [PathExclusionIndexTest] pin the rules the index is built on. This test
+ * pins the equivalence itself: over a generated corpus the index must answer exactly what the
+ * linear `any { it.match(candidate) }` it replaced answers, for every ordered
+ * (exclusion, candidate) pair.
+ *
+ * The corpus is every string over `/`, `a` and `b` up to length 5, which covers separator
+ * boundaries, repeated and trailing separators, the root, the empty path, relative paths and
+ * strings that share a prefix without sharing a path component.
+ */
+class PathExclusionIndexDifferentialTest : BaseTest() {
+
+    @Test
+    fun `local - the index agrees with the linear scan for every pair`() = runTest {
+        // java.io.File normalizes, so "/a/" and "//a" collapse onto "/a" and would be tested twice.
+        val corpus = CORPUS.map { LocalPath(File(it)) }.distinctBy { it.path }
+        assertAgreement(corpus)
+    }
+
+    @Test
+    fun `raw - the index agrees with the linear scan for every pair`() = runTest {
+        // RAW paths are not normalized, the string is the path.
+        assertAgreement(CORPUS.map { RawPath(it) })
+    }
+
+    private suspend fun assertAgreement(corpus: List<APath>) {
+        corpus.forEach { exclusionPath ->
+            val exclusions = listOf<Exclusion.Path>(PathExclusion(exclusionPath))
+            val index = PathExclusionIndex(exclusions)
+
+            corpus.forEach { candidate ->
+                val expected = exclusions.any { it.match(candidate) }
+                // Lazy clue: the corpus produces six figures of pairs, only the failing one needs a message.
+                withClue({ "exclusion='${exclusionPath.path}' candidate='${candidate.path}'" }) {
+                    index.matches(candidate) shouldBe expected
+                }
+            }
+        }
+    }
+
+    companion object {
+        private val CORPUS: List<String> = run {
+            val alphabet = listOf("/", "a", "b")
+            val all = mutableListOf<String>()
+            var current = listOf("")
+            repeat(5) {
+                current = current.flatMap { prefix -> alphabet.map { prefix + it } }
+                all.addAll(current)
+            }
+            all
+        }
+    }
+}

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndexSafTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndexSafTest.kt
@@ -1,0 +1,89 @@
+package eu.darken.sdmse.exclusion.core.types
+
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.saf.SAFPath
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * SAF half of [PathExclusionIndexTest]. Separate class because `SAFPath` parses its tree URI with
+ * `android.net.Uri`, which needs Robolectric (and therefore JUnit 4).
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class PathExclusionIndexSafTest : BaseTest() {
+
+    private val treeA = "content://com.android.externalstorage.documents/tree/primary%3A"
+    private val treeB = "content://com.android.externalstorage.documents/tree/1234-5678%3A"
+
+    private suspend fun assertMatch(exclusion: PathExclusion, candidate: APath, expected: Boolean) {
+        val reference = listOf<Exclusion.Path>(exclusion).any { it.match(candidate) }
+        reference shouldBe expected
+        PathExclusionIndex(listOf(exclusion)).matches(candidate) shouldBe expected
+    }
+
+    @Test
+    fun `saf - exact match`() = runTest {
+        assertMatch(
+            PathExclusion(SAFPath.build(treeA, "a", "b")),
+            SAFPath.build(treeA, "a", "b"),
+            true,
+        )
+    }
+
+    @Test
+    fun `saf - descendant`() = runTest {
+        assertMatch(
+            PathExclusion(SAFPath.build(treeA, "a", "b")),
+            SAFPath.build(treeA, "a", "b", "c", "d"),
+            true,
+        )
+    }
+
+    @Test
+    fun `saf - tree root exclusion covers everything below it`() = runTest {
+        assertMatch(
+            PathExclusion(SAFPath.build(treeA)),
+            SAFPath.build(treeA, "a"),
+            true,
+        )
+    }
+
+    @Test
+    fun `saf - parent of the excluded path`() = runTest {
+        assertMatch(
+            PathExclusion(SAFPath.build(treeA, "a", "b")),
+            SAFPath.build(treeA, "a"),
+            false,
+        )
+    }
+
+    @Test
+    fun `saf - shared segment prefix without a boundary`() = runTest {
+        assertMatch(
+            PathExclusion(SAFPath.build(treeA, "a", "b")),
+            SAFPath.build(treeA, "a", "bc"),
+            false,
+        )
+    }
+
+    @Test
+    fun `saf - same segments under a different tree`() = runTest {
+        assertMatch(
+            PathExclusion(SAFPath.build(treeA, "a", "b")),
+            SAFPath.build(treeB, "a", "b"),
+            false,
+        )
+        assertMatch(
+            PathExclusion(SAFPath.build(treeA, "a", "b")),
+            SAFPath.build(treeB, "a", "b", "c"),
+            false,
+        )
+    }
+}

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndexSafTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndexSafTest.kt
@@ -74,6 +74,17 @@ class PathExclusionIndexSafTest : BaseTest() {
     }
 
     @Test
+    fun `saf - a segment may contain any character`() = runTest {
+        // SAF display names come verbatim from the DocumentsProvider cursor, so a single segment can
+        // hold what looks like two segments to a delimiter-based key encoding.
+        assertMatch(
+            PathExclusion(SAFPath.build(treeA, "a\u0000b")),
+            SAFPath.build(treeA, "a", "b", "file"),
+            false,
+        )
+    }
+
+    @Test
     fun `saf - same segments under a different tree`() = runTest {
         assertMatch(
             PathExclusion(SAFPath.build(treeA, "a", "b")),

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndexTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionIndexTest.kt
@@ -1,0 +1,150 @@
+package eu.darken.sdmse.exclusion.core.types
+
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.RawPath
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.segs
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.File
+
+/**
+ * Each path case runs against an index that holds only the one exclusion under test, so a broken
+ * prefix rule can't hide behind an unrelated hit. Every case is also asserted against the linear
+ * `any { it.match(...) }` it replaces.
+ */
+class PathExclusionIndexTest : BaseTest() {
+
+    private suspend fun assertMatch(exclusion: PathExclusion, candidate: APath, expected: Boolean) {
+        val reference = listOf<Exclusion.Path>(exclusion).any { it.match(candidate) }
+        reference shouldBe expected
+        PathExclusionIndex(listOf(exclusion)).matches(candidate) shouldBe expected
+    }
+
+    private fun local(path: String) = LocalPath(File(path))
+
+    @Test
+    fun `local - exact match`() = runTest {
+        assertMatch(PathExclusion(local("/a/b")), local("/a/b"), true)
+    }
+
+    @Test
+    fun `local - direct child`() = runTest {
+        assertMatch(PathExclusion(local("/a/b")), local("/a/b/c"), true)
+    }
+
+    @Test
+    fun `local - deep descendant`() = runTest {
+        assertMatch(PathExclusion(local("/a/b")), local("/a/b/c/d/e"), true)
+    }
+
+    @Test
+    fun `local - shared string prefix without a separator boundary`() = runTest {
+        assertMatch(PathExclusion(local("/a/b")), local("/a/bc/d"), false)
+    }
+
+    @Test
+    fun `local - parent of the excluded path`() = runTest {
+        assertMatch(PathExclusion(local("/a/b")), local("/a"), false)
+    }
+
+    @Test
+    fun `local - root exclusion covers everything below it`() = runTest {
+        assertMatch(PathExclusion(local("/")), local("/a"), true)
+        assertMatch(PathExclusion(local("/")), local("/a/b"), true)
+        assertMatch(PathExclusion(local("/")), local("/"), true)
+    }
+
+    @Test
+    fun `local - empty path is an ancestor of any absolute path`() = runTest {
+        assertMatch(PathExclusion(local("")), local("/a"), true)
+    }
+
+    @Test
+    fun `raw - exact match`() = runTest {
+        assertMatch(PathExclusion(RawPath("/a/b")), RawPath("/a/b"), true)
+    }
+
+    @Test
+    fun `raw - deep descendant`() = runTest {
+        assertMatch(PathExclusion(RawPath("/a/b")), RawPath("/a/b/c/d"), true)
+    }
+
+    @Test
+    fun `raw - shared string prefix without a separator boundary`() = runTest {
+        assertMatch(PathExclusion(RawPath("/a/b")), RawPath("/a/bc/d"), false)
+    }
+
+    @Test
+    fun `raw - root is not an ancestor`() = runTest {
+        // The generic RAW branch is `descendant.path.startsWith(this.path + "/")`, so "/" would need
+        // the candidate to start with "//". There is no root special case like LOCAL has.
+        assertMatch(PathExclusion(RawPath("/")), RawPath("/a"), false)
+    }
+
+    @Test
+    fun `raw - empty path is an ancestor of any absolute path`() = runTest {
+        assertMatch(PathExclusion(RawPath("")), RawPath("/a"), true)
+    }
+
+    @Test
+    fun `raw - relative exclusion does not match an absolute candidate`() = runTest {
+        // RawPathExtensions.isAncestorOf would absolutize both sides and match, but PathExclusion
+        // goes through the generic APath branch, which compares the strings as they are.
+        assertMatch(PathExclusion(RawPath("a")), RawPath("/cwd/a/b"), false)
+    }
+
+    @Test
+    fun `raw - repeated separators in the candidate`() = runTest {
+        assertMatch(PathExclusion(RawPath("/a")), RawPath("/a//b"), true)
+    }
+
+    @Test
+    fun `raw - trailing separator on the exclusion`() = runTest {
+        assertMatch(PathExclusion(RawPath("/a/")), RawPath("/a/b"), false)
+    }
+
+    @Test
+    fun `cross type - a local exclusion never matches a raw candidate`() = runTest {
+        assertMatch(PathExclusion(local("/a/b")), RawPath("/a/b"), false)
+        assertMatch(PathExclusion(RawPath("/a/b")), local("/a/b"), false)
+    }
+
+    @Test
+    fun `non indexable exclusions still match through the fallback`() = runTest {
+        val index = PathExclusionIndex(
+            listOf(SegmentExclusion(segs("cache"), allowPartial = false, ignoreCase = true)),
+        )
+
+        index.matches(local("/a/cache/b")) shouldBe true
+        index.matches(local("/a/b")) shouldBe false
+    }
+
+    @Test
+    fun `the result does not depend on the exclusion order`() = runTest {
+        val segment = SegmentExclusion(segs("cache"), allowPartial = false, ignoreCase = true)
+        val path = PathExclusion(local("/a/b"))
+
+        PathExclusionIndex(listOf(segment, path)).matches(local("/a/b/c")) shouldBe true
+        PathExclusionIndex(listOf(path, segment)).matches(local("/a/b/c")) shouldBe true
+        PathExclusionIndex(listOf(segment, path)).matches(local("/x/cache")) shouldBe true
+        PathExclusionIndex(listOf(path, segment)).matches(local("/x/cache")) shouldBe true
+        PathExclusionIndex(listOf(segment, path)).matches(local("/x/y")) shouldBe false
+        PathExclusionIndex(listOf(path, segment)).matches(local("/x/y")) shouldBe false
+    }
+
+    @Test
+    fun `a raw candidate is answered by the path exclusion instead of throwing`() = runTest {
+        // RawPath.segments throws NotImplementedError, so the old order-dependent `any { }` threw
+        // whenever a SegmentExclusion was evaluated before the matching PathExclusion.
+        val exclusions = listOf<Exclusion.Path>(
+            SegmentExclusion(segs("cache"), allowPartial = false, ignoreCase = true),
+            PathExclusion(RawPath("/a/b")),
+        )
+
+        PathExclusionIndex(exclusions).matches(RawPath("/a/b/c")) shouldBe true
+        PathExclusionIndex(exclusions.reversed()).matches(RawPath("/a/b/c")) shouldBe true
+    }
+}

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -47,6 +47,7 @@ import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.ExclusionId
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
 import eu.darken.sdmse.exclusion.core.types.PkgExclusion
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.setup.IncompleteSetupException
@@ -487,6 +488,12 @@ class AppCleaner @Inject constructor(
         }.toSet()
         exclusionManager.save(exclusions)
 
+        // A bulk exclude can carry tens of thousands of targets. Matching every junk item against
+        // every exclusion would be quadratic (and suspend), so index the exclusions once.
+        val index = PathExclusionIndex(exclusions)
+        var excludedCount = 0
+        var totalCount = 0
+
         val snapshot = internalData.value!!
         internalData.value = snapshot.copy(
             junks = snapshot.junks.map { junk ->
@@ -495,8 +502,9 @@ class AppCleaner @Inject constructor(
                         expendables = junk.expendables?.entries
                             ?.map { entry ->
                                 entry.key to entry.value.filter { match ->
-                                    val hit = exclusions.any { it.match(match.path) }
-                                    if (hit) log(TAG) { "exclude(): Excluded $match" }
+                                    totalCount++
+                                    val hit = index.matches(match.path)
+                                    if (hit) excludedCount++
                                     !hit
                                 }
                             }
@@ -508,6 +516,8 @@ class AppCleaner @Inject constructor(
                 }
             }
         )
+
+        log(TAG) { "exclude(): Excluded $excludedCount of $totalCount matches for $identifier" }
     }
 
     data class State(

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExclusionExtensions.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExclusionExtensions.kt
@@ -2,14 +2,18 @@ package eu.darken.sdmse.appcleaner.core
 
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
 import eu.darken.sdmse.exclusion.core.types.excludeNestedLookups
 
 suspend fun Collection<Exclusion.Path>.excludeNestedLookups(
     matches: Collection<ExpendablesFilter.Match>
+): Set<ExpendablesFilter.Match> = PathExclusionIndex(this).excludeNestedLookups(matches)
+
+suspend fun PathExclusionIndex.excludeNestedLookups(
+    matches: Collection<ExpendablesFilter.Match>
 ): Set<ExpendablesFilter.Match> {
-    var temp = matches.map { it.lookup }.toSet()
-    this.forEach { temp = it.excludeNestedLookups(temp) }
+    val survivors = this.excludeNestedLookups(matches.map { it.lookup })
     return matches
-        .filter { temp.contains(it.lookup) }
+        .filter { survivors.contains(it.lookup) }
         .toSet()
 }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
@@ -61,6 +61,7 @@ import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
 import eu.darken.sdmse.exclusion.core.pkgExclusions
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
 import eu.darken.sdmse.main.core.SDMTool
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -332,7 +333,7 @@ class AppScanner @Inject constructor(
      * i.e. public/priv storage and some levels of the root of the sdcard
      */
     private suspend fun createDataAreaMap(currentAreas: Collection<DataArea>): Map<DataArea.Type, Collection<AreaInfo>> {
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.APPCLEANER)
+        val exclusionIndex = PathExclusionIndex(exclusionManager.pathExclusions(SDMTool.Type.APPCLEANER))
 
         val areaDataMap = mutableMapOf<DataArea.Type, Collection<AreaInfo>>()
 
@@ -351,7 +352,7 @@ class AppScanner @Inject constructor(
             .map { (area, content) ->
                 area.type to content
                     .filter { path ->
-                        val isExcluded = pathExclusions.any { it.match(path) }
+                        val isExcluded = exclusionIndex.matches(path)
                         if (isExcluded) log(TAG, INFO) { "Excluded during PRIVATE_DATA scan: $path" }
                         !isExcluded
                     }
@@ -391,7 +392,7 @@ class AppScanner @Inject constructor(
                         }
                     }
                     .filter { areaInfo ->
-                        val excluded = pathExclusions.any { it.match(areaInfo.file) }
+                        val excluded = exclusionIndex.matches(areaInfo.file)
                         val edgeCase = !useRoot && area.type == DataArea.Type.PUBLIC_DATA
                                 && areaInfo.prefixFreeSegments.size >= 2
                                 && areaInfo.prefixFreeSegments[1] == "cache"

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/PostProcessorModule.kt
@@ -27,6 +27,7 @@ import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
 import eu.darken.sdmse.main.core.SDMTool
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -58,10 +59,14 @@ class PostProcessorModule @Inject constructor(
         // performs a PackageManager lookup (permission-based Shizuku detection), so calling it inside
         // the per-app checkExclusions loop would issue one binder round-trip per scanned app.
         val adbManagerIds = if (useAdb) adbManager.managerIds() else emptySet()
+        // Same reasoning for the exclusions: a bulk exclude can leave tens of thousands of path
+        // exclusions behind, and checkExclusions runs per app per expendables category. Loading and
+        // indexing them there would rebuild the whole index hundreds of times per scan.
+        val exclusionIndex = PathExclusionIndex(exclusionManager.pathExclusions(SDMTool.Type.APPCLEANER))
 
         val processed = apps
             .map { checkAliasedItems(it) }
-            .mapNotNull { checkExclusions(it, useAdb, adbManagerIds) }
+            .mapNotNull { checkExclusions(it, useAdb, adbManagerIds, exclusionIndex) }
             .map { checkForHiddenModules(it) }
             .filter {
                 val isMinSize = it.size >= minCacheSize
@@ -100,6 +105,7 @@ class PostProcessorModule @Inject constructor(
         before: AppJunk,
         useAdb: Boolean,
         adbManagerIds: Set<Pkg.Id>,
+        exclusionIndex: PathExclusionIndex,
     ): AppJunk? {
         // Empty apps don't generate edge cases (and are omitted).
         if (before.expendables.isNullOrEmpty()) return before
@@ -127,11 +133,9 @@ class PostProcessorModule @Inject constructor(
                 }
         }
 
-        val exclusions = exclusionManager.pathExclusions(SDMTool.Type.APPCLEANER)
-
         var after = before.copy(
             expendables = before.expendables.mapValues { (_, paths) ->
-                exclusions.excludeNestedLookups(paths)
+                exclusionIndex.excludeNestedLookups(paths)
             }
         )
 

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -14,8 +14,10 @@ import eu.darken.sdmse.appcleaner.ui.preview.previewExpendables
 import eu.darken.sdmse.appcleaner.ui.preview.previewInstalled
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.common.files.GatewaySwitch
 import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
 import eu.darken.sdmse.common.forensics.FileForensics
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.features.InstallId
@@ -59,6 +61,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import java.time.Instant
 import javax.inject.Provider
 
 class AppCleanerTest : BaseTest() {
@@ -84,6 +87,20 @@ class AppCleanerTest : BaseTest() {
         pkg = previewInstalled(pkgName = pkgName, label = pkgName),
         expendables = expendables,
         inaccessibleCache = null,
+    )
+
+    private fun deletionMatch(
+        path: LocalPath,
+        fileType: FileType = FileType.FILE,
+    ): ExpendablesFilter.Match = ExpendablesFilter.Match.Deletion(
+        identifier = DefaultCachesPublicFilter::class,
+        lookup = LocalPathLookup(
+            lookedUp = path,
+            fileType = fileType,
+            size = 1024L,
+            modifiedAt = Instant.EPOCH,
+            target = null,
+        ),
     )
 
     private class Setup(
@@ -452,6 +469,64 @@ class AppCleanerTest : BaseTest() {
         val targetAfter = data.junks.single { it.identifier == target.identifier }
         targetAfter.expendables?.values?.flatten()?.map { it.path } shouldBe
             target.expendables!!.values.flatten().drop(1).map { it.path }
+    }
+
+    @Test
+    fun `path-level exclude drops the descendants of an excluded directory`() = runTest2 {
+        // exclude() keeps the PathExclusion semantics: the target itself and everything below it
+        // goes, so excluding a directory must take its children with it.
+        val cacheDir = LocalPath.build("storage", "emulated", "0", "Android", "data", "com.target", "cache")
+        val nested = LocalPath.build(
+            "storage", "emulated", "0", "Android", "data", "com.target", "cache", "inner", "blob.bin",
+        )
+        val sibling = LocalPath.build(
+            "storage", "emulated", "0", "Android", "data", "com.target", "files", "keep.txt",
+        )
+        val target = appJunk(
+            "com.target",
+            expendables = mapOf(
+                DefaultCachesPublicFilter::class to listOf(
+                    deletionMatch(cacheDir, FileType.DIRECTORY),
+                    deletionMatch(nested),
+                    deletionMatch(sibling),
+                ),
+            ),
+        )
+        val setup = setupCleaner(scanResults = listOf(target))
+        setup.cleaner.submit(AppCleanerScanTask())
+
+        setup.cleaner.exclude(target.identifier, setOf(cacheDir))
+
+        val data = setup.cleaner.dataFromState()!!
+        val after = data.junks.single { it.identifier == target.identifier }
+        after.expendables?.values?.flatten()?.map { it.path } shouldBe listOf(sibling)
+    }
+
+    @Test
+    fun `path-level exclude keeps the parent of an excluded path`() = runTest2 {
+        // The opposite direction: ancestors are NOT pruned here (unlike the scan-time
+        // excludeNestedLookups), so a parent entry stays in the junk.
+        val cacheDir = LocalPath.build("storage", "emulated", "0", "Android", "data", "com.target", "cache")
+        val child = LocalPath.build(
+            "storage", "emulated", "0", "Android", "data", "com.target", "cache", "blob.bin",
+        )
+        val target = appJunk(
+            "com.target",
+            expendables = mapOf(
+                DefaultCachesPublicFilter::class to listOf(
+                    deletionMatch(cacheDir, FileType.DIRECTORY),
+                    deletionMatch(child),
+                ),
+            ),
+        )
+        val setup = setupCleaner(scanResults = listOf(target))
+        setup.cleaner.submit(AppCleanerScanTask())
+
+        setup.cleaner.exclude(target.identifier, setOf(child))
+
+        val data = setup.cleaner.dataFromState()!!
+        val after = data.junks.single { it.identifier == target.identifier }
+        after.expendables?.values?.flatten()?.map { it.path } shouldBe listOf(cacheDir)
     }
 
     // ─────────────────────────── chained-task dispatch ───────────────────────────

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/CorpseFinder.kt
@@ -46,7 +46,8 @@ import eu.darken.sdmse.exclusion.core.pkgExclusions
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.ExclusionId
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
-import eu.darken.sdmse.exclusion.core.types.match
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
+import eu.darken.sdmse.exclusion.core.types.matches
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.setup.SetupHeartbeat
 import eu.darken.sdmse.setup.SetupBinding
@@ -254,7 +255,7 @@ class CorpseFinder @Inject constructor(
             .map { it.create() }
             .onEach { log(TAG) { "Created filter: $it" } }
 
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
+        val pathExclusionIndex = PathExclusionIndex(exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER))
         val pkgExclusions = exclusionManager.pkgExclusions(SDMTool.Type.CORPSEFINDER)
 
         val results = filters
@@ -274,11 +275,9 @@ class CorpseFinder @Inject constructor(
                 }
             }
             .filter { corpse ->
-                pathExclusions.none { excl ->
-                    excl.match(corpse.lookup).also {
-                        if (it) log(TAG, INFO) { "Excluded due to $excl: $corpse" }
-                    }
-                }
+                val isExcluded = pathExclusionIndex.matches(corpse.lookup)
+                if (isExcluded) log(TAG, INFO) { "Excluded due to path exclusion: $corpse" }
+                !isExcluded
             }
             .filter { corpse ->
                 // One extra check for multi-user devices without root
@@ -454,9 +453,13 @@ class CorpseFinder @Inject constructor(
         }.toSet()
         val saved = exclusionManager.save(exclusions)
 
+        // A bulk exclude can carry a large number of targets, so index them once instead of
+        // matching every corpse against every exclusion.
+        val exclusionIndex = PathExclusionIndex(exclusions)
+
         val updated = snapshot.copy(
             corpses = snapshot.corpses.filter { corpse ->
-                exclusions.none { it.match(corpse.lookup) }
+                !exclusionIndex.matches(corpse.lookup)
             }
         )
         internalData.value = updated

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/DalvikCorpseFilter.kt
@@ -31,6 +31,7 @@ import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
 import eu.darken.sdmse.main.core.SDMTool
 import javax.inject.Inject
 import javax.inject.Provider
@@ -66,7 +67,7 @@ class DalvikCorpseFilter @Inject constructor(
 
         val areas = areaManager.currentAreas()
 
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
+        val exclusionIndex = PathExclusionIndex(exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER))
 
         // Android 16 (API36) uses a new structure for Dalvik profiles in /data/misc/profiles (covered by another filter)
         val profileCorpses = areas
@@ -81,11 +82,9 @@ class DalvikCorpseFilter @Inject constructor(
                 area.path
                     .listFiles(gatewaySwitch)
                     .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also {
-                                if (it) log(TAG, INFO) { "Excluded due to $excl: $path" }
-                            }
-                        }
+                        val isExcluded = exclusionIndex.matches(path)
+                        if (isExcluded) log(TAG, INFO) { "Excluded due to path exclusion: $path" }
+                        !isExcluded
                     }
             }
             .map { profilesToCheck ->
@@ -106,11 +105,9 @@ class DalvikCorpseFilter @Inject constructor(
                 area.path
                     .listFiles(gatewaySwitch)
                     .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also {
-                                if (it) log(TAG, INFO) { "Excluded due to $excl: $path" }
-                            }
-                        }
+                        val isExcluded = exclusionIndex.matches(path)
+                        if (isExcluded) log(TAG, INFO) { "Excluded due to path exclusion: $path" }
+                        !isExcluded
                     }
             }
             .map { dalvikFilesToCheck ->

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilter.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/filter/StandardCorpseFilter.kt
@@ -24,6 +24,7 @@ import eu.darken.sdmse.corpsefinder.core.Corpse
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
 import eu.darken.sdmse.main.core.SDMTool
 
 /**
@@ -79,7 +80,7 @@ abstract class StandardCorpseFilter(
 
         updateProgressPrimary(scanProgressLabel)
 
-        val pathExclusions = exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER)
+        val exclusionIndex = PathExclusionIndex(exclusionManager.pathExclusions(SDMTool.Type.CORPSEFINDER))
 
         return areaManager.currentAreas()
             .filter { it.type == areaType }
@@ -93,11 +94,9 @@ abstract class StandardCorpseFilter(
                 val topLevelContents = area.path
                     .listFiles(gatewaySwitch)
                     .filter { path ->
-                        pathExclusions.none { excl ->
-                            excl.match(path).also {
-                                if (it) log(filterTag, INFO) { "Excluded due to $excl: $path" }
-                            }
-                        }
+                        val isExcluded = exclusionIndex.matches(path)
+                        if (isExcluded) log(filterTag, INFO) { "Excluded due to path exclusion: $path" }
+                        !isExcluded
                     }
 
                 log(filterTag) { "Filtering $area" }

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/DuplicatesScanner.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/DuplicatesScanner.kt
@@ -37,7 +37,8 @@ import eu.darken.sdmse.deduplicator.core.scanner.phash.PHashDuplicate
 import eu.darken.sdmse.deduplicator.core.scanner.phash.PHashSleuth
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.exclusion.core.types.match
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
+import eu.darken.sdmse.exclusion.core.types.matches
 import eu.darken.sdmse.main.core.SDMTool
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -103,13 +104,14 @@ class DuplicatesScanner @Inject constructor(
 
         val exclusions = exclusionManager.pathExclusions(SDMTool.Type.DEDUPLICATOR)
         log(TAG) { "Deduplicator exclusions are: $exclusions" }
+        val exclusionIndex = PathExclusionIndex(exclusions)
 
         return targetAreas.asFlow()
             .flatMapMerge(2) { area ->
                 val filter: suspend (APathLookup<*>) -> Boolean = when (area.type) {
                     DataArea.Type.SDCARD -> filter@{ toCheck: APathLookup<*> ->
                         if (sdcardSkips.any { toCheck.segments.endsWith(it) }) return@filter false
-                        exclusions.none { it.match(toCheck) }
+                        !exclusionIndex.matches(toCheck)
                     }
 
                     else -> filter@{ toCheck: APathLookup<*> ->
@@ -117,7 +119,7 @@ class DuplicatesScanner @Inject constructor(
                             log(TAG, WARN) { "Skipping: $toCheck" }
                             return@filter false
                         }
-                        exclusions.none { it.match(toCheck) }
+                        !exclusionIndex.matches(toCheck)
                     }
                 }
                 area.path.walk(
@@ -132,6 +134,7 @@ class DuplicatesScanner @Inject constructor(
     private suspend fun customPathSearchFlow(paths: Set<APath>): Flow<APathLookup<*>> {
         val exclusions = exclusionManager.pathExclusions(SDMTool.Type.DEDUPLICATOR)
         log(TAG) { "Deduplicator exclusions are: $exclusions" }
+        val exclusionIndex = PathExclusionIndex(exclusions)
 
         val allowedAreas = setOf(
             DataArea.Type.SDCARD,
@@ -156,7 +159,7 @@ class DuplicatesScanner @Inject constructor(
         return paths.asFlow()
             .flatMapMerge(2) { path ->
                 val filter: suspend (APathLookup<*>) -> Boolean = filter@{ toCheck: APathLookup<*> ->
-                    exclusions.none { it.match(toCheck) }
+                    !exclusionIndex.matches(toCheck)
                 }
                 path.walk(
                     gatewaySwitch,

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/scanner/DuplicatesScannerExclusionTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/scanner/DuplicatesScannerExclusionTest.kt
@@ -1,0 +1,151 @@
+package eu.darken.sdmse.deduplicator.core.scanner
+
+import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.areas.DataAreaManager
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.APathGateway
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.deduplicator.core.arbiter.DuplicatesArbiter
+import eu.darken.sdmse.deduplicator.core.scanner.checksum.ChecksumSleuth
+import eu.darken.sdmse.exclusion.core.ExclusionManager
+import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.ExclusionHolder
+import eu.darken.sdmse.exclusion.core.types.PathExclusion
+import eu.darken.sdmse.exclusion.core.types.UserExclusion
+import io.kotest.matchers.collections.shouldContainExactly
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toSet
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.time.Instant
+import javax.inject.Provider
+
+/**
+ * The scan-side counterpart to the exclusion tests the other tools have: a [PathExclusion] tagged
+ * [Exclusion.Tag.DEDUPLICATOR] has to keep the matching path out of the candidate set that
+ * [DuplicatesScanner] hands to its sleuths.
+ *
+ * The gateway is stubbed to honour the walk filter the scanner installs, which is where the
+ * exclusion check lives, and the checksum sleuth captures what survived it.
+ */
+class DuplicatesScannerExclusionTest : BaseTest() {
+
+    private val exclusionManager: ExclusionManager = mockk()
+    private val areaManager: DataAreaManager = mockk()
+    private val gatewaySwitch: GatewaySwitch = mockk()
+    private val commonFilesCheck: CommonFilesCheck = mockk(relaxed = true)
+    private val fileForensics: FileForensics = mockk(relaxed = true)
+    private val arbiter: DuplicatesArbiter = mockk(relaxed = true)
+    private val checksumSleuth: ChecksumSleuth = mockk<ChecksumSleuth>(relaxed = true).apply {
+        every { progress } returns MutableStateFlow<Progress.Data?>(null)
+    }
+
+    private val sdcard = DataArea(
+        path = LocalPath.build("/storage/emulated/0"),
+        type = DataArea.Type.SDCARD,
+        userHandle = UserHandle2(handleId = 0),
+    )
+
+    private val keeper = lookup("/storage/emulated/0/photos/keeper.jpg")
+    private val excluded = lookup("/storage/emulated/0/excluded/dupe.jpg")
+
+    private fun lookup(path: String) = LocalPathLookup(
+        lookedUp = LocalPath.build(path),
+        fileType = FileType.FILE,
+        size = 16L,
+        modifiedAt = Instant.EPOCH,
+        target = null,
+    )
+
+    private fun scanner(vararg exclusions: Exclusion): DuplicatesScanner {
+        val holders: Collection<ExclusionHolder> = exclusions.map { UserExclusion(it) }
+        every { exclusionManager.exclusions } returns flowOf(holders)
+        every { areaManager.state } returns flowOf(DataAreaManager.State(areas = setOf(sdcard)))
+
+        // The scanner's walk filter is what applies the exclusions, so the stub has to run it.
+        coEvery { gatewaySwitch.walk(any(), any()) } answers {
+            val options = arg<APathGateway.WalkOptions<APath, APathLookup<APath>>>(1)
+            val onFilter = options.onFilter
+            listOf(keeper, excluded).asFlow().filter { onFilter == null || onFilter(it) }
+        }
+
+        return DuplicatesScanner(
+            checksumSleuthProvider = Provider { checksumSleuth },
+            pHashSleuthProvider = mockk(),
+            mediaHashSleuthProvider = mockk(),
+            exclusionManager = exclusionManager,
+            areaManager = areaManager,
+            dispatcherProvider = TestDispatcherProvider(),
+            gatewaySwitch = gatewaySwitch,
+            commonFilesCheck = commonFilesCheck,
+            fileForensics = fileForensics,
+            arbiter = arbiter,
+        )
+    }
+
+    private fun options() = DuplicatesScanner.Options(
+        paths = emptySet(),
+        minimumSize = 0L,
+        skipUncommon = false,
+        useSleuthChecksum = true,
+        useSleuthPHash = false,
+        useSleuthMedia = false,
+    )
+
+    private suspend fun candidatesOf(scanner: DuplicatesScanner): List<String> {
+        val candidates = mutableListOf<String>()
+        coEvery { checksumSleuth.investigate(any()) } coAnswers {
+            firstArg<Flow<APathLookup<*>>>().toSet().forEach { candidates.add(it.path) }
+            emptySet()
+        }
+
+        scanner.scan(options())
+
+        return candidates
+    }
+
+    @Test
+    fun `a DEDUPLICATOR path exclusion keeps the matching path out of the scan`() = runTest {
+        val scanner = scanner(
+            PathExclusion(
+                path = LocalPath.build("/storage/emulated/0/excluded"),
+                tags = setOf(Exclusion.Tag.DEDUPLICATOR),
+            ),
+        )
+
+        candidatesOf(scanner) shouldContainExactly listOf(keeper.path)
+    }
+
+    @Test
+    fun `a path exclusion tagged for another tool does not affect the scan`() = runTest {
+        val scanner = scanner(
+            PathExclusion(
+                path = LocalPath.build("/storage/emulated/0/excluded"),
+                tags = setOf(Exclusion.Tag.SYSTEMCLEANER),
+            ),
+        )
+
+        candidatesOf(scanner).sorted() shouldContainExactly listOf(excluded.path, keeper.path).sorted()
+    }
+
+    @Test
+    fun `without exclusions both paths are candidates`() = runTest {
+        candidatesOf(scanner()).sorted() shouldContainExactly listOf(excluded.path, keeper.path).sorted()
+    }
+}

--- a/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/scanner/MediaScanner.kt
+++ b/app-tool-squeezer/src/main/java/eu/darken/sdmse/squeezer/core/scanner/MediaScanner.kt
@@ -22,7 +22,8 @@ import eu.darken.sdmse.common.progress.updateProgressPrimary
 import eu.darken.sdmse.common.progress.updateProgressSecondary
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.exclusion.core.types.match
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
+import eu.darken.sdmse.exclusion.core.types.matches
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.squeezer.core.CompressibleImage
 import eu.darken.sdmse.squeezer.core.CompressibleMedia
@@ -93,6 +94,7 @@ class MediaScanner @Inject constructor(
     private suspend fun createSearchFlow(paths: Set<APath>): Flow<APathLookup<*>> {
         val exclusions = exclusionManager.pathExclusions(SDMTool.Type.SQUEEZER)
         log(TAG) { "Squeezer exclusions are: $exclusions" }
+        val exclusionIndex = PathExclusionIndex(exclusions)
         log(TAG) { "Search paths: $paths" }
 
         // Walk in Mode.NORMAL only: Transformer / BitmapFactory can't read files that would
@@ -107,7 +109,7 @@ class MediaScanner @Inject constructor(
                     return@flatMapMerge emptyFlow()
                 }
                 val filter: suspend (APathLookup<*>) -> Boolean = filter@{ toCheck: APathLookup<*> ->
-                    exclusions.none { it.match(toCheck) }
+                    !exclusionIndex.matches(toCheck)
                 }
                 localGateway.walk(
                     path = localPath,

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/core/scanner/SwiperScanner.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/core/scanner/SwiperScanner.kt
@@ -19,7 +19,8 @@ import eu.darken.sdmse.common.progress.updateProgressPrimary
 import eu.darken.sdmse.common.progress.updateProgressSecondary
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.exclusion.core.types.match
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
+import eu.darken.sdmse.exclusion.core.types.matches
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.swiper.core.FileTypeFilter
 import eu.darken.sdmse.swiper.core.SessionState
@@ -76,11 +77,12 @@ class SwiperScanner @Inject constructor(
 
         val exclusions = exclusionManager.pathExclusions(SDMTool.Type.SWIPER)
         log(TAG) { "Swiper exclusions are: $exclusions" }
+        val exclusionIndex = PathExclusionIndex(exclusions)
 
         val searchFlow = options.paths.asFlow()
             .flatMapMerge(2) { path ->
                 val filter: suspend (APathLookup<*>) -> Boolean = filter@{ toCheck: APathLookup<*> ->
-                    exclusions.none { it.match(toCheck) }
+                    !exclusionIndex.matches(toCheck)
                 }
 
                 // A source path can vanish or become unreadable between picking and scanning (more

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCrawler.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/SystemCrawler.kt
@@ -29,7 +29,8 @@ import eu.darken.sdmse.common.progress.updateProgressSecondary
 import eu.darken.sdmse.common.sharedresource.useRes
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.pathExclusions
-import eu.darken.sdmse.exclusion.core.types.match
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
+import eu.darken.sdmse.exclusion.core.types.matches
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.systemcleaner.core.filter.FilterIdentifier
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
@@ -75,6 +76,7 @@ class SystemCrawler @Inject constructor(
 
         val exclusions = exclusionManager.pathExclusions(SDMTool.Type.SYSTEMCLEANER)
         log(TAG, INFO) { "Loaded exclusions: $exclusions" }
+        val exclusionIndex = PathExclusionIndex(exclusions)
 
         val currentAreas = areaManager.currentAreas()
         val targetAreas = filters
@@ -115,9 +117,9 @@ class SystemCrawler @Inject constructor(
                             }
                         }
 
-                        exclusions.none { excl ->
-                            excl.match(toCheck).also { if (it) log(TAG, INFO) { "Excluded $toCheck by $excl" } }
-                        }
+                        val isExcluded = exclusionIndex.matches(toCheck)
+                        if (isExcluded) log(TAG, INFO) { "Excluded $toCheck" }
+                        !isExcluded
                     }
                     log(TAG) { "Scanning $targetArea" }
 

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterExtensions.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/SystemCleanerFilterExtensions.kt
@@ -1,6 +1,7 @@
 package eu.darken.sdmse.systemcleaner.core.filter
 
 import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
 import eu.darken.sdmse.exclusion.core.types.excludeNestedLookups
 import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve
 
@@ -10,10 +11,13 @@ suspend fun SystemCrawlerSieve.Result.toDeletion(): SystemCleanerFilter.Match.De
 
 suspend fun Collection<Exclusion.Path>.excludeNestedLookups(
     matches: Collection<SystemCleanerFilter.Match>
+): Set<SystemCleanerFilter.Match> = PathExclusionIndex(this).excludeNestedLookups(matches)
+
+suspend fun PathExclusionIndex.excludeNestedLookups(
+    matches: Collection<SystemCleanerFilter.Match>
 ): Set<SystemCleanerFilter.Match> {
-    var temp = matches.map { it.lookup }.toSet()
-    this.forEach { temp = it.excludeNestedLookups(temp) }
+    val survivors = this.excludeNestedLookups(matches.map { it.lookup })
     return matches
-        .filter { temp.contains(it.lookup) }
+        .filter { survivors.contains(it.lookup) }
         .toSet()
 }


### PR DESCRIPTION
## What changed

Excluding a lot of items at once used to look like it did nothing. You would select everything in a
big list, tap Exclude, and the screen would stay exactly as it was. The exclusions were saved, but
the list kept showing them.

On a Pixel 7a with 20,089 items in one app, that took 4 minutes 38 seconds with a CPU core pegged
the whole time. It now takes 1.4 seconds.

Having a lot of exclusions also made every later scan slow, because each tool compared every file it
found against the whole exclusion list. That is fixed as well.

Affects AppCleaner, SystemCleaner, CorpseFinder, Deduplicator, Media Squeeze and Swiper.

## Technical Context

- Cause: every exclusion check was a linear scan over the exclusion list, and the match function is
  a suspend function, so both the exclude action and the scan filters cost items times exclusions.
  `AppCleaner.exclude` held the tool lock for the whole loop, which is why the UI never updated.
- `PathExclusionIndex` hashes the exclusions and answers a match by walking the candidate's own path
  keys, so the cost depends on path depth instead of on how many exclusions exist.
- How bad it got depended on the selection. A path exclusion matches that path or anything below it,
  so a selection that happened to include a parent folder found its match almost immediately and
  stayed fast (measured 1.85s). Without a covering parent it hit the full quadratic case (measured
  278s). Both are now around 1.4s.
- SAF keys are length prefixed instead of joined with a separator character. Folder names there come
  straight from a DocumentsProvider and can contain anything, so no character is safe as a separator.
- `excludeNested` changed from one pass per exclusion to a single pass. Two differential tests pin
  the rewrite: the index against the linear scan it replaces, and the new `excludeNested` against the
  old implementation kept as a reference oracle.
