### PR TITLE
AppCleaner: Fix cleaning failing when accessibility isn't set up

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -14,6 +14,7 @@ import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask.StopReason
+import eu.darken.sdmse.automation.core.errors.AutomationNoConsentException
 import eu.darken.sdmse.automation.core.errors.isScreenUnavailable
 import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.ca.CaString
@@ -457,6 +458,16 @@ class AppCleaner @Inject constructor(
             if (salvaged.affectedCount == 0 && salvaged.affectedSpace == 0L) throw failure
             val reason = if (failure.isScreenUnavailable()) StopReason.SCREEN_UNAVAILABLE else StopReason.ERROR
             throw PartialResultException(failure, salvaged.copy(stoppedEarly = reason))
+        }
+
+        if (acsOutcome != null && acsOutcome.skippedNoConsent.isNotEmpty()) {
+            log(TAG, WARN) { "Skipped for lack of ACS consent: ${acsOutcome.skippedNoConsent}" }
+            // Nothing was salvaged, so there is no outcome to report and no other place that offers
+            // the user a way to grant consent. Fail with the dialog that routes to setup.
+            if (salvaged.affectedCount == 0 && salvaged.affectedSpace == 0L) {
+                throw InaccessibleDeletionException(AutomationNoConsentException())
+            }
+            return salvaged.copy(stoppedEarly = StopReason.AUTOMATION_NO_CONSENT)
         }
 
         return salvaged

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -83,6 +83,7 @@ private fun AppCleanerProcessingTask.Success.toSchedulerSuccess() = AppCleanerSc
     affectedPaths = affectedPaths,
     affectedCount = affectedCount,
     stoppedEarly = stoppedEarly,
+    skippedCount = skippedCount,
 )
 
 private fun AppCleanerProcessingTask.Success.toOneClickSuccess() = AppCleanerOneClickTask.Success(
@@ -90,6 +91,7 @@ private fun AppCleanerProcessingTask.Success.toOneClickSuccess() = AppCleanerOne
     affectedPaths = affectedPaths,
     affectedCount = affectedCount,
     stoppedEarly = stoppedEarly,
+    skippedCount = skippedCount,
 )
 
 @Singleton
@@ -467,7 +469,10 @@ class AppCleaner @Inject constructor(
             if (salvaged.affectedCount == 0 && salvaged.affectedSpace == 0L) {
                 throw InaccessibleDeletionException(AutomationNoConsentException())
             }
-            return salvaged.copy(stoppedEarly = StopReason.AUTOMATION_NO_CONSENT)
+            return salvaged.copy(
+                stoppedEarly = StopReason.AUTOMATION_NO_CONSENT,
+                skippedCount = acsOutcome.skippedNoConsent.size,
+            )
         }
 
         return salvaged

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
 import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCacheProvider
 import eu.darken.sdmse.automation.core.AutomationSubmitter
 import eu.darken.sdmse.automation.core.ForceStopAutomationTask
+import eu.darken.sdmse.automation.core.errors.AutomationNoConsentException
 import eu.darken.sdmse.automation.core.errors.AutomationUnavailableException
 import eu.darken.sdmse.automation.core.errors.DisabledAppException
 import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
@@ -36,6 +37,7 @@ import eu.darken.sdmse.common.progress.updateProgressSecondary
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.user.UserManager2
+import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.setup.SetupBinding
 import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.isComplete
@@ -65,6 +67,7 @@ class InaccessibleDeleter @Inject constructor(
     private val inaccessibleCacheProvider: InaccessibleCacheProvider,
     private val rootManager: RootManager,
     private val settings: AppCleanerSettings,
+    private val generalSettings: GeneralSettings,
     @SetupBinding(SetupModule.Type.AUTOMATION) private val automationSetupModule: SetupModule,
     private val noSettingsDetector: NoSettingsDetector,
 ) : Progress.Host, Progress.Client {
@@ -167,7 +170,13 @@ class InaccessibleDeleter @Inject constructor(
                 }
             }
 
