### PR TITLE
AppCleaner: Show what was cleaned even if the run stopped early

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/ScreenUnavailableExtensions.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/ScreenUnavailableExtensions.kt
@@ -1,0 +1,11 @@
+package eu.darken.sdmse.automation.core.errors
+
+import eu.darken.sdmse.common.error.causes
+
+/**
+ * Whether this is (or was caused by) the accessibility service being unable to run because the
+ * screen was off or locked, e.g. during an unattended scheduled run. That's a by-design limitation
+ * rather than a genuine failure, so callers can surface it with its own wording.
+ */
+fun Throwable.isScreenUnavailable(): Boolean =
+    this is ScreenUnavailableException || causes.any { it is ScreenUnavailableException }

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/StatsRepo.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/StatsRepo.kt
@@ -82,6 +82,8 @@ class StatsRepo @Inject constructor(
             endAt = task.completedAt ?: Instant.now(),
             tool = task.toolType,
             status = when {
+                // A task that failed but still handed back a result got part of its work done.
+                task.error != null && reportDetails != null -> Report.Status.PARTIAL_SUCCESS
                 task.error != null -> Report.Status.FAILURE
                 reportDetails != null -> reportDetails.status
                 else -> Report.Status.SUCCESS

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/reports/reports/items/ReportRow.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/ui/reports/reports/items/ReportRow.kt
@@ -67,6 +67,11 @@ fun ReportRow(
         Report.Status.PARTIAL_SUCCESS -> row.primaryMessage.orEmpty()
         Report.Status.FAILURE -> row.errorMessage.orEmpty()
     }
+    // A partial success has something to show AND something that went wrong, so it needs both.
+    val tertiaryText: String = when (row.status) {
+        Report.Status.PARTIAL_SUCCESS -> row.errorMessage.orEmpty()
+        else -> ""
+    }
 
     Column(
         modifier = modifier
@@ -129,6 +134,14 @@ fun ReportRow(
                 maxLines = 3,
             )
         }
+        if (tertiaryText.isNotEmpty()) {
+            Text(
+                text = tertiaryText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 3,
+            )
+        }
     }
 }
 
