### PR TITLE
General: Show the Xiaomi Auto Start tip on HyperOS phones

### DIFF
--- a/app-common-setup/src/main/java/eu/darken/sdmse/setup/automation/AutomationToolsHelper.kt
+++ b/app-common-setup/src/main/java/eu/darken/sdmse/setup/automation/AutomationToolsHelper.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.setup.automation
 import android.annotation.SuppressLint
 import android.content.Context
 import android.security.advancedprotection.AdvancedProtectionManager
+import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.features.InstallerInfo
 import eu.darken.sdmse.common.pkgs.features.getInstallerInfo
@@ -68,3 +69,13 @@ fun decideAcsRestrictionHints(
     showAdvancedProtectionHint = advancedProtectionBlocksAcs && hasConsent == true && !isServiceRunning,
     showAppOpsRestrictionHint = appOpsRestrictionApplies && !advancedProtectionBlocksAcs,
 )
+
+/**
+ * Decides whether to point the user at the system "Auto Start" toggle, which exists on MIUI and on
+ * its HyperOS successor. A device that can enable the service on its own (root/ADB) has no use for
+ * the hint, it doesn't depend on the toggle to get the service up.
+ */
+fun needsXiaomiAutostartHint(
+    romType: RomType,
+    canSelfEnable: Boolean,
+): Boolean = (romType == RomType.MIUI || romType == RomType.HYPEROS) && !canSelfEnable

--- a/app-common-setup/src/test/java/eu/darken/sdmse/setup/automation/XiaomiAutostartHintTest.kt
+++ b/app-common-setup/src/test/java/eu/darken/sdmse/setup/automation/XiaomiAutostartHintTest.kt
@@ -1,0 +1,50 @@
+package eu.darken.sdmse.setup.automation
+
+import eu.darken.sdmse.common.device.RomType
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class XiaomiAutostartHintTest : BaseTest() {
+
+    @Test
+    fun `hint shows on HyperOS`() {
+        needsXiaomiAutostartHint(
+            romType = RomType.HYPEROS,
+            canSelfEnable = false,
+        ) shouldBe true
+    }
+
+    @Test
+    fun `hint shows on MIUI`() {
+        needsXiaomiAutostartHint(
+            romType = RomType.MIUI,
+            canSelfEnable = false,
+        ) shouldBe true
+    }
+
+    @Test
+    fun `no hint when the service can be self enabled`() {
+        needsXiaomiAutostartHint(
+            romType = RomType.HYPEROS,
+            canSelfEnable = true,
+        ) shouldBe false
+
+        needsXiaomiAutostartHint(
+            romType = RomType.MIUI,
+            canSelfEnable = true,
+        ) shouldBe false
+    }
+
+    @Test
+    fun `no hint on any other ROM type`() {
+        RomType.entries
+            .filter { it != RomType.MIUI && it != RomType.HYPEROS }
+            .forEach { romType ->
+                needsXiaomiAutostartHint(
+                    romType = romType,
+                    canSelfEnable = false,
+                ) shouldBe false
+            }
+    }
+}

