### PR TITLE
General: Stop keeping cleanup history when retention is set to zero

### DIFF
--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/StatsRepo.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/StatsRepo.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.withContext
+import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -95,7 +96,32 @@ class StatsRepo @Inject constructor(
             affectedSpace = reportDetails?.affectedSpace,
             extra = null,
         )
-        reportsDatabase.addReport(report)
+        val reportsRetention = statsSettings.retentionReports.value()
+        if (reportsRetention <= Duration.ZERO) {
+            log(TAG) { "report(${task.id}): Retention for reports is $reportsRetention, not storing it" }
+        } else {
+            val pathsRetention = statsSettings.retentionPaths.value()
+            reportsDatabase.withTransaction {
+                reportsDatabase.addReport(report)
+
+                (reportDetails as? ReportDetails.AffectedPaths)?.let { pathsReport ->
+                    if (pathsRetention <= Duration.ZERO) {
+                        log(TAG) { "report(${task.id}): Retention for affected files is $pathsRetention, skipping" }
+                    } else {
+                        log(TAG) { "report(${task.id}): Saving details about ${pathsReport.affectedPaths.size} files" }
+                        val affectedPaths = pathsReport.affectedPaths
+                            .map { it.toAffectedPath(report.reportId, pathsReport.action) }
+                        reportsDatabase.addPaths(affectedPaths)
+                    }
+                }
+
+                reportDetails?.affectedPkgs?.let { pkgs ->
+                    log(TAG) { "report(${task.id}): Saving details about affected pkgs: ${pkgs.size}" }
+                    val affectedPkgs = pkgs.toAffectedPkgs(report.reportId)
+                    reportsDatabase.addPkgs(affectedPkgs)
+                }
+            }
+        }
 
         report.affectedSpace?.let { affected ->
             log(TAG) { "report(${task.id}): Saving details about affected space: $affected" }
@@ -106,17 +132,7 @@ class StatsRepo @Inject constructor(
             statsSettings.totalItemsProcessed.update { it + affected }
         }
 
-        (reportDetails as? ReportDetails.AffectedPaths)?.let { pathsReport ->
-            log(TAG) { "report(${task.id}): Saving details about affected ${pathsReport.affectedPaths.size} files " }
-            val affectedPaths = pathsReport.affectedPaths.map { it.toAffectedPath(report.reportId, pathsReport.action) }
-            reportsDatabase.addPaths(affectedPaths)
-        }
-
-        reportDetails?.affectedPkgs?.let { pkgs ->
-            log(TAG) { "report(${task.id}): Saving details about affected pkgs: ${pkgs.size}" }
-            val affectedPkgs = pkgs.toAffectedPkgs(report.reportId)
-            reportsDatabase.addPkgs(affectedPkgs)
-        }
+        reportsDatabase.applyRetention()
     }
 
     suspend fun recordSnapshot(force: Boolean = false) {

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/AffectedPathsDao.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/AffectedPathsDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.Query
 import eu.darken.sdmse.stats.core.ReportId
 import kotlinx.coroutines.flow.Flow
+import java.time.Instant
 
 @Dao
 interface AffectedPathsDao {
@@ -21,6 +22,9 @@ interface AffectedPathsDao {
     @Insert
     fun insert(files: List<AffectedPathEntity>)
 
-    @Query("DELETE FROM affected_paths WHERE report_id IN (:reportIds)")
-    fun delete(reportIds: List<ReportId>)
+    @Query("DELETE FROM affected_paths WHERE report_id IN (SELECT report_id FROM reports WHERE end_at < :cutOff)")
+    fun deleteForReportsOlderThan(cutOff: Instant): Int
+
+    @Query("DELETE FROM affected_paths WHERE report_id NOT IN (SELECT report_id FROM reports)")
+    fun deleteOrphans(): Int
 }

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/AffectedPathsDao.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/AffectedPathsDao.kt
@@ -16,9 +16,6 @@ interface AffectedPathsDao {
     @Query("SELECT * FROM affected_paths")
     fun waterfall(): Flow<List<AffectedPathEntity>>
 
-    @Query("SELECT COUNT(*) FROM affected_paths")
-    fun filesCount(): Flow<Int>
-
     @Insert
     fun insert(files: List<AffectedPathEntity>)
 

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/AffectedPkgsDao.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/AffectedPkgsDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.Query
 import eu.darken.sdmse.stats.core.ReportId
 import kotlinx.coroutines.flow.Flow
+import java.time.Instant
 
 @Dao
 interface AffectedPkgsDao {
@@ -21,6 +22,9 @@ interface AffectedPkgsDao {
     @Insert
     fun insert(files: List<AffectedPkgEntity>)
 
-    @Query("DELETE FROM affected_pkgs WHERE report_id IN (:reportIds)")
-    fun delete(reportIds: List<ReportId>)
+    @Query("DELETE FROM affected_pkgs WHERE report_id IN (SELECT report_id FROM reports WHERE end_at < :cutOff)")
+    fun deleteForReportsOlderThan(cutOff: Instant): Int
+
+    @Query("DELETE FROM affected_pkgs WHERE report_id NOT IN (SELECT report_id FROM reports)")
+    fun deleteOrphans(): Int
 }

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/ReportsDao.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/ReportsDao.kt
@@ -23,11 +23,8 @@ interface ReportsDao {
     @Insert
     fun insert(entity: ReportEntity)
 
-    @Query("SELECT * FROM reports WHERE end_at < :cutOff")
-    fun getReportsOlderThan(cutOff: Instant): List<ReportEntity>
-
-    @Query("DELETE FROM reports WHERE report_id IN (:ids)")
-    fun delete(ids: List<ReportId>)
+    @Query("DELETE FROM reports WHERE end_at < :cutOff")
+    fun deleteOlderThan(cutOff: Instant): Int
 
     @Query("SELECT * FROM reports WHERE end_at >= :since AND status IN ('SUCCESS', 'PARTIAL_SUCCESS') ORDER BY end_at ASC")
     fun getReportsSince(since: Instant): Flow<List<ReportEntity>>

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/ReportsDatabase.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/ReportsDatabase.kt
@@ -20,6 +20,7 @@ import eu.darken.sdmse.stats.core.AffectedPkg
 import eu.darken.sdmse.stats.core.Report
 import eu.darken.sdmse.stats.core.ReportId
 import eu.darken.sdmse.stats.core.StatsSettings
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -120,6 +121,8 @@ class ReportsDatabase @Inject constructor(
         try {
             pruneReports(statsSettings.retentionReports.value())
             pruneAffectedPaths(statsSettings.retentionPaths.value())
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             log(TAG, ERROR) { "applyRetention() failed: ${e.asLog()}" }
         }
@@ -130,6 +133,8 @@ class ReportsDatabase @Inject constructor(
             .onEach { retention ->
                 try {
                     pruneReports(retention)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "Failed to clean up reports: ${e.asLog()}" }
                 }
@@ -140,6 +145,8 @@ class ReportsDatabase @Inject constructor(
             .onEach { retention ->
                 try {
                     pruneAffectedPaths(retention)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "Failed to clean up affected files: ${e.asLog()}" }
                 }

--- a/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/ReportsDatabase.kt
+++ b/app-common-stats/src/main/java/eu/darken/sdmse/stats/core/db/ReportsDatabase.kt
@@ -7,6 +7,7 @@ import androidx.room.withTransaction
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
 import eu.darken.sdmse.common.debug.logging.asLog
@@ -26,12 +27,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -84,54 +84,66 @@ class ReportsDatabase @Inject constructor(
     internal val spaceSnapshotDao: SpaceSnapshotDao
         get() = database.spaceSnapshots()
 
+    private suspend fun pruneReports(retention: Duration) {
+        log(TAG, INFO) { "Retention for reports is $retention" }
+        val cutOff = Instant.now() - retention
+
+        val deleted = database.withTransaction {
+            val paths = pathsDao.deleteForReportsOlderThan(cutOff)
+            val pkgs = pkgsDao.deleteForReportsOlderThan(cutOff)
+            val reports = reportsDao.deleteOlderThan(cutOff)
+            val orphanedPaths = pathsDao.deleteOrphans()
+            val orphanedPkgs = pkgsDao.deleteOrphans()
+            log(TAG) {
+                "Clean up of reports older than $cutOff finished: $reports reports, " +
+                        "$paths paths ($orphanedPaths orphaned), $pkgs pkgs ($orphanedPkgs orphaned)"
+            }
+            reports + paths + pkgs + orphanedPaths + orphanedPkgs
+        }
+
+        if (deleted > 0) databaseSize.value = getDatabaseSize()
+    }
+
+    private suspend fun pruneAffectedPaths(retention: Duration) {
+        log(TAG, INFO) { "Retention for affected files is $retention" }
+        val cutOff = Instant.now() - retention
+
+        val deleted = database.withTransaction { pathsDao.deleteForReportsOlderThan(cutOff) }
+        log(TAG) { "Clean up of stale file infos finished, deleted $deleted" }
+
+        if (deleted > 0) databaseSize.value = getDatabaseSize()
+    }
+
+    /** Sweeps expired data now, instead of waiting for the retention settings to emit again. */
+    suspend fun applyRetention() = withContext(dispatcherProvider.IO) {
+        log(TAG) { "applyRetention()" }
+        try {
+            pruneReports(statsSettings.retentionReports.value())
+            pruneAffectedPaths(statsSettings.retentionPaths.value())
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "applyRetention() failed: ${e.asLog()}" }
+        }
+    }
+
     init {
         statsSettings.retentionReports.flow
-            .mapNotNull { retention ->
-                log(TAG, INFO) { "Retention for reports is $retention" }
-                reportsDao.getReportsOlderThan(Instant.now() - retention).takeIf { it.isNotEmpty() }
-            }
-            .map { reports -> reports.map { it.reportId } }
-            .onEach { oldReportIds ->
-                var updateSize = false
-                run {
-                    val beforeCount = reportsDao.reportCount().first()
-                    log(TAG) { "Deleting old reports (${oldReportIds.size})" }
-                    reportsDao.delete(oldReportIds)
-                    val deleted = beforeCount - reportsDao.reportCount().first()
-                    log(TAG) { "Clean up of reports finished, deleted $deleted" }
-                    if (deleted > 0) updateSize = true
+            .onEach { retention ->
+                try {
+                    pruneReports(retention)
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "Failed to clean up reports: ${e.asLog()}" }
                 }
-
-                run {
-                    val filesBefore = pathsDao.filesCount().first()
-                    log(TAG) { "Deleting file infos related to old reports (${filesBefore})" }
-                    pathsDao.delete(oldReportIds)
-                    val deleted = filesBefore - pathsDao.filesCount().first()
-                    log(TAG) { "Clean up of file infos finished, deleted $deleted" }
-                    if (deleted > 0) updateSize = true
-                }
-
-                if (updateSize) databaseSize.value = getDatabaseSize()
             }
-            .catch { log(TAG, ERROR) { "Failed to clean up reports: ${it.asLog()}" } }
             .launchIn(appScope + dispatcherProvider.IO)
 
         statsSettings.retentionPaths.flow
-            .mapNotNull { retention ->
-                log(TAG, INFO) { "Retention for affected files is $retention" }
-                reportsDao.getReportsOlderThan(Instant.now() - retention).takeIf { it.isNotEmpty() }
+            .onEach { retention ->
+                try {
+                    pruneAffectedPaths(retention)
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "Failed to clean up affected files: ${e.asLog()}" }
+                }
             }
-            .map { reports -> reports.map { it.reportId } }
-            .onEach { oldReportIds ->
-                val filesBefore = pathsDao.filesCount().first()
-                log(TAG) { "Deleting stale infos about affected files (${filesBefore})" }
-                pathsDao.delete(oldReportIds)
-                val deleted = filesBefore - pathsDao.filesCount().first()
-                log(TAG) { "Clean up of stale file infos finished, deleted $deleted" }
-
-                if (deleted > 0) databaseSize.value = getDatabaseSize()
-            }
-            .catch { log(TAG, ERROR) { "Failed to clean up affected files: ${it.asLog()}" } }
             .launchIn(appScope + dispatcherProvider.IO)
 
         statsSettings.retentionSnapshots.flow

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/StatsRepoTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/StatsRepoTest.kt
@@ -5,6 +5,10 @@ import android.os.Parcel
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.stats.core.db.ReportsDatabase
@@ -23,7 +27,9 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import testhelpers.mockDataStoreValue
 import java.io.IOException
+import java.time.Duration
 import java.time.Instant
 
 class StatsRepoTest : BaseTest() {
@@ -40,9 +46,16 @@ class StatsRepoTest : BaseTest() {
     private val reportsDatabase: ReportsDatabase = mockk(relaxed = true)
     private val spaceFreed: DataStoreValue<Long> = mockk(relaxed = true)
     private val itemsProcessed: DataStoreValue<Long> = mockk(relaxed = true)
+
+    // Read via answers, so a test can change them before it calls reportOf().
+    private var reportsRetention: Duration = Duration.ofDays(30)
+    private var pathsRetention: Duration = Duration.ofDays(7)
+
     private val statsSettings: StatsSettings = mockk(relaxed = true) {
         every { totalSpaceFreed } returns spaceFreed
         every { totalItemsProcessed } returns itemsProcessed
+        every { retentionReports } answers { mockDataStoreValue(reportsRetention) }
+        every { retentionPaths } answers { mockDataStoreValue(pathsRetention) }
     }
     private val context: Context = mockk(relaxed = true)
 
@@ -66,6 +79,18 @@ class StatsRepoTest : BaseTest() {
         override val status: Report.Status = Report.Status.SUCCESS,
     ) : PlainResult(), ReportDetails.AffectedSpace, ReportDetails.AffectedCount
 
+    /**
+     * Carries both detail kinds, so an `exactly = 0` on addPaths/addPkgs can only pass because
+     * retention gated it — a result missing either interface never reaches those calls at all.
+     */
+    private class PathsAndPkgsResult : PlainResult(), ReportDetails.AffectedPaths, ReportDetails.AffectedPkgs {
+        override val affectedPaths: Set<APath> = setOf(LocalPath.build("/data/cache/thing"))
+        override val affectedPkgs: Map<Pkg.Id, AffectedPkg.Action> = mapOf(
+            "eu.thedarken.sdm".toPkgId() to AffectedPkg.Action.DELETED,
+        )
+        override val affectedCount: Int = affectedPaths.size + affectedPkgs.size
+    }
+
     private fun managedTask(
         result: SDMTool.Task.Result?,
         error: Throwable?,
@@ -79,15 +104,23 @@ class StatsRepoTest : BaseTest() {
         error = error,
     )
 
-    /** Reports [task] and returns what was written to the database. */
-    private suspend fun reportOf(task: TaskSubmitter.ManagedTask): Report {
-        val repo = StatsRepo(
+    private fun newRepo(): StatsRepo {
+        // A relaxed mock would swallow the transaction block and nothing would ever be written.
+        coEvery { reportsDatabase.withTransaction<Any?>(any()) } coAnswers {
+            firstArg<suspend () -> Any?>().invoke()
+        }
+        return StatsRepo(
             appScope = repoScope,
             context = context,
             reportsDatabase = reportsDatabase,
             statsSettings = statsSettings,
             spaceTracker = mockk(relaxed = true),
         )
+    }
+
+    /** Reports [task] and returns what was written to the database. */
+    private suspend fun reportOf(task: TaskSubmitter.ManagedTask): Report {
+        val repo = newRepo()
         val captured = slot<Report>()
         coEvery { reportsDatabase.addReport(capture(captured)) } returns Unit
         repo.report(task)
@@ -142,5 +175,59 @@ class StatsRepoTest : BaseTest() {
         val report = reportOf(managedTask(PlainResult(), error = null))
 
         report.status shouldBe Report.Status.SUCCESS
+    }
+
+    @Test
+    fun `zero reports retention stores neither the report nor its details`() = runTest2 {
+        reportsRetention = Duration.ZERO
+
+        newRepo().report(managedTask(PathsAndPkgsResult(), error = null))
+
+        coVerify(exactly = 0) { reportsDatabase.addReport(any()) }
+        coVerify(exactly = 0) { reportsDatabase.addPaths(any()) }
+        coVerify(exactly = 0) { reportsDatabase.addPkgs(any()) }
+
+        // The lifetime odometer keeps running, it is not what retention governs.
+        coVerify { itemsProcessed.update(any()) }
+    }
+
+    @Test
+    fun `a negative reports retention is treated like zero`() = runTest2 {
+        reportsRetention = Duration.ofDays(-1)
+
+        newRepo().report(managedTask(PathsAndPkgsResult(), error = null))
+
+        coVerify(exactly = 0) { reportsDatabase.addReport(any()) }
+    }
+
+    @Test
+    fun `zero paths retention drops only the affected files`() = runTest2 {
+        reportsRetention = Duration.ofDays(30)
+        pathsRetention = Duration.ZERO
+
+        newRepo().report(managedTask(PathsAndPkgsResult(), error = null))
+
+        coVerify(exactly = 1) { reportsDatabase.addReport(any()) }
+        coVerify(exactly = 0) { reportsDatabase.addPaths(any()) }
+        coVerify(exactly = 1) { reportsDatabase.addPkgs(any()) }
+    }
+
+    @Test
+    fun `positive retentions store the report and both detail kinds`() = runTest2 {
+        reportsRetention = Duration.ofDays(30)
+        pathsRetention = Duration.ofDays(7)
+
+        newRepo().report(managedTask(PathsAndPkgsResult(), error = null))
+
+        coVerify(exactly = 1) { reportsDatabase.addReport(any()) }
+        coVerify(exactly = 1) { reportsDatabase.addPaths(any()) }
+        coVerify(exactly = 1) { reportsDatabase.addPkgs(any()) }
+    }
+
+    @Test
+    fun `a stored report sweeps expired history`() = runTest2 {
+        newRepo().report(managedTask(PathsAndPkgsResult(), error = null))
+
+        coVerify { reportsDatabase.applyRetention() }
     }
 }

--- a/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/db/RetentionSweepDaoTest.kt
+++ b/app-common-stats/src/test/java/eu/darken/sdmse/stats/core/db/RetentionSweepDaoTest.kt
@@ -1,0 +1,145 @@
+package eu.darken.sdmse.stats.core.db
+
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.room.APathTypeConverter
+import eu.darken.sdmse.main.core.SDMTool
+import eu.darken.sdmse.stats.core.AffectedPath
+import eu.darken.sdmse.stats.core.AffectedPkg
+import eu.darken.sdmse.stats.core.Report
+import eu.darken.sdmse.stats.core.ReportId
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.time.Instant
+import java.util.UUID
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class RetentionSweepDaoTest : BaseTest() {
+
+    private lateinit var db: ReportsRoomDb
+    private lateinit var reports: ReportsDao
+    private lateinit var paths: AffectedPathsDao
+    private lateinit var pkgs: AffectedPkgsDao
+
+    private val now = Instant.parse("2026-06-01T10:00:00Z")
+
+    @Before
+    fun setup() {
+        db = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(), ReportsRoomDb::class.java)
+            .addTypeConverter(APathTypeConverter(Json))
+            .allowMainThreadQueries()
+            .build()
+        reports = db.reports()
+        paths = db.paths()
+        pkgs = db.pkgs()
+    }
+
+    @After
+    fun tearDown() {
+        db.close()
+    }
+
+    private fun pathRow(reportId: ReportId) = AffectedPathEntity(
+        reportId = reportId,
+        action = AffectedPath.Action.DELETED,
+        path = LocalPath.build("/data/media/0/$reportId"),
+    )
+
+    private fun pkgRow(reportId: ReportId) = AffectedPkgEntity(
+        reportId = reportId,
+        action = AffectedPkg.Action.DELETED,
+        pkgId = "eu.thedarken.sdm".toPkgId(),
+    )
+
+    /** A report plus one path and one pkg child. */
+    private fun seed(endAt: Instant): ReportId {
+        val entity = ReportEntity(
+            startAt = endAt.minusSeconds(1),
+            endAt = endAt,
+            tool = SDMTool.Type.APPCLEANER,
+            status = Report.Status.SUCCESS,
+            primaryMessage = null,
+            secondaryMessage = null,
+            errorMessage = null,
+            affectedCount = 1,
+            affectedSpace = 1L,
+            extra = null,
+        )
+        reports.insert(entity)
+        paths.insert(listOf(pathRow(entity.reportId)))
+        pkgs.insert(listOf(pkgRow(entity.reportId)))
+        return entity.reportId
+    }
+
+    /** Mirrors the sweep order of ReportsDatabase.pruneReports: children first, then parents, then orphans. */
+    private fun sweep(cutOff: Instant): Int {
+        val deletedPaths = paths.deleteForReportsOlderThan(cutOff)
+        val deletedPkgs = pkgs.deleteForReportsOlderThan(cutOff)
+        val deletedReports = reports.deleteOlderThan(cutOff)
+        return deletedPaths + deletedPkgs + deletedReports + paths.deleteOrphans() + pkgs.deleteOrphans()
+    }
+
+    @Test
+    fun `the cutoff sweep takes the expired report with its children and leaves the recent one`() =
+        runBlocking<Unit> {
+            val expired = seed(now.minusSeconds(600))
+            val recent = seed(now.plusSeconds(600))
+
+            sweep(now) shouldBe 3
+
+            reports.getById(expired).shouldBeNull()
+            paths.getById(expired).shouldBeEmpty()
+            pkgs.getById(expired).shouldBeEmpty()
+
+            reports.getById(recent).shouldNotBeNull()
+            paths.getById(recent).size shouldBe 1
+            pkgs.getById(recent).size shouldBe 1
+        }
+
+    @Test
+    fun `orphan deletes reclaim children whose report is already gone`() = runBlocking<Unit> {
+        val live = seed(now.plusSeconds(600))
+        val ghost: ReportId = UUID.randomUUID()
+        paths.insert(listOf(pathRow(ghost)))
+        pkgs.insert(listOf(pkgRow(ghost)))
+
+        paths.deleteOrphans() shouldBe 1
+        pkgs.deleteOrphans() shouldBe 1
+
+        paths.getById(ghost).shouldBeEmpty()
+        pkgs.getById(ghost).shouldBeEmpty()
+        paths.getById(live).size shouldBe 1
+        pkgs.getById(live).size shouldBe 1
+    }
+
+    @Test
+    fun `a history far beyond the SQLite bind parameter limit sweeps in one go`() = runBlocking<Unit> {
+        // An ID-keyed delete would bind one parameter per report and trip SQLite's 999 limit here.
+        val count = 1100
+        val seeded = mutableListOf<ReportId>()
+        db.runInTransaction(Runnable { repeat(count) { seeded += seed(now.minusSeconds(600)) } })
+
+        sweep(now) shouldBe count * 3
+
+        seeded.forEach { id ->
+            reports.getById(id).shouldBeNull()
+            paths.getById(id).shouldBeEmpty()
+            pkgs.getById(id).shouldBeEmpty()
+        }
+    }
+}


### PR DESCRIPTION
## What changed

Setting the History retention options to zero now actually means "keep nothing".

Before, with retention at zero, SD Maid still recorded every cleanup and the paths it touched, and that history stayed visible until the app restarted or you tapped "Reset all". Retention was only ever applied when the app started, or when you changed the setting itself, never when a cleanup was recorded. It is now applied right after each cleanup too, so history expires while the app is running instead of only at launch.

Two related problems are fixed along the way. Per-app records, the ones AppControl and CorpseFinder actions produce, were never removed by retention at any setting and simply accumulated for the life of the install. And a large accumulated history could make the cleanup fail outright and silently do nothing, which is most likely to hit exactly the person who has used SD Maid for years and has just turned retention down.

## Technical Context

- Root cause: retention pruning ran only on emissions of the retention DataStore flows, which are `distinctUntilChanged`. That is one emission when collection starts, then nothing until the value changes. The insert path read no retention setting at all, so with retention already at zero nothing pruned newly written rows for the life of the process.
- The sweep changed from "load every expired report, delete by ID list" to cutoff-keyed and orphan-keyed DELETE statements that return row counts. Chunking the ID list was the alternative and was rejected: Room expands `IN (:ids)` into one bind parameter per ID and Android's SQLite caps those (999 on older versions), so a first sweep over a large history threw before deleting anything.
- `affected_pkgs` rows had never been reachable by the sweep: `AffectedPkgsDao.delete` existed with zero callers. An ID-keyed delete could not reclaim the historical rows either, because their parent report row was already gone, which is why the new queries are orphan predicates rather than ID lists.
- The retention collectors' terminal `Flow.catch` moved inside `onEach`. A `catch` on the chain completes the flow, so the first sweep error permanently disabled that collector for the rest of the process.
- Deliberately out of scope, each a considered decision: no periodic idle sweep, so a process that stays alive without further cleanups still holds reports past their age; no hook into the backup restore path, since `StatsDbBackupContributor` writes the tables directly and restored history reappears until the next cleanup or restart; snapshot retention keeps its existing trigger; and the lifetime totals ("X freed, N items processed") intentionally keep counting under zero retention.