@@ -164,7 +177,7 @@ private fun ReportRowPartialPreview() {
                 endAt = Instant.now().minusSeconds(3600),
                 primaryMessage = "Freed 4 MB, 2 items could not be removed",
                 secondaryMessage = null,
-                errorMessage = null,
+                errorMessage = "The screen was turned off or locked",
             ),
             now = Instant.now(),
             onClick = {},

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/StatsRepoTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/StatsRepoTest.kt
@@ -1,0 +1,146 @@
+package eu.darken.sdmse.stats.core
+
+import android.content.Context
+import android.os.Parcel
+import eu.darken.sdmse.common.ca.CaString
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.stats.core.db.ReportsDatabase
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.io.IOException
+import java.time.Instant
+
+class StatsRepoTest : BaseTest() {
+
+    // StatsRepo.state does a stateIn() on construction; that sharing coroutine must not live in the
+    // test scope, which would then never see all its children complete.
+    private val repoScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    @AfterEach
+    fun stopRepoScope() {
+        repoScope.coroutineContext[Job]?.cancel()
+    }
+
+    private val reportsDatabase: ReportsDatabase = mockk(relaxed = true)
+    private val spaceFreed: DataStoreValue<Long> = mockk(relaxed = true)
+    private val itemsProcessed: DataStoreValue<Long> = mockk(relaxed = true)
+    private val statsSettings: StatsSettings = mockk(relaxed = true) {
+        every { totalSpaceFreed } returns spaceFreed
+        every { totalItemsProcessed } returns itemsProcessed
+    }
+    private val context: Context = mockk(relaxed = true)
+
+    private class TestTask : SDMTool.Task, Reportable {
+        override val type: SDMTool.Type = SDMTool.Type.APPCLEANER
+        override fun describeContents(): Int = 0
+        override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+    }
+
+    private open class PlainResult : SDMTool.Task.Result {
+        override val type: SDMTool.Type = SDMTool.Type.APPCLEANER
+        override val primaryInfo: CaString = "46 expendable items deleted".toCaString()
+        override fun describeContents(): Int = 0
+        override fun writeToParcel(dest: Parcel, flags: Int) = Unit
+    }
+
+    /** [ReportDetails.AffectedCount], not AffectedPaths: the affected-path table is not what these assert. */
+    private class DetailedResult(
+        override val affectedSpace: Long,
+        override val affectedCount: Int,
+        override val status: Report.Status = Report.Status.SUCCESS,
+    ) : PlainResult(), ReportDetails.AffectedSpace, ReportDetails.AffectedCount
+
+    private fun managedTask(
+        result: SDMTool.Task.Result?,
+        error: Throwable?,
+    ) = TaskSubmitter.ManagedTask(
+        id = "task-1",
+        toolType = SDMTool.Type.APPCLEANER,
+        task = TestTask(),
+        startedAt = Instant.EPOCH,
+        completedAt = Instant.EPOCH.plusSeconds(60),
+        result = result,
+        error = error,
+    )
+
+    /** Reports [task] and returns what was written to the database. */
+    private suspend fun reportOf(task: TaskSubmitter.ManagedTask): Report {
+        val repo = StatsRepo(
+            appScope = repoScope,
+            context = context,
+            reportsDatabase = reportsDatabase,
+            statsSettings = statsSettings,
+            spaceTracker = mockk(relaxed = true),
+        )
+        val captured = slot<Report>()
+        coEvery { reportsDatabase.addReport(capture(captured)) } returns Unit
+        repo.report(task)
+        return captured.captured
+    }
+
+    @Test
+    fun `a failure that still produced details is a partial success`() = runTest2 {
+        val report = reportOf(
+            managedTask(DetailedResult(affectedSpace = 512L, affectedCount = 3), IOException("screen went off")),
+        )
+
+        report.status shouldBe Report.Status.PARTIAL_SUCCESS
+        // Both halves are kept: what was freed and what went wrong.
+        report.affectedSpace shouldBe 512L
+        report.affectedCount shouldBe 3
+        report.primaryMessage shouldBe "46 expendable items deleted"
+        report.errorMessage!! shouldContain "screen went off"
+
+        // The lifetime counters must see the salvaged run too.
+        val spaceUpdate = slot<(Long) -> Long?>()
+        val itemsUpdate = slot<(Long) -> Long?>()
+        coVerify { spaceFreed.update(capture(spaceUpdate)) }
+        coVerify { itemsProcessed.update(capture(itemsUpdate)) }
+        spaceUpdate.captured.invoke(1_000L) shouldBe 1_512L
+        itemsUpdate.captured.invoke(10L) shouldBe 13L
+    }
+
+    @Test
+    fun `a failure with nothing to show is a failure`() = runTest2 {
+        val report = reportOf(managedTask(null, IOException("screen went off")))
+
+        report.status shouldBe Report.Status.FAILURE
+        report.affectedSpace shouldBe null
+        report.affectedCount shouldBe null
+    }
+
+    @Test
+    fun `a successful run keeps the status its details report`() = runTest2 {
+        val report = reportOf(
+            managedTask(
+                DetailedResult(affectedSpace = 1L, affectedCount = 1, status = Report.Status.PARTIAL_SUCCESS),
+                error = null,
+            ),
+        )
+
+        report.status shouldBe Report.Status.PARTIAL_SUCCESS
+    }
+
+    @Test
+    fun `a result without details is a plain success`() = runTest2 {
+        val report = reportOf(managedTask(PlainResult(), error = null))
+
+        report.status shouldBe Report.Status.SUCCESS
+    }
+}

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/ui/reports/reports/items/ReportRowTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/ui/reports/reports/items/ReportRowTest.kt
@@ -1,0 +1,57 @@
+package eu.darken.sdmse.stats.ui.reports.items
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.stats.core.Report
+import eu.darken.sdmse.stats.ui.reports.ReportsViewModel
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+import java.time.Instant
+import java.util.UUID
+
+class ReportRowTest : BaseComposeRobolectricTest() {
+
+    private fun partialRow(errorMessage: String?) = ReportsViewModel.Row(
+        reportId = UUID.randomUUID(),
+        tool = SDMTool.Type.APPCLEANER,
+        status = Report.Status.PARTIAL_SUCCESS,
+        endAt = Instant.now(),
+        primaryMessage = "46 expendable items deleted",
+        secondaryMessage = null,
+        errorMessage = errorMessage,
+    )
+
+    @Test
+    fun `a partial row shows what was done and what went wrong`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                ReportRow(
+                    row = partialRow("The screen was turned off or locked"),
+                    now = Instant.now(),
+                    onClick = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("46 expendable items deleted").assertIsDisplayed()
+        composeRule.onNodeWithText("The screen was turned off or locked").assertIsDisplayed()
+    }
+
+    @Test
+    fun `a partial row without an error shows no error line`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                ReportRow(
+                    row = partialRow(errorMessage = null),
+                    now = Instant.now(),
+                    onClick = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText("46 expendable items deleted").assertIsDisplayed()
+        composeRule.onNodeWithText("The screen was turned off or locked").assertDoesNotExist()
+    }
+}

--- a/app-common/src/main/java/eu/darken/sdmse/main/core/PartialResultException.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/main/core/PartialResultException.kt
@@ -1,0 +1,20 @@
+package eu.darken.sdmse.main.core
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * A tool failed after completing part of its work. [partialResult] carries what succeeded;
+ * [cause] is the failure and is what callers should surface. TaskManager unwraps this at the
+ * completion boundary: ManagedTask records both, callers of submit() see only [cause].
+ */
+class PartialResultException(
+    override val cause: Throwable,
+    val partialResult: SDMTool.Task.Result,
+) : Exception("Partial result before failure: $partialResult", cause) {
+
+    init {
+        // Wrapping a cancellation would let TaskManager consume it as an ordinary failure and
+        // publish a partial result for a cancelled task.
+        require(cause !is CancellationException) { "Cancellations must propagate unwrapped" }
+    }
+}

