### PR TITLE
Analyzer: Fix storage size not matching what the device is sold as

### DIFF
--- a/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageSpaceReconcile.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageSpaceReconcile.kt
@@ -21,6 +21,8 @@ object StorageSpaceReconcile {
 
     private const val GIB = 1L shl 30
     private const val GB = 1_000_000_000L
+    private const val TIB = 1L shl 40
+    private const val TB = 1_000_000_000_000L
 
     data class Result(
         val total: Long,
@@ -41,8 +43,8 @@ object StorageSpaceReconcile {
      * agree — the doubled-total bug leaves free correct, so free agreement is the signal that the
      * two APIs describe the same volume and the total is simply wrong.
      *
-     * The over-inflation check always compares the *raw* framework value, [normalizeStatsTotal]
-     * runs afterwards on whatever total we ended up trusting from StorageStatsManager.
+     * [normalizeStatsTotal] cannot influence that decision: the over-inflation rule reads the raw
+     * [statsTotal]/[statsFree] parameters and never the normalized result.
      */
     fun reconcilePrimary(
         statsTotal: Long,
@@ -76,12 +78,17 @@ object StorageSpaceReconcile {
      * "137 GB". An exact multiple of 2^30 that isn't an exact multiple of 10^9 can only come from
      * such a ROM, and the marketing value is the same mantissa in decimal units.
      *
+     * The mantissa only names its own tier, so each binary unit is paired with its decimal
+     * counterpart: 2^40 with 10^12, 2^30 with 10^9. 2^40 is tested first because every multiple of
+     * it is also a multiple of 2^30, which would turn a 1 TB device's 1 TiB reading into 1024 GB.
+     * The 10^9 exclusion covers both tiers, as every multiple of 10^12 is also a multiple of 10^9.
+     *
      * Two sanity guards keep us from inventing a capacity that contradicts the rest of the reading:
-     * the conversion shrinks the total by ~6.9% while free space is untouched, so a candidate below
+     * the conversion shrinks the total by ~7-9% while free space is untouched, so a candidate below
      * [statsFree] would make derived used space negative, and a candidate below [fileTotal] would
      * claim a retail capacity smaller than the measured filesystem. The latter also catches ROMs
      * that return a real filesystem measurement here: those land near [fileTotal], so their
-     * candidate falls to ~0.93x of it and is rejected.
+     * candidate falls to ~0.91-0.93x of it and is rejected.
      */
     private fun normalizeStatsTotal(
         statsTotal: Long,
@@ -89,9 +96,13 @@ object StorageSpaceReconcile {
         fileTotal: Long,
     ): Result {
         val raw = Result(statsTotal, statsFree, usedFileFallback = false)
-        if (statsTotal <= 0L || statsTotal % GIB != 0L || statsTotal % GB == 0L) return raw
+        if (statsTotal <= 0L || statsTotal % GB == 0L) return raw
 
-        val candidate = (statsTotal / GIB) * GB
+        val candidate = when {
+            statsTotal % TIB == 0L -> (statsTotal / TIB) * TB
+            statsTotal % GIB == 0L -> (statsTotal / GIB) * GB
+            else -> return raw
+        }
         if (candidate < statsFree) return raw
         if (fileTotal > 0L && candidate < fileTotal) return raw
 

--- a/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageSpaceReconcile.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/storage/StorageSpaceReconcile.kt
@@ -11,17 +11,24 @@ import kotlin.math.abs
  *   correct, so used = capacity - free gets doubled too).
  * - return a doubled/garbage total for FAT-synthesised-UUID SD cards
  *   (https://github.com/d4rken-org/sdmaid-se/issues/2389).
+ * - express the advertised capacity in binary units, e.g. 137438953472 (128 * 2^30) on a phone sold
+ *   as 128 GB, where AOSP would report 128000000000.
  *
  * When the framework value is implausible we fall back to the filesystem reading, which matches
  * what other tools (e.g. DiskInfo) and the actual partition report.
  */
 object StorageSpaceReconcile {
 
+    private const val GIB = 1L shl 30
+    private const val GB = 1_000_000_000L
+
     data class Result(
         val total: Long,
         val free: Long,
         /** True when the filesystem reading was preferred over the StorageStatsManager values. */
         val usedFileFallback: Boolean,
+        /** True when a binary-expressed StorageStatsManager total was converted to decimal units. */
+        val normalizedStatsTotal: Boolean = false,
     )
 
     /**
@@ -33,6 +40,9 @@ object StorageSpaceReconcile {
      * *gross* over-inflation (>1.5x the filesystem total) AND only when the free-space readings
      * agree — the doubled-total bug leaves free correct, so free agreement is the signal that the
      * two APIs describe the same volume and the total is simply wrong.
+     *
+     * The over-inflation check always compares the *raw* framework value, [normalizeStatsTotal]
+     * runs afterwards on whatever total we ended up trusting from StorageStatsManager.
      */
     fun reconcilePrimary(
         statsTotal: Long,
@@ -40,7 +50,7 @@ object StorageSpaceReconcile {
         fileTotal: Long,
         fileFree: Long,
     ): Result {
-        val statsResult = Result(statsTotal, statsFree, usedFileFallback = false)
+        val statsResult = normalizeStatsTotal(statsTotal, statsFree, fileTotal)
 
         // No usable filesystem cross-check.
         if (fileTotal <= 0L) return statsResult
@@ -57,6 +67,35 @@ object StorageSpaceReconcile {
         } else {
             statsResult
         }
+    }
+
+    /**
+     * `getTotalBytes(...)` is specified to return the capacity the device is *sold* as, which AOSP
+     * derives via `FileUtils.roundStorageSize` and is therefore always `{1,2,4,...,512} * 1000^n`.
+     * Some ROMs round to `1024^n` instead, so a 128 GB phone reports 137438953472 and the card shows
+     * "137 GB". An exact multiple of 2^30 that isn't an exact multiple of 10^9 can only come from
+     * such a ROM, and the marketing value is the same mantissa in decimal units.
+     *
+     * Two sanity guards keep us from inventing a capacity that contradicts the rest of the reading:
+     * the conversion shrinks the total by ~6.9% while free space is untouched, so a candidate below
+     * [statsFree] would make derived used space negative, and a candidate below [fileTotal] would
+     * claim a retail capacity smaller than the measured filesystem. The latter also catches ROMs
+     * that return a real filesystem measurement here: those land near [fileTotal], so their
+     * candidate falls to ~0.93x of it and is rejected.
+     */
+    private fun normalizeStatsTotal(
+        statsTotal: Long,
+        statsFree: Long,
+        fileTotal: Long,
+    ): Result {
+        val raw = Result(statsTotal, statsFree, usedFileFallback = false)
+        if (statsTotal <= 0L || statsTotal % GIB != 0L || statsTotal % GB == 0L) return raw
+
+        val candidate = (statsTotal / GIB) * GB
+        if (candidate < statsFree) return raw
+        if (fileTotal > 0L && candidate < fileTotal) return raw
+
+        return Result(candidate, statsFree, usedFileFallback = false, normalizedStatsTotal = true)
     }
 
     /**

--- a/app-common-data/src/test/java/eu/darken/sdmse/common/storage/StorageSpaceReconcileTest.kt
+++ b/app-common-data/src/test/java/eu/darken/sdmse/common/storage/StorageSpaceReconcileTest.kt
@@ -9,6 +9,7 @@ class StorageSpaceReconcileTest : BaseTest() {
     // ~1TB device reported as 2TB, free correct. Reproduces realme/ColorOS A15 report.
     private val TB = 1_000_000_000_000L
     private val GB = 1_000_000_000L
+    private val GIB = 1L shl 30
 
     // --- reconcilePrimary ---
 
@@ -99,6 +100,128 @@ class StorageSpaceReconcileTest : BaseTest() {
         )
         result.total shouldBe 2 * TB
         result.usedFileFallback shouldBe false
+    }
+
+    // --- reconcilePrimary: binary-rounded marketing capacity ---
+
+    @Test
+    fun `primary binary-rounded total converts to decimal units`() {
+        // 128 GiB = 137438953472 on a phone sold as 128 GB.
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 128 * GIB,
+            statsFree = 60 * GB,
+            fileTotal = 115 * GB,
+            fileFree = 60 * GB,
+        )
+        result.total shouldBe 128 * GB
+        result.free shouldBe 60 * GB
+        result.usedFileFallback shouldBe false
+        result.normalizedStatsTotal shouldBe true
+    }
+
+    @Test
+    fun `primary AOSP-style decimal total is not converted`() {
+        // Feeding the converted value back in must be a no-op.
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 128 * GB,
+            statsFree = 60 * GB,
+            fileTotal = 115 * GB,
+            fileFree = 60 * GB,
+        )
+        result.total shouldBe 128 * GB
+        result.normalizedStatsTotal shouldBe false
+    }
+
+    @Test
+    fun `primary non-round total is not converted`() {
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 137_438_953_000L,
+            statsFree = 60 * GB,
+            fileTotal = 115 * GB,
+            fileFree = 60 * GB,
+        )
+        result.total shouldBe 137_438_953_000L
+        result.normalizedStatsTotal shouldBe false
+    }
+
+    @Test
+    fun `primary File fallback total is not converted`() {
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 2048 * GIB,
+            statsFree = 104 * GB,
+            fileTotal = 1024 * GIB,
+            fileFree = 105 * GB,
+        )
+        result.total shouldBe 1024 * GIB
+        result.usedFileFallback shouldBe true
+        result.normalizedStatsTotal shouldBe false
+    }
+
+    @Test
+    fun `primary over-inflated binary total still prefers File`() {
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 2048 * GIB,
+            statsFree = 104 * GB,
+            fileTotal = 1_010 * GB,
+            fileFree = 105 * GB,
+        )
+        result.total shouldBe 1_010 * GB
+        result.usedFileFallback shouldBe true
+        result.normalizedStatsTotal shouldBe false
+    }
+
+    @Test
+    fun `primary conversion is skipped when it would undercut free space`() {
+        // 128 GB candidate < 130 GB free would make used space negative.
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 128 * GIB,
+            statsFree = 130 * GB,
+            fileTotal = 120 * GB,
+            fileFree = 118 * GB,
+        )
+        result.total shouldBe 128 * GIB
+        result.normalizedStatsTotal shouldBe false
+    }
+
+    @Test
+    fun `primary conversion is skipped when it would undercut the filesystem total`() {
+        // A retail capacity below the measured filesystem size can't be right.
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 128 * GIB,
+            statsFree = 60 * GB,
+            fileTotal = 130 * GB,
+            fileFree = 60 * GB,
+        )
+        result.total shouldBe 128 * GIB
+        result.normalizedStatsTotal shouldBe false
+    }
+
+    @Test
+    fun `primary binary total converts without a filesystem cross-check`() {
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 128 * GIB,
+            statsFree = 60 * GB,
+            fileTotal = 0L,
+            fileFree = 0L,
+        )
+        result.total shouldBe 128 * GB
+        result.normalizedStatsTotal shouldBe true
+    }
+
+    @Test
+    fun `primary over-inflation is judged on the raw total, not the converted one`() {
+        // Raw 64 GiB is >1.5x the 45 GB filesystem total, the 64 GB candidate would not be.
+        // Converting before the comparison would keep stats instead of falling back.
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 64 * GIB,
+            statsFree = 20 * GB,
+            fileTotal = 45 * GB,
+            fileFree = 20 * GB,
+        )
+        result.total shouldBe 45 * GB
+        result.free shouldBe 20 * GB
+        result.usedFileFallback shouldBe true
+        result.normalizedStatsTotal shouldBe false
     }
 
     // --- reconcileSecondary (behavior-preserving, #2389) ---

--- a/app-common-data/src/test/java/eu/darken/sdmse/common/storage/StorageSpaceReconcileTest.kt
+++ b/app-common-data/src/test/java/eu/darken/sdmse/common/storage/StorageSpaceReconcileTest.kt
@@ -10,6 +10,7 @@ class StorageSpaceReconcileTest : BaseTest() {
     private val TB = 1_000_000_000_000L
     private val GB = 1_000_000_000L
     private val GIB = 1L shl 30
+    private val TIB = 1L shl 40
 
     // --- reconcilePrimary ---
 
@@ -115,6 +116,35 @@ class StorageSpaceReconcileTest : BaseTest() {
         )
         result.total shouldBe 128 * GB
         result.free shouldBe 60 * GB
+        result.usedFileFallback shouldBe false
+        result.normalizedStatsTotal shouldBe true
+    }
+
+    @Test
+    fun `primary binary-rounded terabyte total converts to decimal units`() {
+        // 1 TiB = 1099511627776 on a device sold as 1 TB; the GiB tier would yield 1024 GB.
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = TIB,
+            statsFree = 400 * GB,
+            fileTotal = 950 * GB,
+            fileFree = 400 * GB,
+        )
+        result.total shouldBe TB
+        result.free shouldBe 400 * GB
+        result.usedFileFallback shouldBe false
+        result.normalizedStatsTotal shouldBe true
+    }
+
+    @Test
+    fun `primary binary-rounded total below the terabyte tier stays on the GiB tier`() {
+        // 512 GiB is a multiple of 2^30 but not of 2^40, so it must convert to 512 GB.
+        val result = StorageSpaceReconcile.reconcilePrimary(
+            statsTotal = 512 * GIB,
+            statsFree = 200 * GB,
+            fileTotal = 480 * GB,
+            fileFree = 200 * GB,
+        )
+        result.total shouldBe 512 * GB
         result.usedFileFallback shouldBe false
         result.normalizedStatsTotal shouldBe true
     }

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceTracker.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/SpaceTracker.kt
@@ -135,6 +135,11 @@ class SpaceTracker @Inject constructor(
                         "Primary StorageStats total=$statsTotal implausible vs File=$fileTotal; using File"
                     }
                 }
+                if (reconciled.normalizedStatsTotal) {
+                    log(TAG, WARN) {
+                        "Primary StorageStats total=$statsTotal is binary-rounded; using ${reconciled.total}"
+                    }
+                }
                 reconciled.total to reconciled.free
             } catch (e: Exception) {
                 log(TAG, WARN) { "StorageStatsManager failed for primary storage, using File API: ${e.asLog()}" }

--- a/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
+++ b/app-tool-analyzer/src/main/java/eu/darken/sdmse/analyzer/core/device/DeviceStorageScanner.kt
@@ -76,6 +76,11 @@ class DeviceStorageScanner @Inject constructor(
                         "Primary StorageStats total=$statsTotal implausible vs File=$fileTotal for $id; using File"
                     }
                 }
+                if (reconciled.normalizedStatsTotal) {
+                    log(TAG, WARN) {
+                        "Primary StorageStats total=$statsTotal is binary-rounded for $id; using ${reconciled.total}"
+                    }
+                }
                 reconciled.total to reconciled.free
             } catch (e: Exception) {
                 log(TAG, WARN) { "StorageStatsManager failed for primary $id, using File API: ${e.message}" }


### PR DESCRIPTION
## What changed

On some phones the storage analyzer showed a bigger total than the phone is sold as: a 128 GB device showed "137 GB". Because used space is worked out as total minus free, the used figure was inflated by the same amount. Those phones now show the capacity the device is sold as, and phones that already showed the right number are unaffected.

## Technical Context

- Root cause: `StorageStatsManager.getTotalBytes` is specified to return the retail-advertised capacity, which AOSP derives via `FileUtils.roundStorageSize`. That output is always decimal-round, so a conformant 128 GB device reports 128,000,000,000 and already renders correctly today. Some ROMs skip the rounding and return the advertised figure in binary units instead (137,438,953,472, which is exactly 128 GiB), and the decimal formatter renders that as "137 GB".
- The conversion sits at the data source rather than in a formatter on purpose. Formatting the card in binary units would render a conformant device's 128,000,000,000 as "119 GB", regressing every AOSP-conformant device in order to fix one vendor's. The conversion is a no-op on any value that is not exactly binary.
- It lives in `StorageSpaceReconcile` rather than at either call site because `DeviceStorageScanner` (analyzer) and `SpaceTracker` (persisted space history) both call `reconcilePrimary` and must not diverge.
- Two guards stop it inventing a capacity that contradicts the rest of the reading: the candidate must not fall below reported free space, nor below the measured filesystem total. The second also rejects ROMs that return a real filesystem measurement here, since such a value sits at the filesystem total and its candidate lands below it. Worth reviewing alongside the tier-selection branch order in `normalizeStatsTotal`, and the requirement that the over-inflation comparison keeps reading the raw parameters; there is a dedicated test pinning each.
- Deliberate limitation: existing space-history snapshots keep their pre-change capacity, and nothing smooths the transition. On an affected device, a user whose history straddles this change and who has too little history for the day-bucketed trend path will see one spurious window delta of roughly -9.4 GB presented as a real saving, on the trend card, the space-history screen and the dashboard. `StorageTrendCalculator.dailyTrend` is unaffected because it already skips day-pairs whose capacity differs, and the artifact clears as post-update days accumulate.
