### PR TITLE
General: Fix long dashboard slogans overlapping the mascot

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
@@ -261,7 +261,7 @@ internal fun TitleDashboardCard(
 }
 
 @Composable
-private fun TitleHeaderLayout(
+internal fun TitleHeaderLayout(
     modifier: Modifier = Modifier,
     mascot: @Composable () -> Unit,
     title: @Composable () -> Unit,
@@ -288,7 +288,7 @@ private fun TitleHeaderLayout(
         // name on one line — it collapses into an ugly 2–3 line stack ("SD" / "Maid" / "SE"). Switch
         // to a clean centered vertical stack instead — mascot on top, the full-width one-line title
         // below it, then the badge — which reads as a deliberate large-text header, not a cramped
-        // row. The compact horizontal row below is kept verbatim for normal/smaller text.
+        // row. Normal/smaller text keeps the compact horizontal row below.
         if (constraints.hasBoundedWidth && fontScale > 1.15f) {
             val w = constraints.maxWidth
             val titlePlaceable = measurables[1].measure(looseConstraints.copy(maxWidth = w))
@@ -311,13 +311,19 @@ private fun TitleHeaderLayout(
             }
         }
 
-        // When a badge is present, cap the title width so the card-centered title leaves room
-        // for the inline badge. A long randomized slogan then ellipsizes instead of pushing the
-        // badge onto a second row. Reserve against the badge width only (not the wider mascot),
-        // keeping the slot wide enough that most slogans still fit on one line.
-        val titleConstraints = if (constraints.hasBoundedWidth && ribbonPlaceable != null) {
+        // Cap the title width so the card-centered title leaves room for what sits beside it: the
+        // mascot on its left, and the build-type badge on its right when one is present. A long
+        // randomized slogan then ellipsizes instead of drawing over the mascot or pushing the badge
+        // onto a second row. The title is centered, so both gaps are equal and the reservation is
+        // symmetric against whichever neighbour is wider.
+        // Two limits: below ~228dp of layout width with no badge present (more when a wider badge
+        // is reserved against) the floor wins and the reservation stops being honoured, and the
+        // mascot's rotation lives in a graphicsLayer, so the tap easter-egg spin reaches past these
+        // measured bounds.
+        val titleConstraints = if (constraints.hasBoundedWidth) {
             val minTitleWidth = 96.dp.roundToPx()
-            val reserved = 2 * (inlineSpacing + ribbonPlaceable.width)
+            val neighbourWidth = maxOf(mascotPlaceable.width, ribbonPlaceable?.width ?: 0)
+            val reserved = 2 * (inlineSpacing + neighbourWidth)
             val maxTitleWidth = (constraints.maxWidth - reserved)
                 .coerceAtLeast(minTitleWidth)
                 .coerceAtMost(constraints.maxWidth)

--- a/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleHeaderLayoutTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleHeaderLayoutTest.kt
@@ -1,0 +1,211 @@
+package eu.darken.sdmse.main.ui.dashboard.cards
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.getUnclippedBoundsInRoot
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpRect
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * The dashboard header centers the title column in the card and places the mascot to its left, so a
+ * long randomized slogan can grow the column into the mascot's slot and the mascot then draws on
+ * top of it.
+ *
+ * The invariant is about where the children land, not about text, so these drive
+ * [TitleHeaderLayout] with fixed-size stand-ins: a mascot-sized box, a title box far wider than any
+ * card, and an optional badge. Robolectric's stub text metrics never enter into it.
+ */
+class TitleHeaderLayoutTest : BaseComposeRobolectricTest() {
+
+    private fun setLayout(
+        width: Dp = CARD_WIDTH,
+        withBadge: Boolean = false,
+        badgeWidth: Dp = BADGE_WIDTH,
+        layoutDirection: LayoutDirection = LayoutDirection.Ltr,
+    ) {
+        composeRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(LocalLayoutDirection provides layoutDirection) {
+                    Box(modifier = Modifier.width(width)) {
+                        TitleHeaderLayout(
+                            modifier = Modifier.fillMaxWidth(),
+                            mascot = {
+                                Box(
+                                    modifier = Modifier
+                                        .testTag(TAG_MASCOT)
+                                        .size(width = MASCOT_WIDTH, height = MASCOT_HEIGHT),
+                                )
+                            },
+                            title = {
+                                Box(
+                                    modifier = Modifier
+                                        .testTag(TAG_TITLE)
+                                        .width(OVERSIZED_TITLE_WIDTH)
+                                        .height(TITLE_HEIGHT),
+                                )
+                            },
+                            ribbon = if (withBadge) {
+                                {
+                                    Box(
+                                        modifier = Modifier
+                                            .testTag(TAG_BADGE)
+                                            .size(width = badgeWidth, height = BADGE_HEIGHT),
+                                    )
+                                }
+                            } else {
+                                null
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `the title leaves the mascot its slot`() {
+        setLayout()
+
+        val mascot = bounds(TAG_MASCOT)
+        val title = bounds(TAG_TITLE)
+
+        assertNoOverlap(mascot, title)
+        withClue("mascot $mascot and title $title must keep the inline gap") {
+            (horizontalGap(mascot, title) >= INLINE_SPACING - ROUNDING_SLACK) shouldBe true
+        }
+        withClue("mascot $mascot must stay left of title $title") {
+            (mascot.right <= title.left) shouldBe true
+        }
+    }
+
+    @Test
+    fun `the badge stays beside the title without overlapping it`() {
+        setLayout(withBadge = true)
+
+        val mascot = bounds(TAG_MASCOT)
+        val title = bounds(TAG_TITLE)
+        val badge = bounds(TAG_BADGE)
+
+        assertNoOverlap(mascot, title)
+        assertNoOverlap(title, badge)
+        withClue("badge $badge must sit right of title $title") {
+            (title.right <= badge.left) shouldBe true
+        }
+        withClue("badge $badge must stay on the title row $title, not stack below it") {
+            (badge.top < title.bottom && title.top < badge.bottom) shouldBe true
+        }
+    }
+
+    /**
+     * The production badge is content-sized around the version name, so it can be wider than the
+     * mascot and then wins the reservation's `maxOf`. The other badge cases stay below the mascot
+     * width and never reach that branch.
+     */
+    @Test
+    fun `a badge wider than the mascot still keeps its slot`() {
+        setLayout(withBadge = true, badgeWidth = WIDE_BADGE_WIDTH)
+
+        val mascot = bounds(TAG_MASCOT)
+        val title = bounds(TAG_TITLE)
+        val badge = bounds(TAG_BADGE)
+
+        assertNoOverlap(mascot, title)
+        assertNoOverlap(title, badge)
+        withClue("badge $badge must sit right of title $title") {
+            (title.right <= badge.left) shouldBe true
+        }
+        withClue("badge $badge must stay on the title row $title, not stack below it") {
+            (badge.top < title.bottom && title.top < badge.bottom) shouldBe true
+        }
+    }
+
+    @Test
+    fun `RTL mirrors the mascot slot without overlap`() {
+        setLayout(layoutDirection = LayoutDirection.Rtl)
+
+        val mascot = bounds(TAG_MASCOT)
+        val title = bounds(TAG_TITLE)
+
+        assertNoOverlap(mascot, title)
+        withClue("RTL mascot $mascot must sit right of title $title") {
+            (title.right <= mascot.left) shouldBe true
+        }
+        withClue("mascot $mascot and title $title must keep the inline gap") {
+            (horizontalGap(title, mascot) >= INLINE_SPACING - ROUNDING_SLACK) shouldBe true
+        }
+    }
+
+    @Test
+    fun `RTL mirrors the badge slot without overlap`() {
+        setLayout(withBadge = true, layoutDirection = LayoutDirection.Rtl)
+
+        val mascot = bounds(TAG_MASCOT)
+        val title = bounds(TAG_TITLE)
+        val badge = bounds(TAG_BADGE)
+
+        assertNoOverlap(mascot, title)
+        assertNoOverlap(title, badge)
+        withClue("RTL mascot $mascot must sit right of title $title") {
+            (title.right <= mascot.left) shouldBe true
+        }
+        withClue("RTL badge $badge must sit left of title $title") {
+            (badge.right <= title.left) shouldBe true
+        }
+    }
+
+    /**
+     * [NARROW_WIDTH] is where the 96dp title floor starts winning over the reservation: below it the
+     * mascot slot is no longer honoured and the overlap returns.
+     */
+    @Test
+    fun `the narrow width boundary still keeps the slots apart`() {
+        setLayout(width = NARROW_WIDTH)
+
+        assertNoOverlap(bounds(TAG_MASCOT), bounds(TAG_TITLE))
+    }
+
+    private fun bounds(tag: String): DpRect = composeRule
+        .onNodeWithTag(tag, useUnmergedTree = true)
+        .getUnclippedBoundsInRoot()
+
+    private fun assertNoOverlap(a: DpRect, b: DpRect) = withClue("$a must not overlap $b") {
+        (a.left < b.right && b.left < a.right && a.top < b.bottom && b.top < a.bottom) shouldBe false
+    }
+
+    private fun horizontalGap(left: DpRect, right: DpRect): Dp = right.left - left.right
+
+    companion object {
+        private const val TAG_MASCOT = "mascot"
+        private const val TAG_TITLE = "title"
+        private const val TAG_BADGE = "badge"
+
+        // The production mascot measures 96dp tall at a 1080/1920 aspect ratio.
+        private val MASCOT_WIDTH = 54.dp
+        private val MASCOT_HEIGHT = 96.dp
+        private val BADGE_WIDTH = 40.dp
+        private val WIDE_BADGE_WIDTH = 72.dp
+        private val BADGE_HEIGHT = 44.dp
+        private val TITLE_HEIGHT = 48.dp
+        private val OVERSIZED_TITLE_WIDTH = 600.dp
+
+        private val CARD_WIDTH = 312.dp
+        private val NARROW_WIDTH = 228.dp
+        private val INLINE_SPACING = 12.dp
+        private val ROUNDING_SLACK = 1.dp
+    }
+}


### PR DESCRIPTION
## What changed

On the dashboard, the randomized slogan under the app name could be drawn underneath the mascot, hiding its first characters. It needed a slogan long enough to fill the card, so it showed up most in languages whose translations run long, and it only happened in release builds, which is why it rarely came up during development. Long slogans now shorten with an ellipsis instead of running into the mascot.

## Technical Context

- Root cause: the title column's width was capped only when the build-type badge was present. With no badge it measured against the full card width, so a long slogan grew the centred column into the mascot's position; the mascot is placed after the title and neither sets a z-index, so the mascot drew over the slogan rather than the other way round. Release builds and Compose previews have no badge, debug builds always do.
- The cap now applies whenever the incoming width is bounded and reserves against the wider of mascot and badge. Reserving against the badge alone was the smaller change but was rejected: it leaves the same overlap reachable on the badge path whenever a short version string makes the badge narrower than the mascot. Where the badge is the wider of the two the expression reduces to the previous reservation, so that path keeps its geometry exactly.
- Deliberate limits, documented in the code rather than worked around: below roughly 228dp of layout width the existing 96dp minimum title width beats the reservation and the overlap can return, which is pre-existing behaviour on the badge path and unchanged here; and the mascot's tap easter-egg spin is a `graphicsLayer` transform that does not affect measurement, so it still sweeps past the measured bounds.
- Worth knowing: on the no-badge path the title slot is now narrower than the full card width it previously had, so some slogans that used to fit on one line will ellipsize. That is the intended trade for not colliding with the mascot.
- Review pointer: `TitleHeaderLayoutTest` drives the layout with fixed-size stand-in children rather than real text, so it asserts child bounds without depending on Robolectric's stubbed text metrics. It covers both sides of the reservation (badge narrower and wider than the mascot), LTR and RTL, and the narrow-width floor boundary.
