### PR TITLE
AppCleaner: Clean more leftover log and cache folders

### DIFF
--- a/app/src/main/assets/expendables/db_bug_reporting_files.json
+++ b/app/src/main/assets/expendables/db_bug_reporting_files.json
@@ -484,6 +484,28 @@
 		  ]
 		}
 	  ]
+	}, {
+	  "packages": [
+		"com.heytap.htms",
+		"com.oplus.aiunit",
+		"com.oplus.screenshot",
+		"com.coloros.smartsidebar",
+		"com.oplus.themestore",
+		"com.oplus.games"
+	  ],
+	  "fileFilter": [
+		{
+		  "locations": ["PUBLIC_DATA"],
+		  "contains": [
+			"/HLog_file/",
+			"/HLog_cache/",
+			"/hlog/",
+			"/app_log/",
+			"/.opos_ad_log/",
+			"/.opos_ad_mmap_cache_log/"
+		  ]
+		}
+	  ]
 	}
   ]
 }

--- a/app/src/main/assets/expendables/db_hidden_caches_files.json
+++ b/app/src/main/assets/expendables/db_hidden_caches_files.json
@@ -1367,6 +1367,15 @@
 		  ]
 		}
 	  ]
+	}, {
+	  "packages": ["com.grofers.customerapp"],
+	  "fileFilter": [
+		{
+		  "locations": ["PUBLIC_DATA"],
+		  "contains": ["/video_cache/"],
+		  "patterns": ["^com\\.grofers\\.customerapp/.+?/video_cache/.+?\\.exo$"]
+		}
+	  ]
 	}
   ]
 }

--- a/app/src/main/assets/expendables/db_thumbnail_files.json
+++ b/app/src/main/assets/expendables/db_thumbnail_files.json
@@ -92,7 +92,10 @@
 	  "fileFilter": [
 		{
 		  "locations": ["PUBLIC_DATA"],
-		  "startsWith": ["com.oneplus.gallery/files/blob_cache/"]
+		  "startsWith": [
+			"com.oneplus.gallery/files/blob_cache/",
+			"com.oneplus.gallery/files/cloud/thumb/"
+		  ]
 		}
 	  ]
 	}, {

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/BugReportingFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/BugReportingFilterTest.kt
@@ -1089,4 +1089,31 @@ class BugReportingFilterTest : BaseFilterTest() {
 
         confirm(create())
     }
+
+    @Test fun `test heytap oppo logging dirs`() = runTest {
+        addDefaultNegatives()
+
+        neg("com.heytap.htms", PUBLIC_DATA, "com.heytap.htms/files/HeyTap/HLog_file")
+        pos("com.heytap.htms", PUBLIC_DATA, "com.heytap.htms/files/HeyTap/HLog_file/HLog_File_$rngString.dog3")
+        neg("com.oplus.aiunit", PUBLIC_DATA, "com.oplus.aiunit/files/x/HLog_cache")
+        pos("com.oplus.aiunit", PUBLIC_DATA, "com.oplus.aiunit/files/x/HLog_cache/y/nlog_cache/nlog.mmap2")
+        neg("com.oplus.screenshot", PUBLIC_DATA, "com.oplus.screenshot/files/hlog")
+        pos("com.oplus.screenshot", PUBLIC_DATA, "com.oplus.screenshot/files/hlog/$rngString.log")
+        neg("com.oplus.games", PUBLIC_DATA, "com.oplus.games/files/app_log")
+        pos("com.oplus.games", PUBLIC_DATA, "com.oplus.games/files/app_log/$rngString.log")
+        neg("com.oplus.themestore", PUBLIC_DATA, "com.oplus.themestore/files/.opos_ad_log")
+        pos("com.oplus.themestore", PUBLIC_DATA, "com.oplus.themestore/files/.opos_ad_log/$rngString.log")
+        neg("com.coloros.smartsidebar", PUBLIC_DATA, "com.coloros.smartsidebar/files/.opos_ad_mmap_cache_log")
+        pos("com.coloros.smartsidebar", PUBLIC_DATA, "com.coloros.smartsidebar/files/.opos_ad_mmap_cache_log/$rngString.log")
+
+        neg("com.heytap.htms", PUBLIC_DATA, "com.heytap.htms/files/HeyTap/HLog_file_backup/$rngString.dog3")
+        neg("com.oplus.games", PUBLIC_DATA, "com.oplus.games/files/app_logs/$rngString.log")
+
+        neg(testPkg, PUBLIC_DATA, "$testPkg/files/HeyTap/HLog_file/$rngString.dog3")
+
+        neg("com.heytap.htms", PRIVATE_DATA, "com.heytap.htms/files/HeyTap/HLog_file/$rngString.dog3")
+        neg("com.heytap.htms", SDCARD, "com.heytap.htms/files/HeyTap/HLog_file/$rngString.dog3")
+
+        confirm(create())
+    }
 }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/HiddenFilterTest.kt
