### PR TITLE
Scheduler: Explain that a schedule must be disabled to change it

### DIFF
--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModel.kt
@@ -154,12 +154,11 @@ class SchedulerManagerViewModel @Inject constructor(
         schedulerManager.state,
         showBatteryOptimizationHint,
         acsScreenLockedRisk,
-    ) { schedulerState, showBatteryHint, acsRisk ->
+        rootManager.useRoot,
+        adbManager.useAdb,
+    ) { schedulerState, showBatteryHint, acsRisk, useRoot, useAdb ->
         val sortedSchedules = schedulerState.schedules.sortedBy { it.label.lowercase() }
-        // showCommands re-resolved per-emission via the suspend `combine` block; this only
-        // refreshes when schedulerManager.state re-emits, so root/ADB becoming available mid-screen
-        // won't surface until the next emission. Same trade-off as legacy.
-        val showCommands = rootManager.canUseRootNow() || adbManager.canUseAdbNow()
+        val showCommands = useRoot || useAdb
         val acsScreenLockedRisk = if (sortedSchedules.any { it.isEnabled && it.useAppCleaner }) {
             acsRisk
         } else {

--- a/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/items/ScheduleRow.kt
+++ b/app-tool-scheduler/src/main/java/eu/darken/sdmse/scheduler/ui/manager/items/ScheduleRow.kt
@@ -150,6 +150,14 @@ internal fun ScheduleRow(
                 Switch(checked = isEnabled, onCheckedChange = { onToggle() })
             }
 
+            if (isEnabled) {
+                Text(
+                    text = stringResource(R.string.scheduler_schedule_disable_to_edit_hint),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
             Spacer(modifier = Modifier.padding(vertical = 4.dp))
             ToolToggleRow(
                 label = stringResource(CommonR.string.corpsefinder_tool_name),

--- a/app-tool-scheduler/src/main/res/values/strings.xml
+++ b/app-tool-scheduler/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="scheduler_schedule_name_label">Schedule name</string>
     <string name="scheduler_schedule_toggle_enabled">Schedule is enabled</string>
     <string name="scheduler_schedule_toggle_disabled">Schedule is disabled</string>
+    <string name="scheduler_schedule_disable_to_edit_hint">Disable the schedule to change it.</string>
     <string name="scheduler_edit_schedule_action">Edit schedule</string>
     <string name="scheduler_schedule_time_label">Approximate time</string>
     <string name="scheduler_schedule_repeat_label">Repeat interval in days</string>

--- a/app-tool-scheduler/src/test/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModelTest.kt
+++ b/app-tool-scheduler/src/test/java/eu/darken/sdmse/scheduler/ui/manager/SchedulerManagerViewModelTest.kt
@@ -1,0 +1,133 @@
+package eu.darken.sdmse.scheduler.ui.manager
+
+import android.content.Context
+import eu.darken.sdmse.common.BatteryHelper
+import eu.darken.sdmse.common.WebpageTool
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.shell.ShellOps
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.main.core.GeneralSettings
+import eu.darken.sdmse.main.core.taskmanager.AcsScheduleRisk
+import eu.darken.sdmse.main.core.taskmanager.SchedulerAppCleanerAdvisor
+import eu.darken.sdmse.scheduler.core.Schedule
+import eu.darken.sdmse.scheduler.core.SchedulerManager
+import eu.darken.sdmse.scheduler.core.SchedulerSettings
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+import testhelpers.mockDataStoreValue
+
+class SchedulerManagerViewModelTest : BaseTest() {
+
+    private class Harness(
+        val vm: SchedulerManagerViewModel,
+        val useRoot: MutableStateFlow<Boolean>,
+        val useAdb: MutableStateFlow<Boolean>,
+        val schedules: MutableStateFlow<SchedulerManager.State>,
+    )
+
+    private fun TestScope.harness(
+        useRoot: Boolean = false,
+        useAdb: Boolean = false,
+    ): Harness {
+        val rootFlow = MutableStateFlow(useRoot)
+        val adbFlow = MutableStateFlow(useAdb)
+        // A seeded schedule keeps the init block's one-shot default-entry creation from firing and
+        // mutating what the test is observing.
+        val schedules = MutableStateFlow(
+            SchedulerManager.State(schedules = setOf(Schedule(id = "test-schedule", label = "Test"))),
+        )
+        val schedulerManager = mockk<SchedulerManager>(relaxed = true).apply {
+            every { state } returns schedules
+        }
+        val settings = mockk<SchedulerSettings>().apply {
+            every { useAutomation } returns mockDataStoreValue(false)
+            every { createdDefaultEntry } returns mockDataStoreValue(true)
+            every { hintBatteryDismissed } returns mockDataStoreValue(false)
+            every { hintAcsScreenLockedDismissed } returns mockDataStoreValue(false)
+        }
+        val generalSettings = mockk<GeneralSettings>().apply {
+            every { hasAcsConsent } returns mockDataStoreValue(true)
+        }
+        val vm = SchedulerManagerViewModel(
+            context = mockk<Context>(relaxed = true),
+            dispatcherProvider = TestDispatcherProvider(),
+            schedulerManager = schedulerManager,
+            settings = settings,
+            generalSettings = generalSettings,
+            appCleanerAdvisor = mockk<SchedulerAppCleanerAdvisor>().apply {
+                every { acsScheduleRisk } returns flowOf(AcsScheduleRisk.NONE)
+            },
+            upgradeRepo = mockk<UpgradeRepo>(relaxed = true),
+            rootManager = mockk<RootManager>().apply { every { this@apply.useRoot } returns rootFlow },
+            adbManager = mockk<AdbManager>().apply { every { this@apply.useAdb } returns adbFlow },
+            batteryHelper = mockk<BatteryHelper>().apply {
+                every { isIgnoringBatteryOptimizations } returns flowOf(false)
+            },
+            webpageTool = mockk<WebpageTool>(relaxed = true),
+            shellOps = mockk<ShellOps>(relaxed = true),
+        )
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        return Harness(vm, rootFlow, adbFlow, schedules)
+    }
+
+    @Test
+    fun `ADB becoming available reveals the commands section without a schedule change`() = runTest2 {
+        val h = harness()
+        advanceUntilIdle()
+        h.vm.state.first().showCommands shouldBe false
+
+        h.useAdb.value = true
+        advanceUntilIdle()
+
+        h.vm.state.first().showCommands shouldBe true
+    }
+
+    @Test
+    fun `root becoming available reveals the commands section without a schedule change`() = runTest2 {
+        val h = harness()
+        advanceUntilIdle()
+        h.vm.state.first().showCommands shouldBe false
+
+        h.useRoot.value = true
+        advanceUntilIdle()
+
+        h.vm.state.first().showCommands shouldBe true
+    }
+
+    @Test
+    fun `revoked ADB access hides the commands section again`() = runTest2 {
+        val h = harness(useAdb = true)
+        advanceUntilIdle()
+        h.vm.state.first().showCommands shouldBe true
+
+        h.useAdb.value = false
+        advanceUntilIdle()
+
+        h.vm.state.first().showCommands shouldBe false
+    }
+
+    @Test
+    fun `revoked root access hides the commands section again`() = runTest2 {
+        val h = harness(useRoot = true)
+        advanceUntilIdle()
+        h.vm.state.first().showCommands shouldBe true
+
+        h.useRoot.value = false
+        advanceUntilIdle()
+
+        h.vm.state.first().showCommands shouldBe false
+    }
+}


### PR DESCRIPTION
## What changed

An enabled schedule is read-only: its tool switches, its Remove and Edit buttons, and the edit button for commands that run after the schedule are all greyed out until you disable it. Nothing on screen said so, so anyone trying to set a post-schedule command just found a dead button with no explanation. The schedule row now says that the schedule has to be disabled before it can be changed.

The section for post-schedule commands also only appeared if root or Shizuku access was already available when the screen loaded. Granting Shizuku while the screen was open left the section hidden until you navigated away and came back. It now appears as soon as access becomes available, and disappears again if access is revoked.

## Technical Context

- The read-only rule is row-wide, not specific to the commands field: `rowEnabled = !isEnabled` gates the tool toggles, Remove, Edit schedule and the commands edit button alike, and the matching ViewModel guards are documented race guards behind that UI. The hint is therefore placed under the enable switch, above every control it explains, rather than next to the commands field.
- No `enabled = rowEnabled` wiring and no ViewModel guard changed. The editing model is untouched; only its discoverability changes.
- `showCommands` was computed inside the state `combine` by calling the suspend helpers `canUseRootNow()` / `canUseAdbNow()`, so it only re-resolved when `schedulerManager.state` re-emitted. It now takes `rootManager.useRoot` and `adbManager.useAdb` as `combine` inputs. Those are exactly what the suspend helpers read (`canUseRootNow() = useRoot.first()`), so the resolved value is unchanged and only its timing differs.
- `useRoot` is a shared `stateIn` that withholds emission until its first probe completes, which is the same wait the previous `.first()` call performed. Subscribing continuously does not add a root probe or delay the screen.