-        if (useAutomation && remainingTargets.isNotEmpty()) {
+        // `null` = never asked, `false` = declined. Neither can be turned into a prompt from here:
+        // the submitter throws instead of asking, so the stage can only fail. Skip it and let the
+        // caller decide how loud that has to be.
+        val hasAcsConsent = generalSettings.hasAcsConsent.value() == true
+        var noConsentSkip = false
+
+        if (useAutomation && remainingTargets.isNotEmpty() && hasAcsConsent) {
             log(TAG, WARN) { "Using accessibility service to delete inaccessible caches." }
             updateProgressPrimary(eu.darken.sdmse.automation.R.string.automation_loading)
             updateProgressSecondary(CaString.EMPTY)
@@ -222,6 +231,14 @@ class InaccessibleDeleter @Inject constructor(
                 )
                 val result = try {
                     automationManager.submit(acsTask) as ClearCacheTask.Result
+                } catch (e: AutomationNoConsentException) {
+                    // Consent can be withdrawn between the check above and this submission.
+                    log(TAG, WARN) { "No ACS consent, skipping the accessibility stage: $successLive" }
+                    noConsentSkip = true
+                    ClearCacheTask.Result(
+                        successful = successLive,
+                        failed = failedLive,
+                    )
                 } catch (e: AutomationUnavailableException) {
                     // Nothing ran, but fold anyway so the partial-result contract holds uniformly.
                     successTargets.addAll(successLive)
@@ -249,8 +266,20 @@ class InaccessibleDeleter @Inject constructor(
                 successTargets.addAll(result.successful)
                 failedTargets.putAll(result.failed)
             }
+        } else if (useAutomation && remainingTargets.isNotEmpty()) {
+            log(TAG, WARN) { "No ACS consent, skipping the accessibility stage for ${remainingTargets.size} targets" }
+            noConsentSkip = true
         } else if (!useAutomation) {
             log(TAG, INFO) { "useAutomation=false" }
+        }
+
+        val skippedNoConsent = when {
+            noConsentSkip -> remainingTargets
+                .map { it.identifier }
+                .filter { !successTargets.contains(it) && !failedTargets.containsKey(it) }
+                .toSet()
+
+            else -> emptySet()
         }
 
         val observationTargets = targets.filter {
@@ -264,12 +293,12 @@ class InaccessibleDeleter @Inject constructor(
                 // unlikely. Without this the caller would receive no result at all and would keep
                 // advertising caches that are genuinely gone.
                 log(TAG, WARN) { "Freed-byte observation failed, forwarding what was cleared: ${e.asLog()}" }
-                onPartialResult(buildResult(successTargets, failedTargets, freedBytes))
+                onPartialResult(buildResult(successTargets, failedTargets, freedBytes, skippedNoConsent))
                 throw e
             }
         }
 
-        return buildResult(successTargets, failedTargets, freedBytes)
+        return buildResult(successTargets, failedTargets, freedBytes, skippedNoConsent)
     }
 
     /**
@@ -404,12 +433,14 @@ class InaccessibleDeleter @Inject constructor(
         successTargets: Collection<InstallId>,
         failedTargets: Map<InstallId, Exception>,
         freedBytes: Map<InstallId, Long> = emptyMap(),
+        skippedNoConsent: Set<InstallId> = emptySet(),
     ): InaccDelResult {
         val successful = successTargets.toSet()
         return InaccDelResult(
             succesful = successful,
             failed = failedTargets.filterKeys { !successful.contains(it) },
             freedBytes = freedBytes.filterKeys { successful.contains(it) },
+            skippedNoConsent = skippedNoConsent,
         )
     }
 
@@ -619,6 +650,12 @@ class InaccessibleDeleter @Inject constructor(
          * what it reported unconditionally before this existed.
          */
         val freedBytes: Map<InstallId, Long> = emptyMap(),
+        /**
+         * Targets the accessibility stage never touched because SD Maid has no consent to use the
+         * service. Disjoint from [succesful] and [failed]: an app the ADB stage already failed on
+         * has a real per-app error and must keep it.
+         */
+        val skippedNoConsent: Set<InstallId> = emptySet(),
     )
 
     companion object {

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
@@ -37,6 +37,11 @@ data class AppCleanerOneClickTask(
                         affectedCount,
                     )
 
+                    AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT -> getQuantityString2(
+                        R.plurals.appcleaner_result_x_items_deleted_stopped_automation,
+                        affectedCount,
+                    )
+
                     null -> getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)
                 }
             }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerOneClickTask.kt