--- a/app-common/src/test/java/eu/darken/sdmse/main/core/PartialResultExceptionTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/main/core/PartialResultExceptionTest.kt
@@ -1,0 +1,32 @@
+package eu.darken.sdmse.main.core
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.io.IOException
+
+class PartialResultExceptionTest : BaseTest() {
+
+    private val result: SDMTool.Task.Result = mockk(relaxed = true)
+
+    @Test
+    fun `a failure and the work that survived it are both kept`() {
+        val boom = IOException("Disk on fire")
+
+        val wrapper = PartialResultException(boom, result)
+
+        wrapper.cause shouldBe boom
+        wrapper.partialResult shouldBe result
+    }
+
+    @Test
+    fun `a cancellation cannot be wrapped`() {
+        // A cancelled task must stay cancelled, not become a partial success.
+        shouldThrow<IllegalArgumentException> {
+            PartialResultException(CancellationException("cancelled"), result)
+        }
+    }
+}

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -13,6 +13,8 @@ import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask.StopReason
+import eu.darken.sdmse.automation.core.errors.isScreenUnavailable
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.coroutine.AppScope
@@ -49,6 +51,7 @@ import eu.darken.sdmse.exclusion.core.types.ExclusionId
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
 import eu.darken.sdmse.exclusion.core.types.PathExclusionIndex
 import eu.darken.sdmse.exclusion.core.types.PkgExclusion
+import eu.darken.sdmse.main.core.PartialResultException
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.setup.IncompleteSetupException
 import eu.darken.sdmse.setup.SetupModule
@@ -73,6 +76,20 @@ private val AppCleanerTask.requiresPro: Boolean
         is AppCleanerSchedulerTask -> true
         is AppCleanerOneClickTask -> true
     }