--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupModule.kt
@@ -93,6 +93,9 @@ class AutomationSetupModule @Inject constructor(
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
 
+        val romType = deviceDetective.getROMType()
+        log(TAG) { "romType=$romType" }
+
         log(TAG) { "useRoot: $useRoot" }
 
         @Suppress("USELESS_CAST")
@@ -103,12 +106,15 @@ class AutomationSetupModule @Inject constructor(
             isServiceEnabled = isServiceEnabled,
             isServiceRunning = isServiceRunning,
             isShortcutOrButtonEnabled = isShortcutOrButtonEnabled,
-            needsXiaomiAutostart = deviceDetective.getROMType() == RomType.MIUI && !canSelfEnable,
+            needsXiaomiAutostart = needsXiaomiAutostartHint(
+                romType = romType,
+                canSelfEnable = canSelfEnable,
+            ),
             liftRestrictionsIntent = liftRestrictionsIntent,
             showAppOpsRestrictionHint = restrictionHints.showAppOpsRestrictionHint,
             showAdvancedProtectionHint = restrictionHints.showAdvancedProtectionHint,
             isAdvancedProtectionBlocked = aapmBlocksAcs,
-            settingsIntent = when (deviceDetective.getROMType()) {
+            settingsIntent = when (romType) {
                 RomType.ANDROID_TV -> Intent(Settings.ACTION_SETTINGS)
                 else -> Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
             }

--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationUiModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationUiModel.kt
@@ -80,7 +80,8 @@ internal fun AutomationSetupModule.Result.toUiModel(): AutomationUiModel {
     return AutomationUiModel(
         enabledState = enabledChip,
         // Advanced Protection takes precedence; the MIUI autostart hint would be a false remedy here.
-        showMiuiAutostartHint = !isServiceEnabled && needsXiaomiAutostart && !isAdvancedProtectionBlocked,
+        showMiuiAutostartHint = hasConsent == true && !isServiceEnabled && needsXiaomiAutostart
+                && !isAdvancedProtectionBlocked,
         showAppOpsRestrictionHint = showAppOpsRestrictionHint,
         showAdvancedProtectionHint = showAdvancedProtectionHint,
         runningState = runningChip,

--- a/app/src/test/java/eu/darken/sdmse/setup/automation/AutomationUiModelTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/automation/AutomationUiModelTest.kt
@@ -117,6 +117,23 @@ class AutomationUiModelTest : BaseTest() {
     }
 
     @Test
+    fun `MIUI hint requires consent`() {
+        val undecided = result(
+            hasConsent = null,
+            isServiceEnabled = false,
+            needsXiaomiAutostart = true,
+        ).toUiModel()
+        undecided.showMiuiAutostartHint shouldBe false
+
+        val denied = result(
+            hasConsent = false,
+            isServiceEnabled = false,
+            needsXiaomiAutostart = true,
+        ).toUiModel()
+        denied.showMiuiAutostartHint shouldBe false
+    }
+
+    @Test
     fun `MIUI hint is suppressed while Advanced Protection blocks the service`() {
         val ui = result(
             hasConsent = true,


### PR DESCRIPTION
## What changed

SD Maid's setup screen has a Xiaomi-specific tip telling you to switch on the system "Auto Start" toggle when the accessibility service keeps getting turned off. That tip only ever appeared on older MIUI builds, so nobody on a current Xiaomi or POCO phone ever saw it, even though those are exactly the devices where the system switches the service off again. It now appears on HyperOS devices too.

The tip also no longer shows up before you have agreed to use the accessibility service at all. Previously it could appear on a fresh install next to a consent prompt that had not been answered yet, offering a remedy for a problem the user had not had.

## Technical Context

- Root cause: the gate required `RomType.MIUI`, but `DeviceDetective` has classified Xiaomi/POCO devices as `RomType.HYPEROS` since HyperOS detection was added in January 2025, 18 months after the gate was written. The MIUI branch is now only reachable on pre-HyperOS builds, or an `OS*` build below API 33.
- The decision moved into `needsXiaomiAutostartHint()` in `AutomationToolsHelper` rather than being edited in place. The gate previously sat inside `AutomationSetupModule`'s `combine` lambda, unreachable from a unit test without standing up a six-dependency `@Singleton`. That file already established this pattern with `decideAcsRestrictionHints`.
- The existing `AutomationUiModelTest` could not have caught the drift, because it supplies `needsXiaomiAutostart` as a test input. `XiaomiAutostartHintTest` drives the `RomType` directly, and its negative case iterates `RomType.entries` so a ROM type added later cannot silently inherit a Xiaomi-specific hint.
- The consent gate is a deliberate behaviour change beyond the original bug, and it narrows current MIUI behaviour too. It brings the hint in line with the two sibling conditions in the same card, which already require consent.
- `AutomationSetupModule` called `deviceDetective.getROMType()` twice per state emission; it is now resolved once and shared with the settings intent.