@@ -22,6 +22,7 @@ data class AppCleanerOneClickTask(
         override val affectedPaths: Set<APath>,
         override val affectedCount: Int = affectedPaths.size,
         val stoppedEarly: AppCleanerTask.StopReason? = null,
+        val skippedCount: Int = 0,
     ) : Result, ReportDetails.AffectedSpace, ReportDetails.AffectedPaths {
 
         override val primaryInfo
@@ -39,7 +40,9 @@ data class AppCleanerOneClickTask(
 
                     AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT -> getQuantityString2(
                         R.plurals.appcleaner_result_x_items_deleted_stopped_automation,
-                        affectedCount,
+                        skippedCount,
+                        getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount),
+                        skippedCount,
                     )
 
                     null -> getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
@@ -51,6 +51,7 @@ data class AppCleanerProcessingTask(
         // Set when the clean aborted after deleting this much, e.g. the accessibility stage hit a
         // locked screen. Null for a run that went through everything it targeted.
         val stoppedEarly: AppCleanerTask.StopReason? = null,
+        val skippedCount: Int = 0,
     ) : Result, ReportDetails.AffectedSpace, ReportDetails.AffectedPaths {
 
         override val primaryInfo
@@ -68,7 +69,9 @@ data class AppCleanerProcessingTask(
 
                     AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT -> getQuantityString2(
                         R.plurals.appcleaner_result_x_items_deleted_stopped_automation,
-                        affectedCount,
+                        skippedCount,
+                        getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount),
+                        skippedCount,
                     )
 
                     null -> getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingTask.kt
@@ -66,6 +66,11 @@ data class AppCleanerProcessingTask(
                         affectedCount,
                     )
 
+                    AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT -> getQuantityString2(
+                        R.plurals.appcleaner_result_x_items_deleted_stopped_automation,
+                        affectedCount,
+                    )
+
                     null -> getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)
                 }
             }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerSchedulerTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerSchedulerTask.kt
@@ -23,6 +23,7 @@ data class AppCleanerSchedulerTask(
         override val affectedPaths: Set<APath>,
         override val affectedCount: Int = affectedPaths.size,
         val stoppedEarly: AppCleanerTask.StopReason? = null,
+        val skippedCount: Int = 0,
     ) : Result, ReportDetails.AffectedSpace, ReportDetails.AffectedPaths {
 
         override val primaryInfo
@@ -40,7 +41,9 @@ data class AppCleanerSchedulerTask(
 
                     AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT -> getQuantityString2(
                         R.plurals.appcleaner_result_x_items_deleted_stopped_automation,
-                        affectedCount,
+                        skippedCount,
+                        getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount),
+                        skippedCount,
                     )
 
                     null -> getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerSchedulerTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerSchedulerTask.kt
@@ -38,6 +38,11 @@ data class AppCleanerSchedulerTask(
                         affectedCount,
                     )
 
+                    AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT -> getQuantityString2(
+                        R.plurals.appcleaner_result_x_items_deleted_stopped_automation,
+                        affectedCount,
+                    )
+
                     null -> getQuantityString2(R.plurals.appcleaner_result_x_items_deleted, affectedCount)
                 }
             }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerTask.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerTask.kt
@@ -13,5 +13,8 @@ sealed interface AppCleanerTask : SDMTool.Task {
     enum class StopReason {
         SCREEN_UNAVAILABLE,
         ERROR,
+
+        /** SD Maid may not use the accessibility service, so the caches only it can reach were left alone. */
+        AUTOMATION_NO_CONSENT,
     }
 }

--- a/app-tool-appcleaner/src/main/res/values/strings.xml
+++ b/app-tool-appcleaner/src/main/res/values/strings.xml
@@ -69,8 +69,8 @@
         <item quantity="other">%d expendable items deleted, stopped by an error</item>
     </plurals>
     <plurals name="appcleaner_result_x_items_deleted_stopped_automation">
-        <item quantity="one">%d expendable item deleted, accessibility cleaning was not permitted</item>
-        <item quantity="other">%d expendable items deleted, accessibility cleaning was not permitted</item>
+        <item quantity="one">%1$s, %2$d cache still needs the accessibility service</item>
+        <item quantity="other">%1$s, %2$d caches still need the accessibility service</item>
     </plurals>
     <plurals name="appcleaner_result_x_items_found">
         <item quantity="one">%d expendable item found</item>
