### PR TITLE
AppCleaner: Clean OnePlus Gallery's hidden thumbnail cache

### DIFF
--- a/app/src/main/assets/expendables/db_thumbnail_files.json
+++ b/app/src/main/assets/expendables/db_thumbnail_files.json
@@ -88,6 +88,14 @@
 		}
 	  ]
 	}, {
+	  "packages": ["com.oneplus.gallery"],
+	  "fileFilter": [
+		{
+		  "locations": ["PUBLIC_DATA"],
+		  "startsWith": ["com.oneplus.gallery/files/blob_cache/"]
+		}
+	  ]
+	}, {
 	  "packages": [
 		"com.lenovo.anyshare.gps",
 		"com.lenovo.anyshare",

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
@@ -5,6 +5,7 @@ import eu.darken.sdmse.appcleaner.core.forensics.neg
 import eu.darken.sdmse.appcleaner.core.forensics.pos
 import eu.darken.sdmse.common.areas.DataArea.Type.PRIVATE_DATA
 import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_DATA
+import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_MEDIA
 import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import eu.darken.sdmse.common.rngString
 import kotlinx.coroutines.test.runTest
@@ -194,6 +195,26 @@ class ThumbnailsFilterTest : BaseFilterTest() {
 
         neg("com.viber.voip", PRIVATE_DATA, "com.viber.voip/cache/User photos/.thumbnails/$rngString")
         neg("com.viber.voip", PRIVATE_DATA, "com.viber.voip/Cache/.thumbnails/$rngString")
+        confirm(create())
+    }
+
+    @Test fun `test oneplus gallery blob cache filter`() = runTest {
+        addDefaultNegatives()
+
+        neg("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/blob_cache")
+        neg("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/blob_cache_v2/imgcache.0")
+        neg("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/other/imgcache.0")
+        neg("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/blob_cache/.nomedia")
+        neg(testPkg, PUBLIC_DATA, "$testPkg/files/blob_cache/imgcache.0")
+
+        neg("com.oneplus.gallery", PRIVATE_DATA, "com.oneplus.gallery/files/blob_cache/imgcache.0")
+        neg("com.oneplus.gallery", SDCARD, "com.oneplus.gallery/files/blob_cache/imgcache.0")
+        neg("com.oneplus.gallery", PUBLIC_MEDIA, "com.oneplus.gallery/files/blob_cache/imgcache.0")
+
+        pos("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/blob_cache/imgcache.0")
+        pos("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/blob_cache/$rngString")
+        pos("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/blob_cache/sub/file")
+
         confirm(create())
     }
 


### PR DESCRIPTION
## What changed

AppCleaner now recognises the OnePlus Gallery's thumbnail cache at
`Android/data/com.oneplus.gallery/files/blob_cache/` as expendable, so it shows up for cleaning like
any other app cache. Until now AppCleaner cleaned only the Gallery's conventional `cache/` folder
sitting right next to it, while this directory grew to several GB on affected devices.

The files in there are regenerable thumbnail data (image, screennail, tile, medium-image and face
caches), not photos or videos. The Gallery rebuilds them on demand.

This only has an effect for users who have "Include system apps" enabled, since a preinstalled
Gallery is a system app.

Closes #2732

## Technical Context

- Root cause: every filter carrying a generic `files/<folder>` rule compares segment 2 against a
  fixed list of folder names, none of which contains `blob_cache`, and `DefaultCachesPublicFilter`
  only matches when segment 1 is the literal `cache`. The subtree was walked, it just never matched.
- Implemented as one per-package entry in `db_thumbnail_files.json` rather than adding `blob_cache`
  to `HiddenFilter`'s generic `HIDDEN_CACHE_FOLDERS`, which would have applied it to every installed
  app across PUBLIC_DATA, PRIVATE_DATA and SDCARD.
- The trailing slash in the `startsWith` value is load-bearing. `toSegs()` keeps a trailing empty
  segment, so the comparison is segment-wise and a sibling directory such as `blob_cache_v2` does
  not match. The new test pins that boundary, along with the `blob_cache` directory itself staying
  unmatched. No `patterns` regex is needed on top; `startsWith` alone is already exact here, same
  shape as the SHAREit entry in the same file.
- Deliberately scoped to `com.oneplus.gallery` alone. ColorOS and OPPO gallery packages were
  considered and left out: AOSP Gallery2 puts its BlobCache in `getExternalCacheDir()` with no
  subdirectory, so `files/blob_cache/` is a OnePlus deviation from upstream rather than shared fork
  behaviour, and the observed file names are OnePlus-specific too. Their standard `cache/` location
  is already covered.
- Worth a close look: the three area negatives in the test (`PRIVATE_DATA`, `SDCARD`,
  `PUBLIC_MEDIA`). `JsonAppSieve` treats an empty `locations` array as "all areas", so those
  assertions are what stops a future edit from silently widening the rule beyond PUBLIC_DATA.
