### PR TITLE
General: Don't delete everything when only some items are selected

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/layout/SdmWholeScopeActions.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/layout/SdmWholeScopeActions.kt
@@ -1,0 +1,76 @@
+package eu.darken.sdmse.common.compose.layout
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.DeleteSweep
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.FilledTonalButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.icons.SdmIcons
+import eu.darken.sdmse.common.compose.icons.ShieldAdd
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+
+/**
+ * Exclude/delete pair that acts on a whole scope (a filter, an app, a corpse, a cluster) rather than
+ * on the current selection. [enabled] has no default so a new caller has to decide what happens while
+ * a selection is active.
+ */
+@Composable
+fun SdmWholeScopeActions(
+    modifier: Modifier = Modifier,
+    enabled: Boolean,
+    onExclude: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        FilledTonalButton(
+            onClick = onExclude,
+            modifier = Modifier.weight(1f),
+            enabled = enabled,
+        ) {
+            Icon(SdmIcons.ShieldAdd, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(CommonR.string.general_exclude_action))
+        }
+        Button(
+            onClick = onDelete,
+            modifier = Modifier.weight(1f),
+            enabled = enabled,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.error,
+                contentColor = MaterialTheme.colorScheme.onError,
+            ),
+        ) {
+            Icon(Icons.TwoTone.DeleteSweep, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text(stringResource(CommonR.string.general_delete_action))
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun SdmWholeScopeActionsPreview() {
+    PreviewWrapper {
+        SdmWholeScopeActions(
+            enabled = true,
+            onExclude = {},
+            onDelete = {},
+        )
+    }
+}

--- a/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/layout/SdmWholeScopeActionsTest.kt
+++ b/app-common-ui/src/test/java/eu/darken/sdmse/common/compose/layout/SdmWholeScopeActionsTest.kt
@@ -1,0 +1,39 @@
+package eu.darken.sdmse.common.compose.layout
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class SdmWholeScopeActionsTest : BaseComposeRobolectricTest() {
+
+    private fun setActions(enabled: Boolean) {
+        composeRule.setContent {
+            PreviewWrapper {
+                SdmWholeScopeActions(
+                    enabled = enabled,
+                    onExclude = {},
+                    onDelete = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `both actions are enabled when the flag is set`() {
+        setActions(enabled = true)
+
+        composeRule.onNodeWithText("Exclude").assertIsEnabled()
+        composeRule.onNodeWithText("Delete").assertIsEnabled()
+    }
+
+    @Test
+    fun `both actions are disabled when the flag is cleared`() {
+        setActions(enabled = false)
+
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+    }
+}

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsScreen.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsScreen.kt
@@ -234,6 +234,9 @@ internal fun AppJunkDetailsScreen(
     }
 
     val selectionActive = selection.isActive
+    // Card actions act on a whole app/category, which is wider than any row selection, so they are
+    // gated screen-wide: adjacent pages stay visible in the pager once the span count exceeds one.
+    val wholeScopeActionsEnabled = !selectionActive
     BackHandler(enabled = selectionActive) { selection.clear() }
 
     SdmScaffold(
@@ -322,6 +325,7 @@ internal fun AppJunkDetailsScreen(
                                     collapsed = collapsed,
                                     selection = selection,
                                     isCurrentPage = isCurrentPage,
+                                    wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                                     onDeleteJunk = {
                                         onRequestDelete(
                                             DeleteSpec.WholeJunk(

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPage.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPage.kt
@@ -3,7 +3,6 @@ package eu.darken.sdmse.appcleaner.ui.details.page
 import android.text.format.Formatter
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -17,13 +16,9 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.FormatListBulleted
-import androidx.compose.material.icons.twotone.DeleteSweep
 import androidx.compose.material.icons.twotone.ExpandLess
 import androidx.compose.material.icons.twotone.ExpandMore
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -31,10 +26,12 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -54,8 +51,7 @@ import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.coil.FileListThumbnail
 import eu.darken.sdmse.common.compose.SystemAppChip
-import eu.darken.sdmse.common.compose.icons.SdmIcons
-import eu.darken.sdmse.common.compose.icons.ShieldAdd
+import eu.darken.sdmse.common.compose.layout.SdmWholeScopeActions
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.selection.SelectionState
@@ -68,12 +64,20 @@ import eu.darken.sdmse.common.pkgs.getSettingsIntent
 
 private val TAG = logTag("AppCleaner", "Details", "Page")
 
+/** Material's disabled-content alpha, applied by hand where explicit colours bypass the theme. */
+private const val DisabledContentAlpha = 0.38f
+
+internal object AppJunkPageTags {
+    const val CATEGORY_COLLAPSE = "appjunk_category_collapse"
+}
+
 @Composable
 internal fun AppJunkPage(
     junk: AppJunk,
     collapsed: Set<ExpendablesFilterIdentifier>,
     selection: SelectionState<APath>,
     isCurrentPage: Boolean,
+    wholeScopeActionsEnabled: Boolean,
     onDeleteJunk: () -> Unit,
     onExcludeJunk: () -> Unit,
     onDeleteInaccessible: () -> Unit,
@@ -95,6 +99,7 @@ internal fun AppJunkPage(
                 AppJunkElement.Header -> item(key = "header", contentType = "header") {
                     AppJunkPageHeaderCard(
                         junk = junk,
+                        wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                         onDeleteJunk = onDeleteJunk,
                         onExcludeJunk = onExcludeJunk,
                     )
@@ -103,6 +108,7 @@ internal fun AppJunkPage(
                 is AppJunkElement.Inaccessible -> item(key = "inaccessible", contentType = "inaccessible") {
                     AppJunkInaccessibleRow(
                         cache = element.cache,
+                        wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                         onClick = onDeleteInaccessible,
                     )
                 }
@@ -113,6 +119,7 @@ internal fun AppJunkPage(
                         matchCount = element.matches.size,
                         totalSize = element.totalSize,
                         isCollapsed = element.isCollapsed,
+                        wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                         onClick = { onDeleteCategory(element.category) },
                         onCollapseToggle = { onToggleCollapse(element.category) },
                     )
@@ -143,6 +150,7 @@ internal fun AppJunkPage(
 @Composable
 private fun AppJunkPageHeaderCard(
     junk: AppJunk,
+    wholeScopeActionsEnabled: Boolean,
     onDeleteJunk: () -> Unit,
     onExcludeJunk: () -> Unit,
 ) {
@@ -240,28 +248,11 @@ private fun AppJunkPageHeaderCard(
             }
 
             Spacer(Modifier.height(16.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                FilledTonalButton(
-                    onClick = onExcludeJunk,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Icon(SdmIcons.ShieldAdd, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(CommonR.string.general_exclude_action))
-                }
-                Button(
-                    onClick = onDeleteJunk,
-                    modifier = Modifier.weight(1f),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.error,
-                        contentColor = MaterialTheme.colorScheme.onError,
-                    ),
-                ) {
-                    Icon(Icons.TwoTone.DeleteSweep, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(CommonR.string.general_delete_action))
-                }
-            }
+            SdmWholeScopeActions(
+                enabled = wholeScopeActionsEnabled,
+                onExclude = onExcludeJunk,
+                onDelete = onDeleteJunk,
+            )
         }
     }
 }
@@ -287,6 +278,7 @@ private fun AppIconWithSettingsLongPress(junk: AppJunk) {
 @Composable
 private fun AppJunkInaccessibleRow(
     cache: InaccessibleCache,
+    wholeScopeActionsEnabled: Boolean,
     onClick: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -295,8 +287,14 @@ private fun AppJunkInaccessibleRow(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp),
+        enabled = wholeScopeActionsEnabled,
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
+        // The card sets explicit content colours, which Card(enabled = false) cannot dim.
+        Column(
+            modifier = Modifier
+                .padding(16.dp)
+                .alpha(if (wholeScopeActionsEnabled) 1f else DisabledContentAlpha),
+        ) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Icon(
                     imageVector = Icons.AutoMirrored.TwoTone.FormatListBulleted,
@@ -332,6 +330,7 @@ private fun AppJunkCategoryCard(
     matchCount: Int,
     totalSize: Long,
     isCollapsed: Boolean,
+    wholeScopeActionsEnabled: Boolean,
     onClick: () -> Unit,
     onCollapseToggle: () -> Unit,
 ) {
@@ -342,11 +341,15 @@ private fun AppJunkCategoryCard(
         matchCount,
     )
     val subtitle = "${Formatter.formatShortFileSize(context, totalSize)} ($itemCountText)"
+    // The card sets explicit content colours, which Card(enabled = false) cannot dim. The collapse
+    // toggle stays outside the dimmed scope so it still reads as usable.
+    val contentAlpha = if (wholeScopeActionsEnabled) 1f else DisabledContentAlpha
     Card(
         onClick = onClick,
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp),
+        enabled = wholeScopeActionsEnabled,
     ) {
         Column(modifier = Modifier.padding(vertical = 8.dp)) {
             Row(
@@ -357,11 +360,17 @@ private fun AppJunkCategoryCard(
                 Icon(
                     imageVector = category.icon,
                     contentDescription = null,
-                    modifier = Modifier.size(24.dp),
+                    modifier = Modifier
+                        .size(24.dp)
+                        .alpha(contentAlpha),
                     tint = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Spacer(Modifier.width(16.dp))
-                Column(modifier = Modifier.weight(1f)) {
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .alpha(contentAlpha),
+                ) {
                     Text(
                         text = stringResource(category.labelRes),
                         style = MaterialTheme.typography.bodyMedium,
@@ -376,7 +385,10 @@ private fun AppJunkCategoryCard(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-                IconButton(onClick = onCollapseToggle) {
+                IconButton(
+                    onClick = onCollapseToggle,
+                    modifier = Modifier.testTag(AppJunkPageTags.CATEGORY_COLLAPSE),
+                ) {
                     Icon(
                         imageVector = if (isCollapsed) Icons.TwoTone.ExpandMore else Icons.TwoTone.ExpandLess,
                         contentDescription = null,
@@ -390,7 +402,8 @@ private fun AppJunkCategoryCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(start = 16.dp, end = 16.dp, top = 4.dp),
+                    .padding(start = 16.dp, end = 16.dp, top = 4.dp)
+                    .alpha(contentAlpha),
             )
         }
     }
@@ -447,6 +460,7 @@ private fun AppJunkPagePreview() {
             collapsed = emptySet(),
             selection = remember { SelectionState() },
             isCurrentPage = true,
+            wholeScopeActionsEnabled = true,
             onDeleteJunk = {},
             onExcludeJunk = {},
             onDeleteInaccessible = {},

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsScreenTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsScreenTest.kt
@@ -1,9 +1,17 @@
 package eu.darken.sdmse.appcleaner.ui.details
 
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTouchInput
 import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
 import eu.darken.sdmse.appcleaner.ui.preview.previewInstalled
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
@@ -22,6 +30,13 @@ class AppJunkDetailsScreenTest : BaseComposeRobolectricTest() {
                 AppJunkDetailsScreen(stateSource = MutableStateFlow(state))
             }
         }
+    }
+
+    // The screen stacks three scrollables (tab strip, pager, page list); only the page list scrolls
+    // vertically, so match on that axis to stay unambiguous.
+    private fun ComposeContentTestRule.scrollTo(text: String) {
+        onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange))
+            .performScrollToNode(hasText(text))
     }
 
     @Test
@@ -46,6 +61,30 @@ class AppJunkDetailsScreenTest : BaseComposeRobolectricTest() {
         composeRule.onNodeWithText("AppCleaner").assertExists()
         // Empty placeholder must NOT render when items are present.
         composeRule.onAllNodesWithText("Empty").assertCountEquals(0)
+    }
+
+    @Test
+    fun `long-pressing a file row gates the header card actions`() {
+        // Drives the screen's own `!selection.isActive` computation instead of injecting the flag.
+        val a = previewAppJunk(pkg = previewInstalled(pkgName = "com.example.gate", label = "Gate"))
+        composeRule.setDetailsScreen(
+            AppJunkDetailsViewModel.State(
+                items = listOf(a),
+                target = a.identifier,
+            ),
+        )
+
+        composeRule.onNodeWithText("Exclude").assertIsEnabled()
+        composeRule.onNodeWithText("Delete").assertIsEnabled()
+
+        val filePath = a.expendables!!.values.first().first().path.path
+        composeRule.scrollTo(filePath)
+        composeRule.onNodeWithText(filePath).performTouchInput { longClick() }
+
+        // The header card scrolls out of view on the way down to the file rows.
+        composeRule.scrollTo("Exclude")
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
     }
 
     // NOTE: Asserting on tab/pager-only content (e.g. junk.label rendered as the tab title) is

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsScreenTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/AppJunkDetailsScreenTest.kt
@@ -12,12 +12,20 @@ import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performScrollToNode
 import androidx.compose.ui.test.performTouchInput
+import eu.darken.sdmse.appcleaner.core.AppJunk
+import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPublicFilter
 import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
 import eu.darken.sdmse.appcleaner.ui.preview.previewInstalled
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Test
+import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
+import java.time.Instant
 
 // HorizontalPager + ScrollableTabRow are known to interact poorly with Robolectric for
 // multi-page assertions. Tests here intentionally stay on single-item / empty state and avoid
@@ -38,6 +46,36 @@ class AppJunkDetailsScreenTest : BaseComposeRobolectricTest() {
         onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange))
             .performScrollToNode(hasText(text))
     }
+
+    // Same axis filter, but every rendered pager page contributes one vertical scrollable, so the
+    // page has to be addressed by index once more than one is on screen.
+    private fun ComposeContentTestRule.scrollPageTo(pageIndex: Int, text: String) {
+        onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange))[pageIndex]
+            .performScrollToNode(hasText(text))
+    }
+
+    // previewExpendables() hardcodes com.example.app paths, which would collide across pages and
+    // make the file row ambiguous. Each junk needs its own package-scoped cache file.
+    private fun junkWithOwnCacheFile(pkgName: String, label: String): AppJunk = previewAppJunk(
+        pkg = previewInstalled(pkgName = pkgName, label = label),
+        expendables = mapOf(
+            DefaultCachesPublicFilter::class to listOf(
+                ExpendablesFilter.Match.Deletion(
+                    identifier = DefaultCachesPublicFilter::class,
+                    lookup = LocalPathLookup(
+                        lookedUp = LocalPath.build(
+                            "storage", "emulated", "0", "Android", "data", pkgName, "cache", "blob.bin",
+                        ),
+                        fileType = FileType.FILE,
+                        size = 6L * 1024 * 1024,
+                        modifiedAt = Instant.parse("2026-04-01T12:00:00Z"),
+                        target = null,
+                    ),
+                ),
+            ),
+        ),
+        inaccessibleCache = null,
+    )
 
     @Test
     fun `empty state shows the Empty placeholder`() {
@@ -85,6 +123,38 @@ class AppJunkDetailsScreenTest : BaseComposeRobolectricTest() {
         composeRule.scrollTo("Exclude")
         composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
         composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+    }
+
+    @Test
+    @Config(qualifiers = "w720dp-h1024dp")
+    fun `on a wide viewport the gate covers the visible neighbour page too`() {
+        // spanCount is (screenWidthDp / 390 + 0.5).toInt(), so 720dp yields two pages side by side
+        // and the neighbour's header card is on screen while the first page owns the selection.
+        val focused = junkWithOwnCacheFile(pkgName = "com.example.focused", label = "Focused")
+        val neighbour = junkWithOwnCacheFile(pkgName = "com.example.neighbour", label = "Neighbour")
+        composeRule.setDetailsScreen(
+            AppJunkDetailsViewModel.State(
+                items = listOf(focused, neighbour),
+                target = focused.identifier,
+            ),
+        )
+
+        composeRule.onAllNodesWithText("Exclude").assertCountEquals(2)
+        composeRule.onAllNodesWithText("Delete").assertCountEquals(2)
+
+        val filePath = focused.expendables!!.values.first().first().path.path
+        composeRule.scrollPageTo(0, filePath)
+        composeRule.onNodeWithText(filePath).performTouchInput { longClick() }
+        composeRule.scrollPageTo(0, "Exclude")
+
+        // Both header cards must gate, not just the selection owner's: a page-scoped gate would
+        // leave the neighbour's whole-app Delete/Exclude live.
+        composeRule.onAllNodesWithText("Exclude").assertCountEquals(2)
+        composeRule.onAllNodesWithText("Delete").assertCountEquals(2)
+        repeat(2) { index ->
+            composeRule.onAllNodesWithText("Exclude")[index].assertIsNotEnabled()
+            composeRule.onAllNodesWithText("Delete")[index].assertIsNotEnabled()
+        }
     }
 
     // NOTE: Asserting on tab/pager-only content (e.g. junk.label rendered as the tab title) is

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPageTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPageTest.kt
@@ -1,0 +1,112 @@
+package eu.darken.sdmse.appcleaner.ui.details.page
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasScrollToNodeAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import eu.darken.sdmse.appcleaner.core.AppJunk
+import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.compose.selection.SelectionState
+import eu.darken.sdmse.common.files.APath
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class AppJunkPageTest : BaseComposeRobolectricTest() {
+
+    private val junk: AppJunk = previewAppJunk()
+    private val categoryLabel = "Public default caches"
+    private val inaccessibleLabel = "Default caches"
+
+    private fun setPage(
+        wholeScopeActionsEnabled: Boolean,
+        isCurrentPage: Boolean = true,
+        selected: Set<APath> = emptySet(),
+        onToggleCollapse: () -> Unit = {},
+    ) {
+        composeRule.setContent {
+            PreviewWrapper {
+                AppJunkPage(
+                    junk = junk,
+                    collapsed = emptySet(),
+                    selection = SelectionState(initial = selected),
+                    isCurrentPage = isCurrentPage,
+                    wholeScopeActionsEnabled = wholeScopeActionsEnabled,
+                    onDeleteJunk = {},
+                    onExcludeJunk = {},
+                    onDeleteInaccessible = {},
+                    onDeleteCategory = {},
+                    onDeleteFile = { _, _ -> },
+                    onToggleCollapse = { onToggleCollapse() },
+                )
+            }
+        }
+    }
+
+    private fun ComposeContentTestRule.scrollTo(text: String) {
+        onNode(hasScrollToNodeAction()).performScrollToNode(hasText(text))
+    }
+
+    private fun selectedPath(): APath = junk.expendables!!.values.first().first().path
+
+    @Test
+    fun `whole-scope affordances are live without a selection`() {
+        setPage(wholeScopeActionsEnabled = true)
+
+        composeRule.onNodeWithText("Exclude").assertIsEnabled()
+        composeRule.onNodeWithText("Delete").assertIsEnabled()
+
+        composeRule.scrollTo(inaccessibleLabel)
+        composeRule.onNode(hasClickAction() and hasText(inaccessibleLabel)).assertIsEnabled()
+
+        composeRule.scrollTo(categoryLabel)
+        composeRule.onNode(hasClickAction() and hasText(categoryLabel)).assertIsEnabled()
+    }
+
+    @Test
+    fun `whole-scope affordances are gated while a selection is active`() {
+        setPage(wholeScopeActionsEnabled = false, selected = setOf(selectedPath()))
+
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+
+        composeRule.scrollTo(inaccessibleLabel)
+        composeRule.onNode(hasClickAction() and hasText(inaccessibleLabel)).assertIsNotEnabled()
+
+        composeRule.scrollTo(categoryLabel)
+        composeRule.onNode(hasClickAction() and hasText(categoryLabel)).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `neighbour page affordances are gated even though it owns no selection`() {
+        // Pager neighbours render side by side but never take part in selection, so they get
+        // isCurrentPage=false while the screen-global gate still applies.
+        setPage(wholeScopeActionsEnabled = false, isCurrentPage = false)
+
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+
+        composeRule.scrollTo(categoryLabel)
+        composeRule.onNode(hasClickAction() and hasText(categoryLabel)).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `the category collapse toggle still fires through a gated card`() {
+        var toggles = 0
+        setPage(wholeScopeActionsEnabled = false, onToggleCollapse = { toggles++ })
+
+        composeRule.scrollTo(categoryLabel)
+        composeRule
+            .onNode(hasTestTag(AppJunkPageTags.CATEGORY_COLLAPSE), useUnmergedTree = true)
+            .performClick()
+
+        composeRule.runOnIdle { assertEquals(1, toggles) }
+    }
+}

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPageTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPageTest.kt
@@ -4,9 +4,9 @@ import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.hasScrollToNodeAction
-import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollToNode
@@ -103,9 +103,7 @@ class AppJunkPageTest : BaseComposeRobolectricTest() {
         setPage(wholeScopeActionsEnabled = false, onToggleCollapse = { toggles++ })
 
         composeRule.scrollTo(categoryLabel)
-        composeRule
-            .onNode(hasTestTag(AppJunkPageTags.CATEGORY_COLLAPSE), useUnmergedTree = true)
-            .performClick()
+        composeRule.onNodeWithTag(AppJunkPageTags.CATEGORY_COLLAPSE).performClick()
 
         composeRule.runOnIdle { assertEquals(1, toggles) }
     }

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsScreen.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsScreen.kt
@@ -178,6 +178,10 @@ internal fun CorpseDetailsScreen(
         selection.retainAll(currentIds)
     }
 
+    // Card actions act on the whole corpse, which is wider than any row selection, so they are gated
+    // screen-wide: adjacent pages stay visible in the pager once the span count exceeds one.
+    val wholeScopeActionsEnabled = !selection.isActive
+
     BackHandler(enabled = selection.isActive) { selection.clear() }
 
     SdmScaffold(
@@ -291,7 +295,8 @@ internal fun CorpseDetailsScreen(
                                 val corpse = items.getOrNull(page) ?: return@HorizontalPager
                                 CorpseContent(
                                     corpse = corpse,
-                                    selection = if (corpse.identifier == currentCorpse?.identifier) selection else null,
+                                    pageSelection = if (corpse.identifier == currentCorpse?.identifier) selection else null,
+                                    wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                                     onDeleteCorpseRequest = {
                                         pendingDelete = PendingDelete(
                                             corpseId = corpse.identifier,

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/content/CorpseContent.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/details/content/CorpseContent.kt
@@ -3,7 +3,6 @@ package eu.darken.sdmse.corpsefinder.ui.details.content
 import android.text.format.Formatter
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -16,12 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.DeleteSweep
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -37,9 +31,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.coil.FileListThumbnail
-import eu.darken.sdmse.common.compose.icons.SdmIcons
-import eu.darken.sdmse.common.compose.icons.ShieldAdd
 import eu.darken.sdmse.common.compose.icons.icon
+import eu.darken.sdmse.common.compose.layout.SdmWholeScopeActions
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.selection.SelectionState
@@ -57,7 +50,8 @@ import eu.darken.sdmse.corpsefinder.ui.preview.previewCorpse
 @Composable
 internal fun CorpseContent(
     corpse: Corpse,
-    selection: SelectionState<APath>?,
+    pageSelection: SelectionState<APath>?,
+    wholeScopeActionsEnabled: Boolean,
     onDeleteCorpseRequest: () -> Unit,
     onExcludeRequest: () -> Unit,
     onFileTap: (APathLookup<*>) -> Unit,
@@ -66,7 +60,7 @@ internal fun CorpseContent(
     val sortedContent = remember(corpse.identifier, corpse.content) {
         corpse.content.sortedByDescending { it.size }
     }
-    val selectionActive = selection?.isActive == true
+    val selectionActive = pageSelection?.isActive == true
     LazyColumn(
         modifier = modifier.fillMaxWidth(),
         contentPadding = PaddingValues(vertical = 8.dp),
@@ -74,25 +68,26 @@ internal fun CorpseContent(
         item(key = "header") {
             CorpseHeaderCard(
                 corpse = corpse,
+                wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                 onDeleteAll = onDeleteCorpseRequest,
                 onExclude = onExcludeRequest,
             )
         }
         items(sortedContent, key = { it.lookedUp.toString() }) { lookup ->
-            val isSelected = selection?.isSelected(lookup.lookedUp) == true
+            val isSelected = pageSelection?.isSelected(lookup.lookedUp) == true
             CorpseFileRow(
                 corpse = corpse,
                 lookup = lookup,
                 selected = isSelected,
                 selectionActive = selectionActive,
                 onClick = {
-                    if (selection != null && selection.isActive) {
-                        selection.toggle(lookup.lookedUp)
+                    if (pageSelection != null && pageSelection.isActive) {
+                        pageSelection.toggle(lookup.lookedUp)
                     } else {
                         onFileTap(lookup)
                     }
                 },
-                onLongClick = { selection?.select(lookup.lookedUp) },
+                onLongClick = { pageSelection?.select(lookup.lookedUp) },
             )
         }
     }
@@ -101,6 +96,7 @@ internal fun CorpseContent(
 @Composable
 private fun CorpseHeaderCard(
     corpse: Corpse,
+    wholeScopeActionsEnabled: Boolean,
     onDeleteAll: () -> Unit,
     onExclude: () -> Unit,
 ) {
@@ -199,28 +195,11 @@ private fun CorpseHeaderCard(
             }
 
             Spacer(Modifier.height(16.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                FilledTonalButton(
-                    onClick = onExclude,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Icon(SdmIcons.ShieldAdd, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(CommonR.string.general_exclude_action))
-                }
-                Button(
-                    onClick = onDeleteAll,
-                    modifier = Modifier.weight(1f),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.error,
-                        contentColor = MaterialTheme.colorScheme.onError,
-                    ),
-                ) {
-                    Icon(Icons.TwoTone.DeleteSweep, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(CommonR.string.general_delete_action))
-                }
-            }
+            SdmWholeScopeActions(
+                enabled = wholeScopeActionsEnabled,
+                onExclude = onExclude,
+                onDelete = onDeleteAll,
+            )
         }
     }
 }
@@ -276,7 +255,8 @@ private fun CorpseContentPreview() {
     PreviewWrapper {
         CorpseContent(
             corpse = previewCorpse(),
-            selection = null,
+            pageSelection = null,
+            wholeScopeActionsEnabled = true,
             onDeleteCorpseRequest = {},
             onExcludeRequest = {},
             onFileTap = {},
@@ -290,7 +270,8 @@ private fun CorpseContentKeeperPreview() {
     PreviewWrapper {
         CorpseContent(
             corpse = previewCorpse(riskLevel = RiskLevel.KEEPER),
-            selection = null,
+            pageSelection = null,
+            wholeScopeActionsEnabled = true,
             onDeleteCorpseRequest = {},
             onExcludeRequest = {},
             onFileTap = {},

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsScreenTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsScreenTest.kt
@@ -1,10 +1,19 @@
 package eu.darken.sdmse.corpsefinder.ui.details
 
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTouchInput
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.files.FileType
 import eu.darken.sdmse.corpsefinder.ui.preview.previewCorpse
 import eu.darken.sdmse.corpsefinder.ui.preview.previewLocalPathLookup
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -22,6 +31,13 @@ class CorpseDetailsScreenTest : BaseComposeRobolectricTest() {
                 CorpseDetailsScreen(stateSource = MutableStateFlow(state))
             }
         }
+    }
+
+    // The screen stacks three scrollables (tab strip, pager, page list); only the page list scrolls
+    // vertically, so match on that axis to stay unambiguous.
+    private fun ComposeContentTestRule.scrollTo(text: String) {
+        onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange))
+            .performScrollToNode(hasText(text))
     }
 
     @Test
@@ -79,5 +95,42 @@ class CorpseDetailsScreenTest : BaseComposeRobolectricTest() {
         )
 
         composeRule.onNodeWithText("tab-target.dat").assertExists()
+    }
+
+    @Test
+    fun `long-pressing a file row gates the header card actions`() {
+        // Drives the screen's own `!selection.isActive` computation instead of injecting the flag.
+        val corpseRoot = previewLocalPathLookup(
+            pathSegments = arrayOf("storage", "emulated", "0", "Android", "data", "gate.target"),
+        )
+        val onlyCorpse = previewCorpse(
+            lookup = corpseRoot,
+            content = listOf(
+                previewLocalPathLookup(
+                    pathSegments = arrayOf(
+                        "storage", "emulated", "0", "Android", "data", "gate.target", "gated.bin",
+                    ),
+                    fileType = FileType.FILE,
+                    size = 8L * 1024 * 1024,
+                ),
+            ),
+        )
+        composeRule.setDetailsScreen(
+            CorpseDetailsViewModel.State(
+                items = listOf(onlyCorpse),
+                target = onlyCorpse.identifier,
+            ),
+        )
+
+        composeRule.onNodeWithText("Exclude").assertIsEnabled()
+        composeRule.onNodeWithText("Delete").assertIsEnabled()
+
+        composeRule.scrollTo("gated.bin")
+        composeRule.onNodeWithText("gated.bin").performTouchInput { longClick() }
+
+        // The header card fills the viewport, so the file row is only reachable after a scroll.
+        composeRule.scrollTo("Exclude")
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
     }
 }

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsScreenTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/details/CorpseDetailsScreenTest.kt
@@ -18,6 +18,7 @@ import eu.darken.sdmse.corpsefinder.ui.preview.previewCorpse
 import eu.darken.sdmse.corpsefinder.ui.preview.previewLocalPathLookup
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Test
+import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
 
 // HorizontalPager + ScrollableTabRow are known to interact poorly with Robolectric for
@@ -37,6 +38,13 @@ class CorpseDetailsScreenTest : BaseComposeRobolectricTest() {
     // vertically, so match on that axis to stay unambiguous.
     private fun ComposeContentTestRule.scrollTo(text: String) {
         onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange))
+            .performScrollToNode(hasText(text))
+    }
+
+    // Same axis filter, but every rendered pager page contributes one vertical scrollable, so the
+    // page has to be addressed by index once more than one is on screen.
+    private fun ComposeContentTestRule.scrollPageTo(pageIndex: Int, text: String) {
+        onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange))[pageIndex]
             .performScrollToNode(hasText(text))
     }
 
@@ -132,5 +140,62 @@ class CorpseDetailsScreenTest : BaseComposeRobolectricTest() {
         composeRule.scrollTo("Exclude")
         composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
         composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+    }
+
+    @Test
+    @Config(qualifiers = "w720dp-h1024dp")
+    fun `on a wide viewport the gate covers the visible neighbour page too`() {
+        // spanCount is (screenWidthDp / 390 + 0.5).toInt(), so 720dp yields two pages side by side
+        // and the neighbour's header card is on screen while the first page owns the selection.
+        val focused = previewCorpse(
+            lookup = previewLocalPathLookup(
+                pathSegments = arrayOf("storage", "emulated", "0", "Android", "data", "focused.target"),
+            ),
+            content = listOf(
+                previewLocalPathLookup(
+                    pathSegments = arrayOf(
+                        "storage", "emulated", "0", "Android", "data", "focused.target", "focused.bin",
+                    ),
+                    fileType = FileType.FILE,
+                    size = 8L * 1024 * 1024,
+                ),
+            ),
+        )
+        val neighbour = previewCorpse(
+            lookup = previewLocalPathLookup(
+                pathSegments = arrayOf("storage", "emulated", "0", "Android", "data", "neighbour.target"),
+            ),
+            content = listOf(
+                previewLocalPathLookup(
+                    pathSegments = arrayOf(
+                        "storage", "emulated", "0", "Android", "data", "neighbour.target", "neighbour.bin",
+                    ),
+                    fileType = FileType.FILE,
+                    size = 4L * 1024 * 1024,
+                ),
+            ),
+        )
+        composeRule.setDetailsScreen(
+            CorpseDetailsViewModel.State(
+                items = listOf(focused, neighbour),
+                target = focused.identifier,
+            ),
+        )
+
+        composeRule.onAllNodesWithText("Exclude").assertCountEquals(2)
+        composeRule.onAllNodesWithText("Delete").assertCountEquals(2)
+
+        composeRule.scrollPageTo(0, "focused.bin")
+        composeRule.onNodeWithText("focused.bin").performTouchInput { longClick() }
+        composeRule.scrollPageTo(0, "Exclude")
+
+        // Both header cards must gate, not just the selection owner's: a page-scoped gate would
+        // leave the neighbour's whole-corpse Delete/Exclude live.
+        composeRule.onAllNodesWithText("Exclude").assertCountEquals(2)
+        composeRule.onAllNodesWithText("Delete").assertCountEquals(2)
+        repeat(2) { index ->
+            composeRule.onAllNodesWithText("Exclude")[index].assertIsNotEnabled()
+            composeRule.onAllNodesWithText("Delete")[index].assertIsNotEnabled()
+        }
     }
 }

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/details/content/CorpseContentTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/details/content/CorpseContentTest.kt
@@ -1,0 +1,65 @@
+package eu.darken.sdmse.corpsefinder.ui.details.content
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.compose.selection.SelectionState
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.corpsefinder.core.Corpse
+import eu.darken.sdmse.corpsefinder.ui.preview.previewCorpse
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class CorpseContentTest : BaseComposeRobolectricTest() {
+
+    private val corpse: Corpse = previewCorpse()
+
+    private fun setContent(
+        wholeScopeActionsEnabled: Boolean,
+        pageSelection: SelectionState<APath>?,
+    ) {
+        composeRule.setContent {
+            PreviewWrapper {
+                CorpseContent(
+                    corpse = corpse,
+                    pageSelection = pageSelection,
+                    wholeScopeActionsEnabled = wholeScopeActionsEnabled,
+                    onDeleteCorpseRequest = {},
+                    onExcludeRequest = {},
+                    onFileTap = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `header actions are live without a selection`() {
+        setContent(wholeScopeActionsEnabled = true, pageSelection = SelectionState())
+
+        composeRule.onNodeWithText("Exclude").assertIsEnabled()
+        composeRule.onNodeWithText("Delete").assertIsEnabled()
+    }
+
+    @Test
+    fun `header actions are gated while a selection is active`() {
+        val selected = corpse.content.first().lookedUp
+        setContent(
+            wholeScopeActionsEnabled = false,
+            pageSelection = SelectionState(initial = setOf(selected)),
+        )
+
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `neighbour page header actions are gated even though it owns no selection`() {
+        // Pager neighbours render side by side but are handed a null selection holder, so a
+        // page-local predicate would read as "nothing selected here" and leave them live.
+        setContent(wholeScopeActionsEnabled = false, pageSelection = null)
+
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+    }
+}

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsScreen.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsScreen.kt
@@ -279,6 +279,10 @@ internal fun DeduplicatorDetailsScreen(
         }
     }
 
+    // Card actions act on a whole cluster/directory/group, which is wider than any row selection,
+    // so they are gated screen-wide: adjacent pages stay visible in the pager.
+    val wholeScopeActionsEnabled = !selection.isActive
+
     BackHandler(enabled = selection.isActive) { selection.clear() }
 
     val tourController = LocalGuidedTourController.current
@@ -447,6 +451,7 @@ internal fun DeduplicatorDetailsScreen(
                                 collapsed = collapsedForCluster,
                                 selection = selection,
                                 selectionEnabled = cluster.identifier == currentCluster?.identifier,
+                                wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                                 onSelectionToggle = { id ->
                                     if (cluster.identifier != currentCluster?.identifier) return@ClusterContent
                                     if (selection.contains(id)) {

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterContent.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterContent.kt
@@ -30,11 +30,8 @@ import androidx.compose.material.icons.twotone.ExpandMore
 import androidx.compose.material.icons.twotone.Folder
 import androidx.compose.material.icons.twotone.GraphicEq
 import androidx.compose.material.icons.twotone.Visibility
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -43,9 +40,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -55,7 +54,7 @@ import eu.darken.sdmse.common.coil.FilePreviewImage
 import eu.darken.sdmse.common.compose.icons.ApproximatelyEqualBox
 import eu.darken.sdmse.common.compose.icons.CodeEqualBox
 import eu.darken.sdmse.common.compose.icons.SdmIcons
-import eu.darken.sdmse.common.compose.icons.ShieldAdd
+import eu.darken.sdmse.common.compose.layout.SdmWholeScopeActions
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.selection.SelectionState
@@ -74,6 +73,13 @@ import eu.darken.sdmse.deduplicator.ui.preview.previewMediaGroup
 import eu.darken.sdmse.deduplicator.ui.preview.previewPHashGroup
 import kotlin.math.roundToLong
 
+/** Material's disabled-content alpha, applied by hand where explicit colours bypass the theme. */
+private const val DisabledContentAlpha = 0.38f
+
+internal object ClusterContentTags {
+    const val DIRECTORY_COLLAPSE = "cluster_directory_collapse"
+}
+
 @Composable
 internal fun ClusterContent(
     cluster: Duplicate.Cluster,
@@ -81,6 +87,7 @@ internal fun ClusterContent(
     collapsed: Set<DirectoryGroup.Id>,
     selection: SelectionState<Duplicate.Id>,
     selectionEnabled: Boolean,
+    wholeScopeActionsEnabled: Boolean,
     onSelectionToggle: (Duplicate.Id) -> Unit,
     onSelectionLongPress: (Duplicate.Id) -> Unit,
     onCollapseToggle: (DirectoryGroup.Id) -> Unit,
@@ -109,6 +116,7 @@ internal fun ClusterContent(
             when (element) {
                 is ClusterElement.ClusterHeader -> ClusterHeaderRow(
                     cluster = element.cluster,
+                    wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                     onDelete = onClusterDelete,
                     onExclude = onClusterExclude,
                     tourModifier = if (applyClusterHeaderTourTarget) {
@@ -121,6 +129,7 @@ internal fun ClusterContent(
                 is ClusterElement.DirectoryHeader -> DirectoryHeaderRow(
                     group = element.group,
                     isCollapsed = element.isCollapsed,
+                    wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                     onCollapseToggle = { onCollapseToggle(element.group.identifier) },
                     onDeleteAll = { onDirectoryDeleteAll(element.group) },
                 )
@@ -128,6 +137,7 @@ internal fun ClusterContent(
                 is ClusterElement.GroupHeader -> GroupHeaderCard(
                     group = element.group,
                     willBeDeleted = element.willBeDeleted,
+                    wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                     onDelete = { onGroupDelete(element.group.identifier) },
                     onView = { onGroupView(element.group, 0) },
                 )
@@ -197,6 +207,7 @@ internal fun ClusterContent(
 @Composable
 private fun ClusterHeaderRow(
     cluster: Duplicate.Cluster,
+    wholeScopeActionsEnabled: Boolean,
     onDelete: () -> Unit,
     onExclude: () -> Unit,
     tourModifier: Modifier = Modifier,
@@ -262,28 +273,11 @@ private fun ClusterHeaderRow(
                 }
             }
             Spacer(Modifier.height(16.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                FilledTonalButton(
-                    onClick = onExclude,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Icon(SdmIcons.ShieldAdd, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(CommonR.string.general_exclude_action))
-                }
-                Button(
-                    onClick = onDelete,
-                    modifier = Modifier.weight(1f),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.error,
-                        contentColor = MaterialTheme.colorScheme.onError,
-                    ),
-                ) {
-                    Icon(Icons.TwoTone.DeleteSweep, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(CommonR.string.general_delete_action))
-                }
-            }
+            SdmWholeScopeActions(
+                enabled = wholeScopeActionsEnabled,
+                onExclude = onExclude,
+                onDelete = onDelete,
+            )
         }
     }
 }
@@ -292,15 +286,20 @@ private fun ClusterHeaderRow(
 private fun DirectoryHeaderRow(
     group: DirectoryGroup,
     isCollapsed: Boolean,
+    wholeScopeActionsEnabled: Boolean,
     onCollapseToggle: () -> Unit,
     onDeleteAll: () -> Unit,
 ) {
     val context = LocalContext.current
+    // The row sets a custom container colour and explicit content colours, neither of which
+    // Card(enabled = false) can dim. The collapse toggle stays outside the dimmed scope.
+    val contentAlpha = if (wholeScopeActionsEnabled) 1f else DisabledContentAlpha
     Card(
         onClick = onDeleteAll,
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 8.dp, vertical = 2.dp),
+        enabled = wholeScopeActionsEnabled,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceContainerHigh),
     ) {
         Row(
@@ -312,11 +311,17 @@ private fun DirectoryHeaderRow(
             Icon(
                 imageVector = Icons.TwoTone.Folder,
                 contentDescription = null,
-                modifier = Modifier.size(24.dp),
+                modifier = Modifier
+                    .size(24.dp)
+                    .alpha(contentAlpha),
                 tint = MaterialTheme.colorScheme.onSurface,
             )
             Spacer(Modifier.width(12.dp))
-            Column(modifier = Modifier.weight(1f)) {
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .alpha(contentAlpha),
+            ) {
                 Text(
                     text = group.parentSegments.joinSegments(),
                     style = MaterialTheme.typography.bodyMedium,
@@ -330,7 +335,10 @@ private fun DirectoryHeaderRow(
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            IconButton(onClick = onCollapseToggle) {
+            IconButton(
+                onClick = onCollapseToggle,
+                modifier = Modifier.testTag(ClusterContentTags.DIRECTORY_COLLAPSE),
+            ) {
                 Icon(
                     imageVector = if (isCollapsed) Icons.TwoTone.ExpandMore else Icons.TwoTone.ExpandLess,
                     contentDescription = null,
@@ -344,6 +352,7 @@ private fun DirectoryHeaderRow(
 private fun GroupHeaderCard(
     group: Duplicate.Group,
     willBeDeleted: Boolean,
+    wholeScopeActionsEnabled: Boolean,
     onDelete: () -> Unit,
     onView: () -> Unit,
 ) {
@@ -420,11 +429,20 @@ private fun GroupHeaderCard(
                     )
                     Spacer(Modifier.width(4.dp))
                 }
-                IconButton(onClick = onDelete) {
+                IconButton(
+                    onClick = onDelete,
+                    enabled = wholeScopeActionsEnabled,
+                ) {
                     Icon(
                         imageVector = Icons.TwoTone.Delete,
                         contentDescription = stringResource(CommonR.string.general_delete_action),
-                        tint = MaterialTheme.colorScheme.error,
+                        // An explicit tint bypasses LocalContentColor, the only channel a disabled
+                        // IconButton uses to signal its state.
+                        tint = if (wholeScopeActionsEnabled) {
+                            MaterialTheme.colorScheme.error
+                        } else {
+                            MaterialTheme.colorScheme.onSurface.copy(alpha = DisabledContentAlpha)
+                        },
                     )
                 }
             }
@@ -617,6 +635,7 @@ private fun ClusterContentChecksumPreview() {
             collapsed = emptySet(),
             selection = SelectionState(),
             selectionEnabled = true,
+            wholeScopeActionsEnabled = true,
             onSelectionToggle = {},
             onSelectionLongPress = {},
             onCollapseToggle = {},
@@ -641,6 +660,7 @@ private fun ClusterContentImagePreview() {
             collapsed = emptySet(),
             selection = SelectionState(),
             selectionEnabled = true,
+            wholeScopeActionsEnabled = true,
             onSelectionToggle = {},
             onSelectionLongPress = {},
             onCollapseToggle = {},
@@ -665,6 +685,7 @@ private fun ClusterContentDirectoryPreview() {
             collapsed = emptySet(),
             selection = SelectionState(),
             selectionEnabled = true,
+            wholeScopeActionsEnabled = true,
             onSelectionToggle = {},
             onSelectionLongPress = {},
             onCollapseToggle = {},

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsScreenTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/DeduplicatorDetailsScreenTest.kt
@@ -1,10 +1,18 @@
 package eu.darken.sdmse.deduplicator.ui.details
 
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performScrollToNode
+import androidx.compose.ui.test.performTouchInput
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.tour.GuidedTourController
 import eu.darken.sdmse.common.compose.tour.LocalGuidedTourController
@@ -57,6 +65,13 @@ class DeduplicatorDetailsScreenTest : BaseComposeRobolectricTest() {
                 }
             }
         }
+    }
+
+    // The screen stacks three scrollables (tab strip, pager, cluster list); only the cluster list
+    // scrolls vertically, so match on that axis to stay unambiguous.
+    private fun ComposeContentTestRule.scrollTo(text: String) {
+        onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.VerticalScrollAxisRange))
+            .performScrollToNode(hasText(text))
     }
 
     @Test
@@ -117,5 +132,30 @@ class DeduplicatorDetailsScreenTest : BaseComposeRobolectricTest() {
         )
 
         composeRule.onNodeWithText("can be freed", substring = true).assertExists()
+    }
+
+    @Test
+    fun `long-pressing a duplicate row gates the cluster card actions`() {
+        // Drives the screen's own `!selection.isActive` computation instead of injecting the flag.
+        val onlyCluster = cluster("gate", dupeNames = listOf("target", "target-copy"))
+        composeRule.setDetailsScreen(
+            DeduplicatorDetailsViewModel.State(
+                items = listOf(onlyCluster),
+                target = onlyCluster.identifier,
+                progress = null,
+            ),
+        )
+
+        // Only the cluster header card renders "Exclude"/"Delete" as text; the group card's delete
+        // is an icon carrying a content description.
+        composeRule.onNodeWithText("Exclude").assertIsEnabled()
+        composeRule.onNodeWithText("Delete").assertIsEnabled()
+
+        composeRule.scrollTo("gate-target.jpg")
+        composeRule.onNodeWithText("gate-target.jpg").performTouchInput { longClick() }
+
+        composeRule.scrollTo("Exclude")
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
     }
 }

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterContentTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/details/cluster/ClusterContentTest.kt
@@ -1,0 +1,134 @@
+package eu.darken.sdmse.deduplicator.ui.details.cluster
+
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasContentDescription
+import androidx.compose.ui.test.hasScrollToNodeAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollToNode
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.compose.selection.SelectionState
+import eu.darken.sdmse.deduplicator.core.Duplicate
+import eu.darken.sdmse.deduplicator.ui.preview.previewChecksumGroup
+import eu.darken.sdmse.deduplicator.ui.preview.previewCluster
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class ClusterContentTest : BaseComposeRobolectricTest() {
+
+    private val cluster: Duplicate.Cluster = previewCluster(groups = setOf(previewChecksumGroup()))
+
+    // Every preview duplicate lives in the same folder, so directory view renders exactly one header.
+    private val directoryLabel = "/storage/emulated/0/Pictures"
+
+    private fun setContent(
+        wholeScopeActionsEnabled: Boolean,
+        isDirectoryView: Boolean = false,
+        selectionEnabled: Boolean = true,
+        onCollapseToggle: () -> Unit = {},
+    ) {
+        composeRule.setContent {
+            PreviewWrapper {
+                ClusterContent(
+                    cluster = cluster,
+                    isDirectoryView = isDirectoryView,
+                    collapsed = emptySet(),
+                    selection = SelectionState(),
+                    selectionEnabled = selectionEnabled,
+                    wholeScopeActionsEnabled = wholeScopeActionsEnabled,
+                    onSelectionToggle = {},
+                    onSelectionLongPress = {},
+                    onCollapseToggle = { onCollapseToggle() },
+                    onClusterDelete = {},
+                    onClusterExclude = {},
+                    onGroupDelete = {},
+                    onGroupView = { _, _ -> },
+                    onDuplicateDelete = {},
+                    onDuplicatePreview = {},
+                    onDirectoryDeleteAll = {},
+                )
+            }
+        }
+    }
+
+    private fun ComposeContentTestRule.scrollTo(matcher: SemanticsMatcher) {
+        onNode(hasScrollToNodeAction()).performScrollToNode(matcher)
+    }
+
+    @Test
+    fun `cluster and group actions are live without a selection`() {
+        setContent(wholeScopeActionsEnabled = true)
+
+        composeRule.onNodeWithText("Exclude").assertIsEnabled()
+        composeRule.onNodeWithText("Delete").assertIsEnabled()
+
+        composeRule.scrollTo(hasContentDescription("Delete"))
+        composeRule.onNodeWithContentDescription("Delete").assertIsEnabled()
+    }
+
+    @Test
+    fun `cluster and group actions are gated while a selection is active`() {
+        setContent(wholeScopeActionsEnabled = false)
+
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+
+        composeRule.scrollTo(hasContentDescription("Delete"))
+        composeRule.onNodeWithContentDescription("Delete").assertIsNotEnabled()
+        // Viewing a group is navigation, not destruction, so it stays available.
+        composeRule.onNodeWithContentDescription("View").assertIsEnabled()
+    }
+
+    @Test
+    fun `neighbour page actions are gated even though it owns no selection`() {
+        // Pager neighbours render side by side but never take part in selection, so they get
+        // selectionEnabled=false while the screen-global gate still applies.
+        setContent(wholeScopeActionsEnabled = false, selectionEnabled = false)
+
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+
+        composeRule.scrollTo(hasContentDescription("Delete"))
+        composeRule.onNodeWithContentDescription("Delete").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `directory header is live without a selection`() {
+        setContent(wholeScopeActionsEnabled = true, isDirectoryView = true)
+
+        composeRule.scrollTo(hasText(directoryLabel))
+        composeRule.onNode(hasClickAction() and hasText(directoryLabel)).assertIsEnabled()
+    }
+
+    @Test
+    fun `directory header is gated while a selection is active`() {
+        setContent(wholeScopeActionsEnabled = false, isDirectoryView = true)
+
+        composeRule.scrollTo(hasText(directoryLabel))
+        composeRule.onNode(hasClickAction() and hasText(directoryLabel)).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `the directory collapse toggle still fires through a gated header`() {
+        var toggles = 0
+        setContent(
+            wholeScopeActionsEnabled = false,
+            isDirectoryView = true,
+            onCollapseToggle = { toggles++ },
+        )
+
+        composeRule.scrollTo(hasTestTag(ClusterContentTags.DIRECTORY_COLLAPSE))
+        composeRule.onNodeWithTag(ClusterContentTags.DIRECTORY_COLLAPSE).performClick()
+
+        composeRule.runOnIdle { assertEquals(1, toggles) }
+    }
+}

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsScreen.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsScreen.kt
@@ -188,6 +188,10 @@ internal fun FilterContentDetailsScreen(
         selection.retainAll(currentPaths)
     }
 
+    // Card actions act on the whole filter, which is wider than any row selection, so they are gated
+    // screen-wide: adjacent pages stay visible in the pager once the span count exceeds one.
+    val wholeScopeActionsEnabled = !selection.isActive
+
     BackHandler(enabled = selection.isActive) { selection.clear() }
 
     SdmScaffold(
@@ -273,6 +277,7 @@ internal fun FilterContentDetailsScreen(
                                     filterContent = filterContent,
                                     selection = selection,
                                     selectionEnabled = filterContent.identifier == currentFilter?.identifier,
+                                    wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                                     onDeleteFilterRequest = {
                                         pendingDelete = PendingFilterDelete(
                                             filterId = filterContent.identifier,

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/page/FilterContentPage.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/ui/details/page/FilterContentPage.kt
@@ -3,7 +3,6 @@ package eu.darken.sdmse.systemcleaner.ui.details.page
 import android.text.format.Formatter
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -16,12 +15,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.twotone.DeleteSweep
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -39,8 +33,7 @@ import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.coil.FileListThumbnail
 import eu.darken.sdmse.common.coil.canAttemptFilePreview
-import eu.darken.sdmse.common.compose.icons.SdmIcons
-import eu.darken.sdmse.common.compose.icons.ShieldAdd
+import eu.darken.sdmse.common.compose.layout.SdmWholeScopeActions
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.compose.selection.SelectionState
@@ -58,6 +51,7 @@ internal fun FilterContentPage(
     filterContent: FilterContent,
     selection: SelectionState<APath>,
     selectionEnabled: Boolean,
+    wholeScopeActionsEnabled: Boolean,
     onDeleteFilterRequest: () -> Unit,
     onExcludeFilterRequest: () -> Unit,
     onFileTap: (FilterContentElement.FileRow) -> Unit,
@@ -73,6 +67,7 @@ internal fun FilterContentPage(
         item(key = "header") {
             FilterContentHeaderCard(
                 filterContent = filterContent,
+                wholeScopeActionsEnabled = wholeScopeActionsEnabled,
                 onDeleteAll = onDeleteFilterRequest,
                 onExclude = onExcludeFilterRequest,
             )
@@ -104,6 +99,7 @@ internal fun FilterContentPage(
 @Composable
 private fun FilterContentHeaderCard(
     filterContent: FilterContent,
+    wholeScopeActionsEnabled: Boolean,
     onDeleteAll: () -> Unit,
     onExclude: () -> Unit,
 ) {
@@ -166,28 +162,11 @@ private fun FilterContentHeaderCard(
             }
 
             Spacer(Modifier.height(16.dp))
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                FilledTonalButton(
-                    onClick = onExclude,
-                    modifier = Modifier.weight(1f),
-                ) {
-                    Icon(SdmIcons.ShieldAdd, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(CommonR.string.general_exclude_action))
-                }
-                Button(
-                    onClick = onDeleteAll,
-                    modifier = Modifier.weight(1f),
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.error,
-                        contentColor = MaterialTheme.colorScheme.onError,
-                    ),
-                ) {
-                    Icon(Icons.TwoTone.DeleteSweep, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text(stringResource(CommonR.string.general_delete_action))
-                }
-            }
+            SdmWholeScopeActions(
+                enabled = wholeScopeActionsEnabled,
+                onExclude = onExclude,
+                onDelete = onDeleteAll,
+            )
         }
     }
 }
@@ -265,6 +244,7 @@ private fun FilterContentPagePreview() {
             filterContent = previewFilterContent(),
             selection = rememberSelectionState(),
             selectionEnabled = true,
+            wholeScopeActionsEnabled = true,
             onDeleteFilterRequest = {},
             onExcludeFilterRequest = {},
             onFileTap = {},

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsScreenTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsScreenTest.kt
@@ -1,9 +1,13 @@
 package eu.darken.sdmse.systemcleaner.ui.details
 
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
+import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.systemcleaner.ui.preview.previewFilterContent
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -72,5 +76,25 @@ class FilterContentDetailsScreenTest : BaseComposeRobolectricTest() {
         )
 
         composeRule.onNodeWithText("Custom description text in header.").assertExists()
+    }
+
+    @Test
+    fun `long-pressing a file row gates the header card actions`() {
+        // Drives the screen's own `!selection.isActive` computation instead of injecting the flag.
+        val fc = previewFilterContent(identifier = "fc-gate", label = "Gate me")
+        composeRule.setDetailsScreen(
+            FilterContentDetailsViewModel.State(
+                items = listOf(fc),
+                target = fc.identifier,
+            ),
+        )
+
+        composeRule.onNodeWithText("Exclude").assertIsEnabled()
+        composeRule.onNodeWithText("Delete").assertIsEnabled()
+
+        composeRule.onNodeWithText(fc.items.first().path.path).performTouchInput { longClick() }
+
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
     }
 }

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsScreenTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/details/FilterContentDetailsScreenTest.kt
@@ -10,8 +10,10 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTouchInput
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.systemcleaner.ui.preview.previewFilterContent
+import eu.darken.sdmse.systemcleaner.ui.preview.previewFilterItems
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Test
+import org.robolectric.annotation.Config
 import testhelpers.compose.BaseComposeRobolectricTest
 
 // HorizontalPager + ScrollableTabRow are known to interact poorly with Robolectric for
@@ -96,5 +98,38 @@ class FilterContentDetailsScreenTest : BaseComposeRobolectricTest() {
 
         composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
         composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+    }
+
+    @Test
+    @Config(qualifiers = "w720dp-h1024dp")
+    fun `on a wide viewport the gate covers the visible neighbour page too`() {
+        // spanCount is (screenWidthDp / 390 + 0.5).toInt(), so 720dp yields two pages side by side
+        // and the neighbour's header card is on screen while the first page owns the selection.
+        val focused = previewFilterContent(identifier = "fc-focused", label = "Focused")
+        val neighbour = previewFilterContent(
+            identifier = "fc-neighbour",
+            label = "Neighbour",
+            items = previewFilterItems(itemCount = 2, totalSize = 4L * 1024 * 1024),
+        )
+        composeRule.setDetailsScreen(
+            FilterContentDetailsViewModel.State(
+                items = listOf(focused, neighbour),
+                target = focused.identifier,
+            ),
+        )
+
+        composeRule.onAllNodesWithText("Exclude").assertCountEquals(2)
+        composeRule.onAllNodesWithText("Delete").assertCountEquals(2)
+
+        composeRule.onNodeWithText(focused.items.first().path.path).performTouchInput { longClick() }
+
+        // Both header cards must gate, not just the selection owner's: a page-scoped gate would
+        // leave the neighbour's whole-filter Delete/Exclude live.
+        composeRule.onAllNodesWithText("Exclude").assertCountEquals(2)
+        composeRule.onAllNodesWithText("Delete").assertCountEquals(2)
+        repeat(2) { index ->
+            composeRule.onAllNodesWithText("Exclude")[index].assertIsNotEnabled()
+            composeRule.onAllNodesWithText("Delete")[index].assertIsNotEnabled()
+        }
     }
 }

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/details/page/FilterContentPageTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/ui/details/page/FilterContentPageTest.kt
@@ -1,0 +1,70 @@
+package eu.darken.sdmse.systemcleaner.ui.details.page
+
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.compose.selection.SelectionState
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.systemcleaner.core.FilterContent
+import eu.darken.sdmse.systemcleaner.ui.preview.previewFilterContent
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class FilterContentPageTest : BaseComposeRobolectricTest() {
+
+    private val filterContent: FilterContent = previewFilterContent()
+
+    private fun setPage(
+        wholeScopeActionsEnabled: Boolean,
+        selectionEnabled: Boolean = true,
+        selected: Set<APath> = emptySet(),
+    ) {
+        composeRule.setContent {
+            PreviewWrapper {
+                FilterContentPage(
+                    filterContent = filterContent,
+                    selection = SelectionState(initial = selected),
+                    selectionEnabled = selectionEnabled,
+                    wholeScopeActionsEnabled = wholeScopeActionsEnabled,
+                    onDeleteFilterRequest = {},
+                    onExcludeFilterRequest = {},
+                    onFileTap = {},
+                    onPreviewFile = {},
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `header actions are live without a selection`() {
+        setPage(wholeScopeActionsEnabled = true)
+
+        composeRule.onNodeWithText("Exclude").assertIsEnabled()
+        composeRule.onNodeWithText("Delete").assertIsEnabled()
+    }
+
+    @Test
+    fun `header actions are gated while a selection is active`() {
+        setPage(
+            wholeScopeActionsEnabled = false,
+            selected = setOf(filterContent.items.first().path),
+        )
+
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+    }
+
+    @Test
+    fun `neighbour page header actions are gated even though it owns no selection`() {
+        // Pager neighbours render side by side but never take part in selection, so they get
+        // selectionEnabled=false while the screen-global gate still applies.
+        setPage(
+            wholeScopeActionsEnabled = false,
+            selectionEnabled = false,
+        )
+
+        composeRule.onNodeWithText("Exclude").assertIsNotEnabled()
+        composeRule.onNodeWithText("Delete").assertIsNotEnabled()
+    }
+}


### PR DESCRIPTION
## What changed

On the details screens for SystemCleaner, AppCleaner, CorpseFinder and Deduplicator, the Delete and Exclude buttons on a card act on everything that card covers, not on the items you picked. They stayed tappable while you were selecting individual entries, so selecting a few files and then pressing the card's Delete removed the whole lot.

That is what #2731 ran into: three of five empty folders were selected, the card's Delete was pressed, and all five disappeared.

Those card actions are now disabled while a selection is active, in all four tools. The selection's own Delete and Exclude in the top bar are unchanged and remain the way to act on what you picked. Controls that don't delete anything keep working while you select: collapsing a category or directory, viewing a duplicate group, and file previews. Tapping individual files behaves as before.

This covers every card action that reaches wider than the selection, not only the button from the report. AppCleaner's per-category card and its inaccessible-cache card are included, as are Deduplicator's directory-group and per-group deletes.

Known limitation: the disabled cards are dimmed, and dimming is a visual property the automated UI tests cannot assert. The disabled appearance is therefore unverified by automation.

## Technical Context

- Root cause: these card actions submit a whole-scope task. SystemCleaner's carries `targetContent = null`, which the executor reads as "every item this filter matched". Nothing gated them on selection state, and they have been ungated since the Compose conversion in 82e739639, so this is not a regression from a later change.
- The gate is a `wholeScopeActionsEnabled` parameter with no default, computed once per screen and threaded down to the leaf composables. It is deliberately screen-global rather than page-local: these pagers render adjacent pages side by side from roughly 585dp width while row selection stays scoped to the focused page, so a page-local predicate leaves a visible neighbour's card actions live. CorpseFinder makes that concrete, since it passes a null selection holder to neighbour pages.
- Worth close review: this also extracts the Exclude/Delete button row, which was near-identical in four header cards, into a shared `SdmWholeScopeActions`. Bundling it with the fix was a deliberate call against the advice to split it out, so reviewing this includes checking that the four header cards still render identically in their normal enabled state, not only that the gate works.
- The three cards whose whole surface is the delete target set explicit content colours that Material's `Card(enabled = false)` cannot dim, so their content is dimmed explicitly. The nested collapse toggles sit outside that dimmed scope on purpose, so they still read as usable. Deduplicator's group-delete icon had an explicit error tint that likewise bypassed the disabled colour, and it now follows the gate.
- Deduplicator is intentionally left out of the wide-viewport regression tests: its pager sets no page size, so it has no stationary side-by-side neighbour for that failure mode to occur on.

Closes #2731