@@ -86,7 +86,7 @@
     <string name="appcleaner_item_caches_inaccessible_title">Default caches</string>
     <string name="appcleaner_item_caches_inaccessible_body">Public and private default caches. Not directly accessible, but can be deleted indirectly (e.g. via accessibility service).</string>
     <string name="appcleaner_automation_unavailable_title">Accessibility service unavailable</string>
-    <string name="appcleaner_automation_unavailable_body">Clearing inaccessible caches requires SD Maid\'s accessibility service, but it was unavailable. If you don\'t want to use it: Disable the option "Include inaccessible caches".</string>
+    <string name="appcleaner_automation_unavailable_body">Clearing these caches requires SD Maid\'s accessibility service, but it wasn\'t available.</string>
     <string name="appcleaner_delete_confirmation_message_x">Delete expendable files for %s?</string>
     <plurals name="appcleaner_delete_confirmation_message_selected_x_items">
         <item quantity="one">Delete expendable files for %d selected app?</item>

--- a/app-tool-appcleaner/src/main/res/values/strings.xml
+++ b/app-tool-appcleaner/src/main/res/values/strings.xml
@@ -68,6 +68,10 @@
         <item quantity="one">%d expendable item deleted, stopped by an error</item>
         <item quantity="other">%d expendable items deleted, stopped by an error</item>
     </plurals>
+    <plurals name="appcleaner_result_x_items_deleted_stopped_automation">
+        <item quantity="one">%d expendable item deleted, accessibility cleaning was not permitted</item>
+        <item quantity="other">%d expendable items deleted, accessibility cleaning was not permitted</item>
+    </plurals>
     <plurals name="appcleaner_result_x_items_found">
         <item quantity="one">%d expendable item found</item>
         <item quantity="other">%d expendable items found</item>

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -1179,6 +1179,7 @@ class AppCleanerTest : BaseTest() {
 
         result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
         result.stoppedEarly shouldBe AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT
+        result.skippedCount shouldBe 1
         result.affectedSpace shouldBe previewExpendables().values.flatten().sumOf { it.expectedGain }
     }
 

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -11,6 +11,7 @@ import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask
 import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
 import eu.darken.sdmse.appcleaner.ui.preview.previewInaccessibleCache
+import eu.darken.sdmse.automation.core.errors.AutomationNoConsentException
 import eu.darken.sdmse.automation.core.errors.InvalidSystemStateException
 import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
 import eu.darken.sdmse.automation.core.errors.ScreenUnavailableException
@@ -716,6 +717,7 @@ class AppCleanerTest : BaseTest() {
     private fun acsDeleter(
         succesful: Set<InstallId>,
         freedBytes: Map<InstallId, Long> = emptyMap(),
+        skippedNoConsent: Set<InstallId> = emptySet(),
     ): InaccessibleDeleter =
         mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
             every { progress } returns MutableStateFlow<Progress.Data?>(null)
@@ -726,6 +728,7 @@ class AppCleanerTest : BaseTest() {
                 succesful = succesful,
                 failed = emptyMap(),
                 freedBytes = freedBytes,
+                skippedNoConsent = skippedNoConsent,
             )
         }
 
