### PR TITLE
AppCleaner: Shorten the wait after clearing app caches

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -283,12 +283,21 @@ class InaccessibleDeleter @Inject constructor(
         baselines: Map<InstallId, Long>,
     ): Map<InstallId, Long> {
         log(TAG) { "Observing freed bytes for ${targets.size} targets" }
+        // The automation stage is over by now and SD Maid is back in the foreground, so leaving the
+        // "preparing automation" label up would describe a step that already finished.
+        updateProgressPrimary(eu.darken.sdmse.appcleaner.R.string.appcleaner_progress_checking_freed_space)
+        updateProgressSecondary(CaString.EMPTY)
+        updateProgressCount(Progress.Count.Percent(targets.size))
 
         val minObserved = mutableMapOf<InstallId, Long>()
         val lastSample = mutableMapOf<InstallId, Long>()
         // A read that failed after an earlier one succeeded must not let that earlier value pass as
         // the final measurement, or a 100MB cache read as 90MB and then unreadable reports 10MB.
         val failedReads = mutableSetOf<InstallId>()
+        // Reads that all came back at exactly the pre-clear size, per target. -1 once a target has
+        // read anything else: a number that has moved is on its way somewhere and gets the full
+        // budget, however many times it reads its old size afterwards.
+        val pinnedReads = mutableMapOf<InstallId, Int>()
 
         // Track the MINIMUM, not the first decrease. A 100MB cache sampled as 90MB and then 0MB
         // freed 100MB; stopping at the first decrease would report 10MB, which is exactly the kind
@@ -308,16 +317,34 @@ class InaccessibleDeleter @Inject constructor(
             val baseline = baselines[id] ?: junk.inaccessibleCache!!.totalSize
             // Zero is the end state. Otherwise the number has to move off the pre-clear size AND
             // stop moving before we trust it: StorageStatsManager lags behind a clear, so two reads
-            // 500ms apart can both still report the stale pre-clear size. A target still sitting at
-            // its baseline keeps polling until the budget runs out.
-            return size == 0L || (previous == size && size < baseline)
+            // 500ms apart can both still report the stale pre-clear size.
+            if (size == 0L || (previous == size && size < baseline)) return true
+
+            // A number that has not once moved off the pre-clear size can never satisfy the rule
+            // above, so it would sit in the poll to the end of the budget and be reported as nothing
+            // freed anyway, making every round in between cost one more query for the targets that
+            // are still moving. Giving up on it early buys that back. The price is a cache whose
+            // size only starts falling after [PINNED_READ_LIMIT] reads, which the budget itself
+            // would still have caught.
+            val pinned = pinnedReads[id] ?: 0
+            if (pinned < 0 || size != baseline) {
+                pinnedReads[id] = -1
+                return false
+            }
+            val reads = pinned + 1
+            pinnedReads[id] = reads
+            if (reads >= PINNED_READ_LIMIT) {
+                log(TAG) { "Still at pre-clear size $baseline after $reads reads, giving up on $id" }
+                return true
+            }
+            return false
         }
 
         // First pass outside the budget: on a large batch a global timeout can expire mid-round and
         // leave late targets unsampled, silently back on the optimistic pre-clear figure. Every
         // target is sampled at least once, always.
         val pending = mutableListOf<AppJunk>()
-        targets.forEach { if (!sample(it)) pending.add(it) }
+        targets.forEach { if (sample(it)) increaseProgress() else pending.add(it) }
 
         if (pending.isNotEmpty()) {
             // Rounds rather than one coroutine per target, like the system app re-check above: no
@@ -326,12 +353,23 @@ class InaccessibleDeleter @Inject constructor(
                 while (pending.isNotEmpty()) {
                     log(TAG, VERBOSE) { "Waiting on ${pending.size} cache sizes to settle" }
                     delay(500)
-                    pending.removeAll(pending.filter { sample(it) })
+                    val round = pending.iterator()
+                    while (round.hasNext()) {
+                        // sample() suspends, so the budget can expire inside it. Removing and
+                        // counting per target keeps what this round already established, instead of
+                        // discarding it and naming settled targets in the timeout warning below.
+                        if (sample(round.next())) {
+                            round.remove()
+                            increaseProgress()
+                        }
+                    }
                 }
             } ?: log(TAG, WARN) {
                 "Freed-byte observation timed out after $ACS_SETTLE_TIMEOUT for: ${pending.map { it.identifier }}"
             }
         }
+        // Hand the next phase a spinner rather than our finished ring.
+        updateProgressCount(Progress.Count.Indeterminate())
 
         return targets.associate { junk ->
             val id = junk.identifier
@@ -590,6 +628,13 @@ class InaccessibleDeleter @Inject constructor(
         private val SYSTEM_RECHECK_TIMEOUT = 10.seconds
 
         /** Wall-clock budget for the whole post-clear settle poll that measures freed bytes. */
-        private val ACS_SETTLE_TIMEOUT = 10.seconds
+        private val ACS_SETTLE_TIMEOUT = 4.seconds
+
+        /**
+         * Reads, all at exactly the pre-clear size, after which a target is dropped from the settle
+         * poll. The first pass is read 1 and rounds are 500ms apart, so this is 2.5s of a number
+         * that has never moved, against the 4s of [ACS_SETTLE_TIMEOUT].
+         */
+        private const val PINNED_READ_LIMIT = 6
     }
 }

--- a/app-tool-appcleaner/src/main/res/values/strings.xml
+++ b/app-tool-appcleaner/src/main/res/values/strings.xml
@@ -98,4 +98,5 @@
     <string name="appcleaner_forcestop_before_clearing_label">Force-stop before clearing</string>
     <string name="appcleaner_forcestop_before_clearing_summary">Force-stop apps before clearing their cache. It can help clear some apps\' caches, but may cause apps to misbehave and require manual restart.</string>
     <string name="appcleaner_progress_force_stopping">Force-stopping apps…</string>
+    <string name="appcleaner_progress_checking_freed_space">Checking freed space…</string>
 </resources>

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
@@ -24,7 +24,7 @@ import eu.darken.sdmse.common.user.UserProfile2
 import eu.darken.sdmse.setup.SetupModule
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContain
-import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
+import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.maps.shouldBeEmpty
@@ -856,10 +856,12 @@ class InaccessibleDeleterTest : BaseTest() {
     }
 
     @Test
-    fun `a cache still at its pre-clear size keeps polling until the budget runs out`() = runTest {
+    fun `a cache still at its pre-clear size is dropped from the poll before the budget expires`() = runTest {
         // Two identical reads are not proof of a settled number while the size still equals what it
         // was before the clear: StorageStatsManager lags, so both can be the same stale value.
-        // Accepting that would report 0 freed for a cache that did clear.
+        // Accepting that would report 0 freed for a cache that did clear. A number that has never
+        // budged off the baseline can't satisfy that rule either, so it would occupy every round to
+        // the end of the budget and be reported as 0 regardless.
         val junk = createAppJunk("com.example.unchanged", cacheSize = 100000)
         val snapshot = createSnapshot(junk)
 
@@ -875,13 +877,66 @@ class InaccessibleDeleterTest : BaseTest() {
             isBackground = false,
         )
 
-        // Virtual time, so this costs no wall-clock: the poll ran for the full settle budget and
-        // then gave up instead of hanging.
-        (currentTime - startedAt) shouldBeGreaterThanOrEqual 10_000L
-        logs.any { it.contains("Freed-byte observation timed out") } shouldBe true
+        // Virtual time, so none of this costs wall-clock. The poll gave up on the target instead of
+        // sitting out the whole budget, and the budget is what bounds the pathological case.
+        (currentTime - startedAt) shouldBeLessThan 4_000L
+        logs.any { it.contains("Still at pre-clear size 100000") } shouldBe true
+        logs.any { it.contains("Freed-byte observation timed out") } shouldBe false
         result.freedBytes[junk.identifier] shouldBe 0L
         result.succesful shouldContain junk.identifier
         result.failed.shouldBeEmpty()
+    }
+
+    @Test
+    fun `giving up on a pinned target does not cost the measurement of one still walking down`() = runTest {
+        // Both are polled in the same rounds. Dropping the one that never moves must not shorten the
+        // budget the other one still needs to walk 100000 -> 90000 -> 40000 -> 0.
+        val pinned = createAppJunk("com.example.pinned", cacheSize = 100000)
+        val walking = createAppJunk("com.example.walking", cacheSize = 100000)
+        val snapshot = createSnapshot(pinned, walking)
+
+        scriptCacheSizes(
+            pinned to listOf(100000L),
+            // Pre-ACS re-query, then a stale read, then the number catches up in stages.
+            walking to listOf(100000L, 100000L, 90000L, 40000L, 0L),
+        )
+        acsClears(pinned, walking)
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.freedBytes[pinned.identifier] shouldBe 0L
+        result.freedBytes[walking.identifier] shouldBe 100000L
+        result.failed.shouldBeEmpty()
+    }
+
+    @Test
+    fun `a target that moved once is never dropped early, however often it reads its old size`() = runTest {
+        // 100000 -> 90000 -> back to 100000 for five reads -> 0. The number demonstrably moved, so
+        // it is still settling and must keep the full budget. Dropping it on the second baseline
+        // streak would credit it with 10000 freed instead of the 100000 it actually gave up.
+        val junk = createAppJunk("com.example.bouncy", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        scriptCacheSizes(
+            junk to listOf(100000L, 90000L, 100000L, 100000L, 100000L, 100000L, 100000L, 0L),
+        )
+        acsClears(junk)
+
+        val logs = collectLogs()
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.freedBytes[junk.identifier] shouldBe 100000L
+        logs.any { it.contains("giving up on") } shouldBe false
     }
 
     @Test


### PR DESCRIPTION
## What changed

After SD Maid clears app caches through the accessibility service, it checks how much space each app actually gave up. That check could run for ten seconds while the screen still showed "Preparing automation via accessibility service" and a spinner, so it looked like the app had frozen at the exact moment the work appeared to be over. It now says what it is doing, counts the apps off as it goes, and finishes sooner.

## Technical Context

- Root cause: `observeFreedBytes` is the last step of `InaccessibleDeleter.deleteInaccessible` and set no progress of its own, so it inherited the label the ACS stage installed before it. `ClearCacheModule` writes to the `AutomationHost`, a separate `Progress.Client` driving the overlay panel, so nothing at the tool level had replaced that label since.
- The settle rule wants a reading that both stops changing and drops below the pre-clear size. A reading pinned at its baseline satisfies neither, so it held a slot in every round for the whole budget and was reported as nothing freed regardless. Those targets are now dropped early.
- The settle budget goes from 10s to 4s. That trades measurement for responsiveness in one direction: an app whose reported size only catches up between 4s and 10s now reports nothing freed instead of the real figure. `ACS_SETTLE_TIMEOUT` and `PINNED_READ_LIMIT` are the two knobs if that balance is wrong.
- Worth a close read: the pinned-counter branch in `sample()`. The `-1` sentinel is what makes the exemption permanent for a target that has moved even once; without it a size bouncing back to its old value mid-settle gets dropped and credited with the partial drop instead of what it went on to free.
- Reported against 2.0.4-rc0 on a Galaxy S24 FE (Android 16) via a Play Store beta review, not a GitHub issue. The pause is not Samsung-specific, but a device whose size readings lag past the budget hits it on every run.