@@ -2005,4 +2005,23 @@ class HiddenFilterTest : BaseFilterTest() {
 
         confirm(create())
     }
+
+    @Test fun `grofers video cache`() = runTest {
+        neg("com.grofers.customerapp", PUBLIC_DATA, "com.grofers.customerapp/files/downloads/video_cache")
+        neg("com.grofers.customerapp", PUBLIC_DATA, "com.grofers.customerapp/files/downloads/video_cache/0")
+        pos("com.grofers.customerapp", PUBLIC_DATA, "com.grofers.customerapp/files/downloads/video_cache/0/$rngString.exo")
+
+        neg(
+            "com.grofers.customerapp",
+            PUBLIC_DATA,
+            "com.grofers.customerapp/files/downloads/video_cache/0/cached_content.uid"
+        )
+        neg(testPkg, PUBLIC_DATA, "com.grofers.customerapp/files/downloads/video_cache/0/$rngString.exo")
+        neg("com.grofers.customerapp", PUBLIC_DATA, "com.grofers.customerapp/files/downloads/video_caches/0/$rngString.exo")
+
+        neg("com.grofers.customerapp", PRIVATE_DATA, "com.grofers.customerapp/files/downloads/video_cache/0/$rngString.exo")
+        neg("com.grofers.customerapp", SDCARD, "com.grofers.customerapp/files/downloads/video_cache/0/$rngString.exo")
+
+        confirm(create())
+    }
 }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/forensics/filter/ThumbnailsFilterTest.kt
@@ -253,4 +253,22 @@ class ThumbnailsFilterTest : BaseFilterTest() {
         }
         confirm(create())
     }
+
+    @Test fun `test oneplus gallery cloud thumb filter`() = runTest {
+        addDefaultNegatives()
+
+        neg("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/cloud/thumb")
+        neg("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/cloud/thumbnails/$rngString")
+        neg("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/cloud/thumb/.nomedia")
+        neg(testPkg, PUBLIC_DATA, "com.oneplus.gallery/files/cloud/thumb/${rngString}_360")
+
+        neg("com.oneplus.gallery", PRIVATE_DATA, "com.oneplus.gallery/files/cloud/thumb/${rngString}_360")
+        neg("com.oneplus.gallery", SDCARD, "com.oneplus.gallery/files/cloud/thumb/${rngString}_360")
+        neg("com.oneplus.gallery", PUBLIC_MEDIA, "com.oneplus.gallery/files/cloud/thumb/${rngString}_360")
+
+        pos("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/cloud/thumb/${rngString}_360")
+        pos("com.oneplus.gallery", PUBLIC_DATA, "com.oneplus.gallery/files/cloud/thumb/${rngString}_1440")
+
+        confirm(create())
+    }
 }


### PR DESCRIPTION
## What changed

AppCleaner now recognises three more kinds of expendable data that it previously walked straight past:

- **HeyTap/OPPO log folders.** Several preinstalled OnePlus and OPPO system apps write logs into their own data directory (`HLog_file`, `HLog_cache`, `hlog`, `app_log`, and two ad-log folders). On the device these were observed on, that came to 349 files and roughly 52 MB.
- **A video cache in Blinkit** that sits one folder deeper than AppCleaner used to look, about 39 MB there.
- **The OnePlus Gallery's cloud thumbnail folder**, about 11 MB.

Worth knowing before expecting to see space freed: the OnePlus/OPPO items belong to preinstalled system apps, and AppCleaner skips system apps unless *Include system apps* is turned on. The log folders additionally need the *Bug reporting files* filter, which is off by default too. The Blinkit video cache is the only one of the three that shows up with stock settings.

## Technical Context

- Root cause is the same for all three: the folder-name filters only examine the first path segment, or the second when the first is `files`. A folder sitting deeper never matches even when its name is already in the filter's vocabulary. `video_cache` is the clearest case — it was already a known hidden-cache name, just never reached at that depth.
- All three land as JSON sieve entries rather than additions to the Kotlin folder lists, specifically so they don't re-inherit that depth ceiling. Directory names are wrapped in slashes, which makes the sieve's substring test segment-exact, so a sibling like `HLog_file_backup` does not match.
- The Blinkit rule is keyed on the `video_cache` folder name and constrained to `.exo` files. Keying on `.exo` alone would also match YouTube's user-downloaded offline videos, which use the same file format and the same ExoPlayer cache machinery. The filename constraint also means directories never match, so nothing becomes a recursive deletion root and the minimum-age setting still applies per file.
- The log-folder rule is scoped to the six packages actually observed writing those folders rather than applied globally. Every package-agnostic entry in that sieve carries a filename regex; a global entry without one would have been the first. Three further packages write the same folder names under `cache/` instead, where the default cache filter already covers them, so they need no entry.
- The OnePlus Gallery rule deliberately carries no filename constraint: those thumbnails come in two render sizes (`_360` and `_1440`), so constraining on either would have missed most of them.