@@ -1151,4 +1154,49 @@ class AppCleanerTest : BaseTest() {
     // filter, includeInaccessible defaults, targetPkgs/targetContents contract) are protected by
     // the contract test above and by `AppCleanerTaskFactoryTest`. Leaving the delete-path
     // integration to a follow-up that introduces a shared FakeFilter test helper.
+
+    @Test
+    fun `caches skipped for lack of ACS consent are reported on an otherwise successful run`() = runTest2 {
+        // The accessible files really were deleted, so the run is a success. It just did not get
+        // through the inaccessible caches, and saying so is the only way the user learns why.
+        val junk = previewAppJunk(
+            pkg = previewInstalled(pkgName = "com.example.mixed", label = "com.example.mixed"),
+            expendables = previewExpendables(),
+            inaccessibleCache = previewInaccessibleCache(pkgName = "com.example.mixed"),
+        )
+        val deleter = acsDeleter(
+            succesful = emptySet(),
+            skippedNoConsent = setOf(installId("com.example.mixed")),
+        )
+        val rebuilt = rebuildWithDeleter(
+            setupCleaner(scanResults = listOf(junk)),
+            deleter,
+            filterFactories = setOf(deletingFilterFactory()),
+        )
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        val result = rebuilt.cleaner.submit(AppCleanerProcessingTask())
+
+        result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        result.stoppedEarly shouldBe AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT
+        result.affectedSpace shouldBe previewExpendables().values.flatten().sumOf { it.expectedGain }
+    }
+
+    @Test
+    fun `a consent skip that salvaged nothing still fails with the consent error`() = runTest2 {
+        // A targeted inaccessible delete has no other mechanism, so "Success, 0 items" would hide
+        // the one prompt that offers the user a way to grant consent.
+        val junk = inaccJunk("com.example.nothing", itemCount = 4, theoreticalPaths = emptySet())
+        val deleter = acsDeleter(
+            succesful = emptySet(),
+            skippedNoConsent = setOf(installId("com.example.nothing")),
+        )
+        val rebuilt = rebuildWithDeleter(setupCleaner(scanResults = listOf(junk)), deleter)
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        val thrown = shouldThrow<InaccessibleDeletionException> {
+            rebuilt.cleaner.submit(AppCleanerProcessingTask(onlyInaccessible = true))
+        }
+        thrown.cause.shouldBeInstanceOf<AutomationNoConsentException>()
+    }
 }

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleterTest.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCacheProvider
 import eu.darken.sdmse.automation.core.AutomationSubmitter
 import eu.darken.sdmse.automation.core.ForceStopAutomationTask
 import eu.darken.sdmse.automation.core.errors.AutomationCompatibilityException
+import eu.darken.sdmse.automation.core.errors.AutomationNoConsentException
 import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
 import eu.darken.sdmse.automation.core.errors.UserCancelledAutomationException
 import eu.darken.sdmse.common.adb.AdbManager