+
+private fun AppCleanerProcessingTask.Success.toSchedulerSuccess() = AppCleanerSchedulerTask.Success(
+    affectedSpace = affectedSpace,
+    affectedPaths = affectedPaths,
+    affectedCount = affectedCount,
+    stoppedEarly = stoppedEarly,
+)
+
+private fun AppCleanerProcessingTask.Success.toOneClickSuccess() = AppCleanerOneClickTask.Success(
+    affectedSpace = affectedSpace,
+    affectedPaths = affectedPaths,
+    affectedCount = affectedCount,
+    stoppedEarly = stoppedEarly,
+)
 
 @Singleton
 class AppCleaner @Inject constructor(
@@ -153,31 +170,35 @@ class AppCleaner @Inject constructor(
                     is AppCleanerProcessingTask -> performProcessing(task)
                     is AppCleanerSchedulerTask -> {
                         performScan()
-                        performProcessing(
-                            AppCleanerProcessingTask(
-                                useAutomation = task.useAutomation,
-                                isBackground = true,
-                            )
-                        ).let {
-                            AppCleanerSchedulerTask.Success(
-                                affectedSpace = it.affectedSpace,
-                                affectedPaths = it.affectedPaths,
-                                affectedCount = it.affectedCount,
+                        // A partial result carries the processing task's own Success type; rewrap it
+                        // so what TaskManager records always matches the submitted task.
+                        try {
+                            performProcessing(
+                                AppCleanerProcessingTask(
+                                    useAutomation = task.useAutomation,
+                                    isBackground = true,
+                                )
+                            ).toSchedulerSuccess()
+                        } catch (e: PartialResultException) {
+                            throw PartialResultException(
+                                e.cause,
+                                (e.partialResult as AppCleanerProcessingTask.Success).toSchedulerSuccess(),
                             )
                         }
                     }
 
                     is AppCleanerOneClickTask -> {
                         performScan()
-                        performProcessing(
-                            AppCleanerProcessingTask(
-                                isBackground = task.shortcutMode,
-                            )
-                        ).let {
-                            AppCleanerOneClickTask.Success(
-                                affectedSpace = it.affectedSpace,
-                                affectedPaths = it.affectedPaths,
-                                affectedCount = it.affectedCount,
+                        try {
+                            performProcessing(
+                                AppCleanerProcessingTask(
+                                    isBackground = task.shortcutMode,
+                                )
+                            ).toOneClickSuccess()
+                        } catch (e: PartialResultException) {
+                            throw PartialResultException(
+                                e.cause,
+                                (e.partialResult as AppCleanerProcessingTask.Success).toOneClickSuccess(),
                             )
                         }
                     }
@@ -403,11 +424,6 @@ class AppCleaner @Inject constructor(
             }.filter { !it.isEmpty() }
         )
 
-        // `internalData` now reflects the accessible deletions plus whatever the ACS stage reported
-        // before failing, so the failure can surface. The task still fails with the original
-        // exception, exactly as it did before this salvage existed.
-        acsFailure?.let { throw it }
-
         // `acsResult` is a var (the partial-result callback writes to it), so it won't smart-cast.
         val acsOutcome = acsResult
         // Prefer what the deleter actually observed disappearing. The pre-clear size is only a
@@ -426,11 +442,24 @@ class AppCleaner @Inject constructor(
         // accessible/inaccessible/public-cache counting rules in a second hand-rolled counter, and it counts ACS
         // cache clears at scan scale rather than as the <=2 synthetic paths that land in `affectedPaths`.
         val affectedCount = (snapshot.totalCount - (internalData.value?.totalCount ?: 0)).coerceAtLeast(0)
-        return AppCleanerProcessingTask.Success(
+        val salvaged = AppCleanerProcessingTask.Success(
             affectedSpace = accessibleDeletionMap.values.sumOf { contents -> contents.sumOf { it.expectedGain } } + automationSize,
             affectedPaths = deleted,
             affectedCount = affectedCount,
         )
+
+        // `internalData` now reflects the accessible deletions plus whatever the ACS stage reported
+        // before failing, so the failure can surface. It travels wrapped, carrying what was already
+        // deleted: TaskManager records both, so the run shows up as a partial success instead of
+        // discarding everything, while submit() callers still see the original exception.
+        acsFailure?.let { failure ->
+            if (failure is CancellationException) throw failure
+            if (salvaged.affectedCount == 0 && salvaged.affectedSpace == 0L) throw failure
+            val reason = if (failure.isScreenUnavailable()) StopReason.SCREEN_UNAVAILABLE else StopReason.ERROR
+            throw PartialResultException(failure, salvaged.copy(stoppedEarly = reason))
+        }
+
+        return salvaged
     }
 
     suspend fun exclude(identifiers: Set<InstallId>): ExclusionUndo = toolLock.withLock {

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
@@ -21,11 +21,24 @@ data class AppCleanerOneClickTask(
         override val affectedSpace: Long,
         override val affectedPaths: Set<APath>,
         override val affectedCount: Int = affectedPaths.size,
+        val stoppedEarly: AppCleanerTask.StopReason? = null,
     ) : Result, ReportDetails.AffectedSpace, ReportDetails.AffectedPaths {
 
         override val primaryInfo
             get() = caString {
-                getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)
+                when (stoppedEarly) {
+                    AppCleanerTask.StopReason.SCREEN_UNAVAILABLE -> getQuantityString2(
+                        R.plurals.appcleaner_result_x_items_deleted_stopped_screen,
+                        affectedCount,
+                    )
+
+                    AppCleanerTask.StopReason.ERROR -> getQuantityString2(
+                        R.plurals.appcleaner_result_x_items_deleted_stopped_error,
+                        affectedCount,
+                    )
+
+                    null -> getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)
+                }
             }
 
         override val secondaryInfo

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
@@ -48,11 +48,26 @@ data class AppCleanerProcessingTask(
         // accessibility-service "Clear cache" tap contribute just their synthetic dir paths, so the path count
         // would massively undershoot what the scan reported as "found". This carries the scan-scale count instead.
         override val affectedCount: Int = affectedPaths.size,
+        // Set when the clean aborted after deleting this much, e.g. the accessibility stage hit a
+        // locked screen. Null for a run that went through everything it targeted.
+        val stoppedEarly: AppCleanerTask.StopReason? = null,
     ) : Result, ReportDetails.AffectedSpace, ReportDetails.AffectedPaths {
 
         override val primaryInfo
             get() = caString {
-                getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)
+                when (stoppedEarly) {
+                    AppCleanerTask.StopReason.SCREEN_UNAVAILABLE -> getQuantityString2(
+                        R.plurals.appcleaner_result_x_items_deleted_stopped_screen,
+                        affectedCount,
+                    )
+
+                    AppCleanerTask.StopReason.ERROR -> getQuantityString2(
+                        R.plurals.appcleaner_result_x_items_deleted_stopped_error,
+                        affectedCount,
+                    )
+
+                    null -> getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)
+                }
             }
 
         override val secondaryInfo

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerSchedulerTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerSchedulerTask.kt
@@ -22,11 +22,24 @@ data class AppCleanerSchedulerTask(
         override val affectedSpace: Long,
         override val affectedPaths: Set<APath>,
         override val affectedCount: Int = affectedPaths.size,
+        val stoppedEarly: AppCleanerTask.StopReason? = null,
     ) : Result, ReportDetails.AffectedSpace, ReportDetails.AffectedPaths {
 
         override val primaryInfo
             get() = caString {
-                getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)
+                when (stoppedEarly) {
+                    AppCleanerTask.StopReason.SCREEN_UNAVAILABLE -> getQuantityString2(
+                        R.plurals.appcleaner_result_x_items_deleted_stopped_screen,
+                        affectedCount,
+                    )
+
+                    AppCleanerTask.StopReason.ERROR -> getQuantityString2(
+                        R.plurals.appcleaner_result_x_items_deleted_stopped_error,
+                        affectedCount,
+                    )
+
+                    null -> getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)
+                }
             }
 
         override val secondaryInfo

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerTask.kt
@@ -8,5 +8,10 @@ sealed interface AppCleanerTask : SDMTool.Task {
     sealed interface Result : SDMTool.Task.Result {
         override val type: SDMTool.Type get() = SDMTool.Type.APPCLEANER
     }
-}
 
+    /** Why a clean stopped before it was through everything it had targeted. */
+    enum class StopReason {
+        SCREEN_UNAVAILABLE,
+        ERROR,
+    }
+}

--- a/app-tool-appcleaner/src/main/res/values/strings.xml
+++ b/app-tool-appcleaner/src/main/res/values/strings.xml
@@ -60,6 +60,14 @@
         <item quantity="one">%d expendable item deleted</item>
         <item quantity="other">%d expendable items deleted</item>
     </plurals>
+    <plurals name="appcleaner_result_x_items_deleted_stopped_screen">
+        <item quantity="one">%d expendable item deleted, stopped because the screen was off or locked</item>
+        <item quantity="other">%d expendable items deleted, stopped because the screen was off or locked</item>
+    </plurals>
+    <plurals name="appcleaner_result_x_items_deleted_stopped_error">
+        <item quantity="one">%d expendable item deleted, stopped by an error</item>
+        <item quantity="other">%d expendable items deleted, stopped by an error</item>
+    </plurals>
     <plurals name="appcleaner_result_x_items_found">
         <item quantity="one">%d expendable item found</item>
         <item quantity="other">%d expendable items found</item>

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -4,12 +4,16 @@ import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPublicFilter
 import eu.darken.sdmse.appcleaner.core.scanner.AppScanner
 import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask
 import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
 import eu.darken.sdmse.appcleaner.ui.preview.previewInaccessibleCache
 import eu.darken.sdmse.automation.core.errors.InvalidSystemStateException
 import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
+import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
 import eu.darken.sdmse.appcleaner.ui.preview.previewExpendables
 import eu.darken.sdmse.appcleaner.ui.preview.previewInstalled
 import eu.darken.sdmse.common.adb.AdbManager
@@ -33,6 +37,7 @@ import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.types.Exclusion
 import eu.darken.sdmse.exclusion.core.types.PathExclusion
 import eu.darken.sdmse.exclusion.core.types.PkgExclusion
+import eu.darken.sdmse.main.core.PartialResultException
 import eu.darken.sdmse.setup.IncompleteSetupException
 import eu.darken.sdmse.setup.SetupModule
 import io.kotest.assertions.throwables.shouldThrow
@@ -819,9 +824,15 @@ class AppCleanerTest : BaseTest() {
         val expendableSize = previewExpendables().values.flatten().sumOf { it.expectedGain }
 
         // The task still fails, with the original exception: the salvage must not mask the failure.
-        shouldThrow<InvalidSystemStateException> {
+        // It rides along on the failure so the run is recorded as a partial success.
+        val thrown = shouldThrow<PartialResultException> {
             rebuilt.cleaner.submit(AppCleanerProcessingTask())
-        } shouldBe boom
+        }
+        thrown.cause shouldBe boom
+        val partial = thrown.partialResult.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        partial.affectedSpace shouldBe expendableSize
+        // InvalidSystemStateException is not a ScreenUnavailableException, so this is a plain error.
+        partial.stoppedEarly shouldBe AppCleanerTask.StopReason.ERROR
 
         val after = rebuilt.cleaner.state.first().data!!.junks.single()
         // Accessible matches were deleted, so they must be gone from the data the dashboard reads.
@@ -890,13 +901,106 @@ class AppCleanerTest : BaseTest() {
         val rebuilt = rebuildWithDeleter(setup, deleter)
 
         rebuilt.cleaner.submit(AppCleanerScanTask())
-        shouldThrow<InvalidSystemStateException> {
+        val thrown = shouldThrow<PartialResultException> {
             rebuilt.cleaner.submit(AppCleanerProcessingTask())
-        } shouldBe boom
+        }
+        thrown.cause shouldBe boom
+        val partial = thrown.partialResult.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        // What the deleter cleared before dying is what the run gets credited with.
+        partial.affectedSpace shouldBe 24L * 1024 * 1024
+        partial.affectedCount shouldBe 4
+        partial.stoppedEarly shouldBe AppCleanerTask.StopReason.ERROR
 
         // The cleared junk is gone entirely; only the app the run never reached is still listed.
         val remaining = rebuilt.cleaner.state.first().data!!.junks
         remaining.map { it.identifier } shouldBe listOf(installId("com.example.later"))
+    }
+
+    /** A cleaner whose accessible stage deletes everything and whose ACS stage dies with [failure]. */
+    private fun salvageSetup(failure: Exception): Setup {
+        val junk = previewAppJunk(
+            pkg = previewInstalled(pkgName = "com.example.mixed", label = "com.example.mixed"),
+            expendables = previewExpendables(),
+            inaccessibleCache = previewInaccessibleCache(pkgName = "com.example.mixed"),
+        )
+        val deleter = mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coEvery { deleteInaccessible(any(), any(), any(), any(), any()) } throws failure
+        }
+        return rebuildWithDeleter(
+            setupCleaner(scanResults = listOf(junk)),
+            deleter,
+            filterFactories = setOf(deletingFilterFactory()),
+        )
+    }
+
+    @Test
+    fun `a locked screen aborting the ACS stage is reported as such`() = runTest2 {
+        val boom = ScreenUnavailableException("screen is off")
+        val rebuilt = salvageSetup(boom)
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        val thrown = shouldThrow<PartialResultException> {
+            rebuilt.cleaner.submit(AppCleanerProcessingTask())
+        }
+
+        thrown.cause shouldBe boom
+        val partial = thrown.partialResult.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        partial.stoppedEarly shouldBe AppCleanerTask.StopReason.SCREEN_UNAVAILABLE
+    }
+
+    @Test
+    fun `an ACS failure with nothing salvaged stays a plain failure`() = runTest2 {
+        // No accessible deletions and no ACS successes: there is no partial result to advertise, so
+        // wrapping the failure would only claim a partial success that freed nothing.
+        val junk = inaccJunk("com.example.nothing", itemCount = 4, theoreticalPaths = emptySet())
+        val boom = InvalidSystemStateException("died before anything was cleared")
+        val deleter = mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coEvery { deleteInaccessible(any(), any(), any(), any(), any()) } throws boom
+        }
+        val rebuilt = rebuildWithDeleter(setupCleaner(scanResults = listOf(junk)), deleter)
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        shouldThrow<InvalidSystemStateException> {
+            rebuilt.cleaner.submit(AppCleanerProcessingTask())
+        } shouldBe boom
+    }
+
+    @Test
+    fun `a one-click run salvages its partial result as a one-click success`() = runTest2 {
+        // The task manager records the result against the submitted task, so the salvaged result
+        // has to be the type that task's own callers expect.
+        val boom = InvalidSystemStateException("screen went off mid-run")
+        val rebuilt = salvageSetup(boom)
+        val expendableSize = previewExpendables().values.flatten().sumOf { it.expectedGain }
+
+        val thrown = shouldThrow<PartialResultException> {
+            rebuilt.cleaner.submit(AppCleanerOneClickTask())
+        }
+
+        thrown.cause shouldBe boom
+        val partial = thrown.partialResult.shouldBeInstanceOf<AppCleanerOneClickTask.Success>()
+        partial.affectedSpace shouldBe expendableSize
+        partial.stoppedEarly shouldBe AppCleanerTask.StopReason.ERROR
+    }
+
+    @Test
+    fun `a scheduled run salvages its partial result as a scheduler success`() = runTest2 {
+        val boom = ScreenUnavailableException("screen is off")
+        val rebuilt = salvageSetup(boom)
+        val expendableSize = previewExpendables().values.flatten().sumOf { it.expectedGain }
+
+        val thrown = shouldThrow<PartialResultException> {
+            rebuilt.cleaner.submit(AppCleanerSchedulerTask(scheduleId = "schedule-1", useAutomation = true))
+        }
+
+        thrown.cause shouldBe boom
+        val partial = thrown.partialResult.shouldBeInstanceOf<AppCleanerSchedulerTask.Success>()
+        partial.affectedSpace shouldBe expendableSize
+        partial.stoppedEarly shouldBe AppCleanerTask.StopReason.SCREEN_UNAVAILABLE
     }
 
     @Test

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingResultTextTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingResultTextTest.kt
@@ -1,0 +1,49 @@
+package eu.darken.sdmse.appcleaner.core.tasks
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class AppCleanerProcessingResultTextTest : BaseTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private fun success(
+        count: Int,
+        stoppedEarly: AppCleanerTask.StopReason?,
+    ) = AppCleanerProcessingTask.Success(
+        affectedSpace = 1024L,
+        affectedPaths = emptySet(),
+        affectedCount = count,
+        stoppedEarly = stoppedEarly,
+    ).primaryInfo.get(context)
+
+    @Test
+    fun `a completed run just states what was deleted`() {
+        success(count = 46, stoppedEarly = null) shouldBe "46 expendable items deleted"
+    }
+
+    @Test
+    fun `a run stopped by a locked screen says so`() {
+        success(count = 1, stoppedEarly = AppCleanerTask.StopReason.SCREEN_UNAVAILABLE) shouldBe
+            "1 expendable item deleted, stopped because the screen was off or locked"
+        success(count = 46, stoppedEarly = AppCleanerTask.StopReason.SCREEN_UNAVAILABLE) shouldBe
+            "46 expendable items deleted, stopped because the screen was off or locked"
+    }
+
+    @Test
+    fun `a run stopped by an error says so`() {
+        success(count = 1, stoppedEarly = AppCleanerTask.StopReason.ERROR) shouldBe
+            "1 expendable item deleted, stopped by an error"
+        success(count = 46, stoppedEarly = AppCleanerTask.StopReason.ERROR) shouldBe
+            "46 expendable items deleted, stopped by an error"
+    }
+}

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/core/SchedulerNotifications.kt
@@ -10,10 +10,10 @@ import androidx.core.app.NotificationCompat
 import androidx.work.ForegroundInfo
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
+import eu.darken.sdmse.automation.core.errors.isScreenUnavailable
 import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
-import eu.darken.sdmse.common.error.causes
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.ByteFormatter
 import eu.darken.sdmse.main.core.SDMTool
@@ -228,8 +228,7 @@ class SchedulerNotifications @Inject constructor(
  * (e.g. an unattended scheduled run). That's a by-design limitation, not a genuine failure, so it's worth surfacing
  * with its own wording instead of the generic error label.
  */
-internal fun Throwable.isScreenUnavailableSkip(): Boolean =
-    this is ScreenUnavailableException || causes.any { it is ScreenUnavailableException }
+internal fun Throwable.isScreenUnavailableSkip(): Boolean = isScreenUnavailable()
 
 internal fun Throwable.toSchedulerErrorLabelRes(): Int = if (isScreenUnavailableSkip()) {
     R.string.scheduler_notification_result_skipped_screen_unavailable

--- a/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/core/taskmanager/TaskManager.kt
@@ -16,6 +16,7 @@ import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.rngString
 import eu.darken.sdmse.common.sharedresource.KeepAlive
 import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.main.core.PartialResultException
 import eu.darken.sdmse.main.core.SDMTool
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
@@ -261,12 +262,18 @@ class TaskManager @Inject constructor(
             } catch (e: Throwable) {
                 // Throwable, not Exception: AppScope has no CoroutineExceptionHandler, so an Error
                 // escaping a tool would take the process down with it.
-                if (e is CancellationException) {
+                // A tool that got part of its work done before failing wraps both in a
+                // PartialResultException. Record each half where it belongs, so the completion is a
+                // partial success while the caller below still sees the failure.
+                val partial = e as? PartialResultException
+                if (partial != null) result = partial.partialResult
+                val unwrapped = partial?.cause ?: e
+                if (unwrapped is CancellationException) {
                     log(TAG, INFO) { "execute(): Task was cancelled (${task.type}-$taskId): $task" }
                 } else {
-                    log(TAG, ERROR) { "execute(): Execution failed (${task.type}-$taskId): $task\n${e.asLog()}" }
+                    log(TAG, ERROR) { "execute(): Execution failed (${task.type}-$taskId): $task\n${unwrapped.asLog()}" }
                 }
-                error = e
+                error = unwrapped
             } finally {
                 try {
                     updateTasks {

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
@@ -31,6 +31,7 @@ import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskManager
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
+import eu.darken.sdmse.main.core.taskmanager.getLatestTask
 import eu.darken.sdmse.stats.core.ReportDetails
 import eu.darken.sdmse.systemcleaner.core.SystemCleaner
 import eu.darken.sdmse.systemcleaner.core.hasData
@@ -807,7 +808,18 @@ class DashboardMainActionEngine(
      */
     private suspend fun runCleanup(type: SDMTool.Type, task: SDMTool.Task) {
         submittedTasks.update { it + (type to task) }
-        accumulateFreed(type, submitTask(task))
+        try {
+            accumulateFreed(type, submitTask(task))
+        } catch (e: Throwable) {
+            // A tool that failed after freeing something records both on its completed task. The
+            // failure still propagates to the error dialog, but what it did free belongs in the hero.
+            if (e !is CancellationException) {
+                taskManager.state.first().getLatestTask(type)
+                    ?.takeIf { it.task === task && it.result != null && it.error != null }
+                    ?.result?.let { accumulateFreed(type, it) }
+            }
+            throw e
+        }
     }
 
     /** Folds a deletion/one-click result into [freedResult] so the hero can show what was freed. */

--- a/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/TaskManagerTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/TaskManagerTest.kt
@@ -4,6 +4,7 @@ import eu.darken.sdmse.common.backup.BackupOperationGate
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.sharedresource.KeepAlive
 import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.main.core.PartialResultException
 import eu.darken.sdmse.main.core.SDMTool
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -168,6 +169,25 @@ class TaskManagerTest : BaseTest() {
 
         shouldThrow<IOException> { manager.submit(task) }.carries(boom) shouldBe true
     }
+
+    @Test fun `a partial result is recorded alongside the failure it came with`() =
+        runTest2(autoCancel = true) {
+            val scope = this + Dispatchers.IO
+            val tool = createTool(scope)
+            val boom = IOException("Screen went off")
+            coEvery { tool.submit(task) } throws PartialResultException(boom, taskResult)
+
+            val manager = createManager(scope, tool)
+
+            // The caller sees the failure, not the transport wrapper: the error dialog must not
+            // change just because the tool salvaged something.
+            shouldThrow<IOException> { manager.submit(task) }.carries(boom) shouldBe true
+
+            manager.state.first().tasks.single().let {
+                it.result shouldBeSameInstanceAs taskResult
+                it.error shouldBeSameInstanceAs boom
+            }
+        }
 
     @Test fun `an error from the tool arrives wrapped instead of killing the process`() =
         runTest2(autoCancel = true) {

--- a/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/TaskResultNotificationsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/core/taskmanager/TaskResultNotificationsTest.kt
@@ -1,0 +1,68 @@
+package eu.darken.sdmse.main.core.taskmanager
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.main.core.SDMTool
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.io.IOException
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class TaskResultNotificationsTest : BaseTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val notificationManager: NotificationManager
+        get() = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+    private fun result(info: String): SDMTool.Task.Result = mockk(relaxed = true) {
+        every { primaryInfo } returns info.toCaString()
+    }
+
+    private fun managedTask(
+        result: SDMTool.Task.Result?,
+        error: Throwable?,
+    ) = TaskSubmitter.ManagedTask(
+        id = "task-1",
+        toolType = SDMTool.Type.APPCLEANER,
+        task = mockk(relaxed = true),
+        completedAt = Instant.now(),
+        result = result,
+        error = error,
+    )
+
+    private fun Notification.body(): String = extras.getCharSequence(Notification.EXTRA_TEXT).toString()
+
+    @Test
+    fun `a task that failed after freeing something reports what it freed`() {
+        val notifications = TaskResultNotifications(context, notificationManager)
+
+        val notification = notifications.getNotification(
+            managedTask(result("46 expendable items deleted"), IOException("Screen went off")),
+        )
+
+        notification.body() shouldBe "46 expendable items deleted"
+    }
+
+    @Test
+    fun `a task that failed with nothing to show falls back to the generic message`() {
+        val notifications = TaskResultNotifications(context, notificationManager)
+
+        val notification = notifications.getNotification(managedTask(null, IOException("Screen went off")))
+
+        notification.body() shouldBe "Task didn't finish successfully."
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngineTest.kt
@@ -23,6 +23,7 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -159,6 +160,8 @@ internal class DashboardMainActionEngineTest : BaseTest() {
          */
         repoIsPro: Boolean = isPro,
         failingTaskType: Class<out SDMTool.Task>? = null,
+        /** Runs on the task a [failingTaskType] submit is about to reject; stages what the task manager recorded. */
+        onFailedSubmit: (SDMTool.Task) -> Unit = {},
         onUpgradeRequired: () -> Unit = {},
         gate: CompletableDeferred<Unit>? = null,
         /** Replaces CorpseFinder's state flow; for tests that need a non-StateFlow source. */
@@ -221,7 +224,10 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             submitTask = { task ->
                 submittedTasks.add(task)
                 // Mirrors TaskManager.submit rethrowing a recorded task error.
-                if (failingTaskType?.isInstance(task) == true) throw IllegalStateException("task failed")
+                if (failingTaskType?.isInstance(task) == true) {
+                    onFailedSubmit(task)
+                    throw IllegalStateException("task failed")
+                }
                 // Stands in for the tool's resource lock, holding a branch in flight.
                 gate?.await()
                 mockk(relaxed = true)
@@ -316,6 +322,72 @@ internal class DashboardMainActionEngineTest : BaseTest() {
             hero.tools.shouldBeEmpty()
             // A NOTHING_FREED card IS a hero, so this one-tap cleanup auto-expands it.
             h.engine.isHeroExpanded.value shouldBe true
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    /**
+     * Stages the task manager entry a tool leaves behind when it fails after freeing something:
+     * both [result] and error on the very task instance the engine submitted.
+     */
+    private fun partiallyFailedState(task: SDMTool.Task, result: SDMTool.Task.Result?): TaskSubmitter.State =
+        TaskSubmitter.State(
+            tasks = listOf(
+                TaskSubmitter.ManagedTask(
+                    id = "delete-partial",
+                    toolType = SDMTool.Type.CORPSEFINDER,
+                    task = task,
+                    completedAt = Instant.now(),
+                    result = result,
+                    error = IOException("screen went off"),
+                ),
+            ),
+        )
+
+    @Test
+    fun `a cleanup that failed after freeing something still credits what it freed`() {
+        val harnessRef = AtomicReference<Harness?>()
+        val h = harness(
+            corpseData = corpseData(),
+            failingTaskType = CorpseFinderDeleteTask::class.java,
+            onFailedSubmit = { task ->
+                harnessRef.get()!!.taskState.value = partiallyFailedState(
+                    task,
+                    CorpseFinderDeleteTask.Success(affectedSpace = 512L, affectedPaths = emptySet()),
+                )
+            },
+        )
+        harnessRef.set(h)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+
+            val hero = h.barState().heroSummary!!
+            hero.mode shouldBe HeroSummary.Mode.FREED
+            hero.totalSize shouldBe 512L
+            // The failure still travels on to the error handling; only the bytes are salvaged.
+            h.branchErrors.size shouldBe 1
+        } finally {
+            h.engineScope.cancel()
+        }
+    }
+
+    @Test
+    fun `a cleanup that failed with nothing on record credits nothing`() {
+        val harnessRef = AtomicReference<Harness?>()
+        val h = harness(
+            corpseData = corpseData(),
+            failingTaskType = CorpseFinderDeleteTask::class.java,
+            onFailedSubmit = { task -> harnessRef.get()!!.taskState.value = partiallyFailedState(task, result = null) },
+        )
+        harnessRef.set(h)
+
+        try {
+            h.engine.mainAction(BottomBarState.Action.DELETE)
+
+            h.barState().heroSummary?.mode shouldNotBe HeroSummary.Mode.FREED
+            h.branchErrors.size shouldBe 1
         } finally {
             h.engineScope.cancel()
         }


### PR DESCRIPTION
## What changed

When a cleaning run is interrupted partway through, the caches that were already cleared are no longer dropped from the results. The typical case: an unattended one-tap or scheduled run clears most caches through the privileged route, then the screen turns off and locks while SD Maid would need to tap through the Settings app, and the run aborts. Previously that run was reported only as "Task didn't finish successfully", with the freed space missing from the notification, the Reports history, and the lifetime freed-space counter.

Now the notification says what was deleted and why the run stopped ("46 expendable items deleted, stopped because the screen was off or locked"). The Reports history records the run as a partial success, showing the freed space, the item count, and the error that stopped it. The lifetime freed-space counter and the dashboard include the salvaged result. In-app error dialogs are unchanged for every failure type.

## Technical Context

- Root cause: `AppCleaner` rethrew any accessibility-stage failure after the privileged clears had already succeeded, so the task completed with a null result and the stats pipeline collapsed everything to a plain failure.
- Approach: the tool still throws (keeping every existing error dialog, hint, and bug-report action intact), but the exception now carries the partial result; `TaskManager` records both halves on the completed task and rethrows the original cause to callers. Chosen over returning a result because returning would silence the in-app error surfaces.
- A completed task holding both an error and result details is reported as `PARTIAL_SUCCESS`; cancellations are never wrapped and keep today's behavior, as does a failure with nothing salvaged.
- The scheduler's own aggregate notification intentionally keeps its "Skipped, screen was off or locked" label (it consumes the thrown error); scheduler runs still get correct report rows and counters through the stats pipeline.
- Closest review targets: the salvage construction and rethrow ordering in `AppCleaner.performProcessing`, and the unwrap boundary in `TaskManager`'s completion catch block.