@@ -21,6 +22,7 @@ import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.common.user.UserProfile2
+import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.setup.SetupModule
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContain
@@ -67,6 +69,7 @@ class InaccessibleDeleterTest : BaseTest() {
     @MockK lateinit var inaccessibleCacheProvider: InaccessibleCacheProvider
     @MockK lateinit var rootManager: RootManager
     @MockK lateinit var settings: AppCleanerSettings
+    @MockK lateinit var generalSettings: GeneralSettings
     @MockK(name = "automation") lateinit var automationSetupModule: SetupModule
     @MockK lateinit var noSettingsDetector: NoSettingsDetector
 
@@ -89,6 +92,8 @@ class InaccessibleDeleterTest : BaseTest() {
         every { adbManager.useAdb } returns flowOf(false)
         // Default: no package is flagged as having no settings. Individual tests override as needed.
         coEvery { noSettingsDetector.getUnreachableReason(any()) } returns null
+        // Default: consent granted, so useAutomation=true actually reaches the ACS stage.
+        setAcsConsent(true)
 
         deleter = InaccessibleDeleter(
             dispatcherProvider = dispatcherProvider,
@@ -99,9 +104,14 @@ class InaccessibleDeleterTest : BaseTest() {
             inaccessibleCacheProvider = inaccessibleCacheProvider,
             rootManager = rootManager,
             settings = settings,
+            generalSettings = generalSettings,
             automationSetupModule = automationSetupModule,
             noSettingsDetector = noSettingsDetector,
         )
+    }
+
+    private fun setAcsConsent(consent: Boolean?) {
+        every { generalSettings.hasAcsConsent } returns mockDataStoreValue(consent)
     }
 
     private var logCollector: Logging.Logger? = null
@@ -1128,5 +1138,147 @@ class InaccessibleDeleterTest : BaseTest() {
         result.freedBytes shouldNotContainKey junk.identifier
         // Only the pre-ACS re-query, no observation reads on top of it.
         coVerify(exactly = 1) { inaccessibleCacheProvider.determineCache(junk.pkg) }
+    }
+
+    @Test
+    fun `a never-asked ACS consent skips the accessibility stage`() = runTest {
+        val junk = createAppJunk("com.example.consentless", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        setAcsConsent(null)
+        scriptCacheSizes(junk to listOf(100000L))
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.skippedNoConsent shouldBe setOf(junk.identifier)
+        result.succesful shouldBe emptySet()
+        result.failed.shouldBeEmpty()
+        coVerify(exactly = 0) { automationManager.submit(any()) }
+    }
+
+    @Test
+    fun `a declined ACS consent skips the accessibility stage`() = runTest {
+        val junk = createAppJunk("com.example.declined", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        setAcsConsent(false)
+        scriptCacheSizes(junk to listOf(100000L))
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.skippedNoConsent shouldBe setOf(junk.identifier)
+        result.succesful shouldBe emptySet()
+        result.failed.shouldBeEmpty()
+        coVerify(exactly = 0) { automationManager.submit(any()) }
+    }
+
+    @Test
+    fun `a granted ACS consent still runs the accessibility stage`() = runTest {
+        // Guards against gating on something stricter than consent: a granted consent must keep
+        // reaching the submitter, which is what turns a not-running service into its own error.
+        val junk = createAppJunk("com.example.consented", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        setAcsConsent(true)
+        scriptCacheSizes(junk to listOf(100000L, 0L))
+        acsClears(junk)
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.skippedNoConsent shouldBe emptySet()
+        result.succesful shouldContain junk.identifier
+        coVerify(exactly = 1) { automationManager.submit(match { it is ClearCacheTask }) }
+    }
+
+    @Test
+    fun `consent withdrawn between the check and the submission is still a skip`() = runTest {
+        val junk = createAppJunk("com.example.withdrawn", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        setAcsConsent(true)
+        scriptCacheSizes(junk to listOf(100000L))
+        every { settings.forceStopBeforeClearing } returns mockDataStoreValue(false)
+        coEvery { automationManager.submit(match { it is ClearCacheTask }) } throws AutomationNoConsentException()
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.skippedNoConsent shouldBe setOf(junk.identifier)
+        result.succesful shouldBe emptySet()
+        result.failed.shouldBeEmpty()
+    }
+
+    @Test
+    fun `skipped targets exclude what ADB already cleared or failed`() = runTest {
+        // An ADB failure is a real per-app error and stays one. Reporting it as skipped as well
+        // would let the run advertise "automation not permitted" for an app that failed elsewhere.
+        val cleared = createAppJunk("com.example.adbcleared", cacheSize = 100000)
+        val adbFailed = createAppJunk("com.example.adbfailed", cacheSize = 100000)
+        val untouched = createAppJunk("com.example.untouched", cacheSize = 100000, isSystemApp = true)
+        val snapshot = createSnapshot(cleared, adbFailed, untouched)
+
+        setAcsConsent(null)
+        every { adbManager.useAdb } returns flowOf(true)
+        coEvery { pkgOps.trimCaches(any(), any(), any()) } returns Unit
+        scriptCacheSizes(
+            cleared to listOf(0L),
+            adbFailed to listOf(null),
+            untouched to listOf(100000L),
+        )
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = null,
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.succesful shouldContain cleared.identifier
+        result.failed shouldContainKey adbFailed.identifier
+        result.skippedNoConsent shouldBe setOf(untouched.identifier)
+        coVerify(exactly = 0) { automationManager.submit(any()) }
+    }
+
+    @Test
+    fun `a targeted delete without consent is skipped, the ADB trim never runs for it`() = runTest {
+        // targetPkgs makes isAllApps false, so the bulk trim is out and the accessibility stage is
+        // the only mechanism this run had.
+        val junk = createAppJunk("com.example.targeted", cacheSize = 100000)
+        val snapshot = createSnapshot(junk)
+
+        setAcsConsent(null)
+        every { adbManager.useAdb } returns flowOf(true)
+        scriptCacheSizes(junk to listOf(100000L))
+
+        val result = deleter.deleteInaccessible(
+            snapshot = snapshot,
+            targetPkgs = setOf(junk.identifier),
+            useAutomation = true,
+            isBackground = false,
+        )
+
+        result.skippedNoConsent shouldBe setOf(junk.identifier)
+        result.succesful shouldBe emptySet()
+        coVerify(exactly = 0) { pkgOps.trimCaches(any(), any(), any()) }
+        coVerify(exactly = 0) { automationManager.submit(any()) }
     }
 }

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingResultTextTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/tasks/AppCleanerProcessingResultTextTest.kt
@@ -19,11 +19,13 @@ class AppCleanerProcessingResultTextTest : BaseTest() {
     private fun success(
         count: Int,
         stoppedEarly: AppCleanerTask.StopReason?,
+        skipped: Int = 0,
     ) = AppCleanerProcessingTask.Success(
         affectedSpace = 1024L,
         affectedPaths = emptySet(),
         affectedCount = count,
         stoppedEarly = stoppedEarly,
+        skippedCount = skipped,
     ).primaryInfo.get(context)
 
     @Test
@@ -45,5 +47,17 @@ class AppCleanerProcessingResultTextTest : BaseTest() {
             "1 expendable item deleted, stopped by an error"
         success(count = 46, stoppedEarly = AppCleanerTask.StopReason.ERROR) shouldBe
             "46 expendable items deleted, stopped by an error"
+    }
+
+    @Test
+    fun `a run that skipped the accessibility service says how many caches are left`() {
+        success(count = 1, stoppedEarly = AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT, skipped = 1) shouldBe
+            "1 expendable item deleted, 1 cache still needs the accessibility service"
+        success(count = 46, stoppedEarly = AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT, skipped = 1) shouldBe
+            "46 expendable items deleted, 1 cache still needs the accessibility service"
+        success(count = 1, stoppedEarly = AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT, skipped = 3) shouldBe
+            "1 expendable item deleted, 3 caches still need the accessibility service"
+        success(count = 46, stoppedEarly = AppCleanerTask.StopReason.AUTOMATION_NO_CONSENT, skipped = 3) shouldBe
+            "46 expendable items deleted, 3 caches still need the accessibility service"
     }
 }


### PR DESCRIPTION
## What changed

If you use Shizuku or ADB access but haven't set up SD Maid's accessibility service, cleaning app junk failed completely, even though most caches had already been cleared moments earlier. The error message also suggested turning off "Include inaccessible caches", which would have made things worse: that option also disables the Shizuku-based clearing that did most of the work.

Now the clean skips the accessibility step it isn't allowed to use, finishes successfully, and says how many caches were left behind for it, for example "50 expendable items deleted, 3 caches still need the accessibility service".

If nothing could be cleared at all, the previous error still appears along with its shortcut to the setup screen, so there is still a way to turn accessibility on. That error no longer suggests disabling "Include inaccessible caches". Existing translations of it still carry the old sentence until Crowdin picks up the change.

## Technical Context

- `AppCleanerProcessingTask.useAutomation` defaults to `true` and every manual entry point uses that default, while the scheduled path reads `SchedulerSettings.useAutomation` (default `false`). `AutomationManager.serviceLauncher` throws `AutomationNoConsentException` immediately when consent is absent and never prompts, so the stage could only fail, discarding whatever the Shizuku trim had already cleared.
- The gate reads ACS consent specifically rather than `AutomationManager.useAcs`. `useAcs` is stricter than the condition that actually throws: it is also false when consent is granted but the service isn't running, a state that raises `AutomationNotRunningException` with its own actionable error, which should keep surfacing.
- The skip is deliberately not recorded for the explicit `useAutomation=false` path. That is the scheduler's user-configured setting, and reporting it as a capability failure would mislabel a deliberate choice on every scheduled run that leaves caches behind.
- Preserving the failure when nothing was salvaged is load-bearing. `InaccessibleDeletionException` carries `fixActionRoute = SetupRoute(AUTOMATION)` and is the only affordance that offers consent. Targeted deletes never run the Shizuku trim, so without that branch they would report "Success, 0 items" instead.
- Worth close review: `skippedNoConsent` excludes both successful and ADB-failed targets. ADB failures stay in `failedTargets` but are not removed from `remainingTargets`, so an ADB-failed package would otherwise be counted as both failed and skipped.
- The result string composes two independently pluralized counts: the outer plural is selected on the skipped count, and the deleted count is rendered by the existing `appcleaner_result_x_items_deleted` plural and passed in as `%1$s`. That keeps the separator inside the translatable resource instead of concatenating in Kotlin, and `AppCleanerProcessingResultTextTest` pins all four singular/plural combinations.
