### PR TITLE
AppCleaner: Warn when Shizuku clears an excluded app's cache anyway

### DIFF
--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/layout/SdmWholeScopeActions.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/compose/layout/SdmWholeScopeActions.kt
@@ -33,19 +33,22 @@ fun SdmWholeScopeActions(
     enabled: Boolean,
     onExclude: () -> Unit,
     onDelete: () -> Unit,
+    showExclude: Boolean = true,
 ) {
     Row(
         modifier = modifier,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        FilledTonalButton(
-            onClick = onExclude,
-            modifier = Modifier.weight(1f),
-            enabled = enabled,
-        ) {
-            Icon(SdmIcons.ShieldAdd, contentDescription = null)
-            Spacer(Modifier.width(8.dp))
-            Text(stringResource(CommonR.string.general_exclude_action))
+        if (showExclude) {
+            FilledTonalButton(
+                onClick = onExclude,
+                modifier = Modifier.weight(1f),
+                enabled = enabled,
+            ) {
+                Icon(SdmIcons.ShieldAdd, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text(stringResource(CommonR.string.general_exclude_action))
+            }
         }
         Button(
             onClick = onDelete,
@@ -71,6 +74,19 @@ private fun SdmWholeScopeActionsPreview() {
             enabled = true,
             onExclude = {},
             onDelete = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun SdmWholeScopeActionsWithoutExcludePreview() {
+    PreviewWrapper {
+        SdmWholeScopeActions(
+            enabled = true,
+            onExclude = {},
+            onDelete = {},
+            showExclude = false,
         )
     }
 }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -16,6 +16,7 @@ import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerTask.StopReason
 import eu.darken.sdmse.automation.core.errors.isScreenUnavailable
 import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.adb.canUseAdbNow
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
@@ -102,7 +103,7 @@ class AppCleaner @Inject constructor(
     private val pkgOps: PkgOps,
     @SetupBinding(SetupModule.Type.USAGE_STATS) usageStatsSetupModule: SetupModule,
     rootManager: RootManager,
-    adbManager: AdbManager,
+    private val adbManager: AdbManager,
     private val shellOps: ShellOps,
     private val filterFactories: Set<@JvmSuppressWildcards ExpendablesFilter.Factory>,
     @SetupBinding(SetupModule.Type.INVENTORY) private val appInventorySetupModule: SetupModule,
@@ -264,6 +265,13 @@ class AppCleaner @Inject constructor(
             val targetJunk = task.targetPkgs
                 ?.map { tp -> snapshot.junks.single { it.identifier == tp } }
                 ?: snapshot.junks
+                    // Exclusion-limited junks are in the snapshot because the ADB cache trim would
+                    // reach them anyway. If this task won't run that trim, nothing justifies
+                    // deleting their files directly.
+                    .let { junks ->
+                        val willTrim = task.includeInaccessible && adbManager.canUseAdbNow()
+                        if (willTrim) junks else junks.filter { !it.isExclusionLimited }
+                    }
 
             updateProgressCount(Progress.Count.Percent(targetJunk.size))
 
@@ -421,7 +429,7 @@ class AppCleaner @Inject constructor(
                         else -> appJunk.acsError
                     },
                 )
-            }.filter { !it.isEmpty() }
+            }.filter { !it.isEmpty() }.pruneOrphanedExclusionLimited()
         )
 
         // `acsResult` is a var (the partial-result callback writes to it), so it won't smart-cast.
@@ -472,13 +480,19 @@ class AppCleaner @Inject constructor(
                 tags = setOf(Exclusion.Tag.APPCLEANER),
             )
         }.toSet()
+
+        // Everything that can suspend or fail is resolved before save(), otherwise a cancel between
+        // a durable exclusion and the state rewrite would leave stale data and no undo handle.
+        val snapshot = internalData.value!!
+        val canUseAdb = adbManager.canUseAdbNow()
+
         val saved = exclusionManager.save(exclusions)
 
-        val snapshot = internalData.value!!
         val updated = snapshot.copy(
-            junks = snapshot.junks.filter { junk ->
-                exclusions.none { it.match(junk.identifier.pkgId) }
-            }
+            junks = snapshot.junks.mapNotNull { junk ->
+                if (exclusions.none { it.match(junk.identifier.pkgId) }) return@mapNotNull junk
+                if (canUseAdb) junk.limitToTrimBlastRadius() else null
+            }.pruneOrphanedExclusionLimited()
         )
         internalData.value = updated
 
@@ -543,7 +557,7 @@ class AppCleaner @Inject constructor(
                 } else {
                     junk
                 }
-            }
+            }.pruneOrphanedExclusionLimited()
         )
 
         log(TAG) { "exclude(): Excluded $excludedCount of $totalCount matches for $identifier" }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -266,12 +266,8 @@ class AppCleaner @Inject constructor(
                 ?.map { tp -> snapshot.junks.single { it.identifier == tp } }
                 ?: snapshot.junks
                     // Exclusion-limited junks are in the snapshot because the ADB cache trim would
-                    // reach them anyway. If this task won't run that trim, nothing justifies
-                    // deleting their files directly.
-                    .let { junks ->
-                        val willTrim = task.includeInaccessible && adbManager.canUseAdbNow()
-                        if (willTrim) junks else junks.filter { !it.isExclusionLimited }
-                    }
+                    // reach them anyway. Deleting their files directly is never ours to do.
+                    .filter { !it.isExclusionLimited }
 
             updateProgressCount(Progress.Count.Percent(targetJunk.size))
 

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleaner.kt
@@ -370,63 +370,62 @@ class AppCleaner @Inject constructor(
 
         val deleted = mutableSetOf<APath>()
 
-        internalData.value = snapshot.copy(
-            junks = snapshot.junks.map { appJunk ->
-                updateProgressSecondary(appJunk.label, extra = appJunk.pkg)
-                // Remove all files we deleted or children of deleted files
+        val reconciledJunks = snapshot.junks.map { appJunk ->
+            updateProgressSecondary(appJunk.label, extra = appJunk.pkg)
+            // Remove all files we deleted or children of deleted files
 
-                val deletedInaccessible = mutableSetOf<ExpendablesFilter.Match>()
+            val deletedInaccessible = mutableSetOf<ExpendablesFilter.Match>()
 
-                val updatedExpendables = appJunk.expendables?.mapValues { (type, matches) ->
-                    if (type == DefaultCachesPublicFilter::class && acsResult?.succesful?.contains(appJunk.identifier) == true) {
-                        // It's inaccessible caches were deleted, this included the default public caches
-                        return@mapValues emptySet<ExpendablesFilter.Match>()
-                    }
-
-                    matches.filter { match ->
-                        val isDeleted = accessibleDeletionMap.getOrDefault(appJunk.identifier, emptySet()).any {
-                            it.path.isAncestorOf(match.path) || it.path.matches(match.path)
-                        }
-                        if (isDeleted) {
-                            deleted.add(match.path)
-                            if (match.identifier == DefaultCachesPublicFilter::class) {
-                                // We need path and size to update the size of `InaccessibleCache` later
-                                deletedInaccessible.add(match)
-                            }
-                        }
-                        !isDeleted
-                    }
-                }?.filterValues { it.isNotEmpty() }
-
-                val updatedInaccessible = appJunk.inaccessibleCache?.let { inacc ->
-                    if (acsResult?.succesful?.contains(appJunk.identifier) == true) {
-                        // Inaccessible were deleted, `expendables` should have been updated correctly by above code
-                        deleted.addAll(inacc.theoreticalPaths)
-                        return@let null
-                    }
-
-                    val deletedSize = deletedInaccessible.sumOf { it.expectedGain }
-                    inacc.copy(
-                        totalSize = inacc.totalSize - deletedSize,
-                        publicSize = inacc.publicSize?.let { it - deletedSize }?.coerceAtLeast(0L),
-                    )
+            val updatedExpendables = appJunk.expendables?.mapValues { (type, matches) ->
+                if (type == DefaultCachesPublicFilter::class && acsResult?.succesful?.contains(appJunk.identifier) == true) {
+                    // It's inaccessible caches were deleted, this included the default public caches
+                    return@mapValues emptySet<ExpendablesFilter.Match>()
                 }
 
+                matches.filter { match ->
+                    val isDeleted = accessibleDeletionMap.getOrDefault(appJunk.identifier, emptySet()).any {
+                        it.path.isAncestorOf(match.path) || it.path.matches(match.path)
+                    }
+                    if (isDeleted) {
+                        deleted.add(match.path)
+                        if (match.identifier == DefaultCachesPublicFilter::class) {
+                            // We need path and size to update the size of `InaccessibleCache` later
+                            deletedInaccessible.add(match)
+                        }
+                    }
+                    !isDeleted
+                }
+            }?.filterValues { it.isNotEmpty() }
 
-                appJunk.copy(
-                    expendables = updatedExpendables,
-                    inaccessibleCache = updatedInaccessible,
-                    acsError = when {
-                        acsResult == null -> appJunk.acsError
-                        acsResult.failed.containsKey(appJunk.identifier) -> acsResult.failed[appJunk.identifier]
-                        acsResult.succesful.contains(appJunk.identifier) -> null
-                        // Not attempted this run (e.g. a targeted delete of other apps): a fresh
-                        // null must not erase what the last actual attempt learned.
-                        else -> appJunk.acsError
-                    },
+            val updatedInaccessible = appJunk.inaccessibleCache?.let { inacc ->
+                if (acsResult?.succesful?.contains(appJunk.identifier) == true) {
+                    // Inaccessible were deleted, `expendables` should have been updated correctly by above code
+                    deleted.addAll(inacc.theoreticalPaths)
+                    return@let null
+                }
+
+                val deletedSize = deletedInaccessible.sumOf { it.expectedGain }
+                inacc.copy(
+                    totalSize = inacc.totalSize - deletedSize,
+                    publicSize = inacc.publicSize?.let { it - deletedSize }?.coerceAtLeast(0L),
                 )
-            }.filter { !it.isEmpty() }.pruneOrphanedExclusionLimited()
-        )
+            }
+
+
+            appJunk.copy(
+                expendables = updatedExpendables,
+                inaccessibleCache = updatedInaccessible,
+                acsError = when {
+                    acsResult == null -> appJunk.acsError
+                    acsResult.failed.containsKey(appJunk.identifier) -> acsResult.failed[appJunk.identifier]
+                    acsResult.succesful.contains(appJunk.identifier) -> null
+                    // Not attempted this run (e.g. a targeted delete of other apps): a fresh
+                    // null must not erase what the last actual attempt learned.
+                    else -> appJunk.acsError
+                },
+            )
+        }.filter { !it.isEmpty() }
+        internalData.value = snapshot.copy(junks = reconciledJunks.pruneOrphanedExclusionLimited())
 
         // `acsResult` is a var (the partial-result callback writes to it), so it won't smart-cast.
         val acsOutcome = acsResult
@@ -445,7 +444,7 @@ class AppCleaner @Inject constructor(
         // the pre- and post-deletion scan totals. Deriving it from the snapshot avoids re-deriving the
         // accessible/inaccessible/public-cache counting rules in a second hand-rolled counter, and it counts ACS
         // cache clears at scan scale rather than as the <=2 synthetic paths that land in `affectedPaths`.
-        val affectedCount = (snapshot.totalCount - (internalData.value?.totalCount ?: 0)).coerceAtLeast(0)
+        val affectedCount = (snapshot.totalCount - reconciledJunks.sumOf { it.itemCount }).coerceAtLeast(0)
         val salvaged = AppCleanerProcessingTask.Success(
             affectedSpace = accessibleDeletionMap.values.sumOf { contents -> contents.sumOf { it.expectedGain } } + automationSize,
             affectedPaths = deleted,

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensions.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensions.kt
@@ -9,3 +9,20 @@ val AppCleaner.Data?.hasData: Boolean
  */
 val AppCleaner.Data?.hasActionableData: Boolean
     get() = this?.junks?.any { !it.isUnclearable } ?: false
+
+/**
+ * Whether the snapshot still contains a target that would make a whole-tool clean reach the ADB
+ * cache trim. Exclusion-limited junks don't count, otherwise the condition could satisfy itself.
+ *
+ * Pinned by `AppCleanerTest.a snapshot whose last trim-eligible junk is gone drops its
+ * exclusion-limited entries`.
+ */
+fun Collection<AppJunk>.hasTrimEligibleTargets(): Boolean =
+    any { !it.isExclusionLimited && it.inaccessibleCache != null }
+
+/**
+ * An exclusion-limited junk may only exist alongside a junk that keeps the trim reachable, e.g.
+ * a snapshot of [limited(excluded app), normal(no inaccessible cache)] becomes [normal].
+ */
+fun Collection<AppJunk>.pruneOrphanedExclusionLimited(): Collection<AppJunk> =
+    if (hasTrimEligibleTargets()) this else filter { !it.isExclusionLimited }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/AppJunk.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.appcleaner.core
 import eu.darken.sdmse.appcleaner.core.automation.errors.LockedAppCacheException
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilterIdentifier
+import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPrivateFilter
 import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPublicFilter
 import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
 import eu.darken.sdmse.automation.core.errors.DisabledAppException
@@ -20,6 +21,7 @@ data class AppJunk(
     val expendables: Map<ExpendablesFilterIdentifier, Collection<ExpendablesFilter.Match>>?,
     val inaccessibleCache: InaccessibleCache?,
     val acsError: Exception? = null,
+    val isExclusionLimited: Boolean = false,
 ) {
 
     val identifier: InstallId
@@ -80,4 +82,28 @@ data class AppJunk(
 
     override fun toString(): String =
         "AppJunk(${pkg.packageName}, categories=${expendables?.size}, inaccessible=$inaccessibleCache)"
+}
+
+/** The content a device-global cache trim can reach, i.e. what an app exclusion can't protect. */
+val TRIM_BLAST_RADIUS_FILTERS: Set<ExpendablesFilterIdentifier> = setOf(
+    DefaultCachesPublicFilter::class,
+    DefaultCachesPrivateFilter::class,
+)
+
+/**
+ * Narrows this junk to [TRIM_BLAST_RADIUS_FILTERS] plus its inaccessible cache, or `null` if
+ * neither is left.
+ */
+fun AppJunk.limitToTrimBlastRadius(): AppJunk? {
+    val narrowed = expendables
+        ?.filterKeys { TRIM_BLAST_RADIUS_FILTERS.contains(it) }
+        ?.filterValues { it.isNotEmpty() }
+        ?.takeIf { it.isNotEmpty() }
+
+    if (narrowed == null && inaccessibleCache == null) return null
+
+    return copy(
+        expendables = narrowed,
+        isExclusionLimited = true,
+    )
 }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -124,12 +124,22 @@ class InaccessibleDeleter @Inject constructor(
     }
 
     private suspend fun deleteInaccessible(
-        targets: Collection<AppJunk>,
+        rawTargets: Collection<AppJunk>,
         isAllApps: Boolean,
         useAutomation: Boolean,
         isBackground: Boolean,
         onPartialResult: (InaccDelResult) -> Unit,
     ): InaccDelResult {
+        // Only a whole-tool clean issues the device-global trim, and only then are exclusion-limited
+        // junks part of the scan results at all. Without the trim there is no reason to touch them.
+        val willTrim = adbManager.canUseAdbNow() && isAllApps
+        val targets = when {
+            !isAllApps -> rawTargets
+            willTrim -> rawTargets
+            // Whole-tool clean without the trim: nothing will reach these anyway.
+            else -> rawTargets.filter { !it.isExclusionLimited }
+        }
+
         log(TAG) { "${targets.size} inaccessible caches to delete." }
         if (targets.isEmpty()) return InaccDelResult()
 
@@ -144,7 +154,7 @@ class InaccessibleDeleter @Inject constructor(
         // the observation so it keeps contributing its scan-time size, exactly as before.
         val zeroCacheSkips = mutableSetOf<InstallId>()
 
-        if (adbManager.canUseAdbNow() && isAllApps) {
+        if (willTrim) {
             val adbResult = trimCachesWithAdb(targets)
             successTargets.addAll(adbResult.succesful)
             failedTargets.putAll(adbResult.failed)
@@ -152,6 +162,11 @@ class InaccessibleDeleter @Inject constructor(
 
         val remainingTargets = targets
             .filter { !successTargets.contains(it.identifier) }
+            // The trim covered these and may have cleared them, but driving their settings page or
+            // force-stopping them are actions the exclusion ruled out. A limited target the trim
+            // did not confirm is left alone rather than reported as a failed attempt. A targeted
+            // clean of such an entry is an explicit user action and keeps the full treatment.
+            .filter { !willTrim || !it.isExclusionLimited }
             .filter { junk ->
                 val currentCache = inaccessibleCacheProvider.determineCache(junk.pkg)
                 if (currentCache != null && currentCache.totalSize == 0L) {

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/InaccessibleDeleter.kt
@@ -154,10 +154,14 @@ class InaccessibleDeleter @Inject constructor(
         // the observation so it keeps contributing its scan-time size, exactly as before.
         val zeroCacheSkips = mutableSetOf<InstallId>()
 
+        // The trim can credit a limited target with a success, but a per-app clear was never
+        // attempted for it, so it must not be able to report a failure either.
+        val limitedIds = targets.filter { it.isExclusionLimited }.map { it.identifier }.toSet()
+
         if (willTrim) {
             val adbResult = trimCachesWithAdb(targets)
             successTargets.addAll(adbResult.succesful)
-            failedTargets.putAll(adbResult.failed)
+            failedTargets.putAll(adbResult.failed.filterKeys { it !in limitedIds })
         }
 
         val remainingTargets = targets

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/scanner/AppScanner.kt
@@ -5,10 +5,14 @@ import eu.darken.sdmse.appcleaner.R
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
 import eu.darken.sdmse.appcleaner.core.AppJunk
+import eu.darken.sdmse.appcleaner.core.limitToTrimBlastRadius
+import eu.darken.sdmse.appcleaner.core.pruneOrphanedExclusionLimited
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilterIdentifier
 import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPublicFilter
 import eu.darken.sdmse.common.ModeUnavailableException
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.adb.canUseAdbNow
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.areas.currentAreas
@@ -87,6 +91,7 @@ class AppScanner @Inject constructor(
     private val inaccessibleCacheProvider: InaccessibleCacheProvider,
     private val userManager: UserManager2,
     private val pkgOps: PkgOps,
+    private val adbManager: AdbManager,
 ) : Progress.Host, Progress.Client {
 
     private val progressPub = MutableStateFlow<Progress.Data?>(
@@ -128,6 +133,18 @@ class AppScanner @Inject constructor(
 
         val pkgExclusions = exclusionManager.pkgExclusions(SDMTool.Type.APPCLEANER)
 
+        // Whether a whole-tool clean would issue the device-global ADB cache trim, which carries no
+        // package identity and so reaches excluded apps too. Mirrors the skip conditions of
+        // `determineInaccessibleCaches(...)` plus ADB availability.
+        val trimBlastRadiusPossible = adbManager.canUseAdbNow()
+            && !rootManager.canUseRootNow()
+            && settings.includeInaccessibleEnabled.value()
+            && settings.filterDefaultCachesPublicEnabled.value()
+            && settings.filterDefaultCachesPrivateEnabled.value()
+        log(TAG) { "trimBlastRadiusPossible=$trimBlastRadiusPossible" }
+
+        val exclusionLimited = mutableSetOf<InstallId>()
+
         updateProgressSecondary(eu.darken.sdmse.common.R.string.general_progress_loading_app_data)
 
         val runningPkgs = try {
@@ -148,7 +165,12 @@ class AppScanner @Inject constructor(
             .filter { pkg ->
                 val isExcluded = pkgExclusions.any { it.match(pkg.id) }
                 if (isExcluded) log(TAG, INFO) { "Excluded package: ${pkg.id}" }
-                !isExcluded
+                if (isExcluded && trimBlastRadiusPossible) {
+                    exclusionLimited.add(pkg.installId)
+                    true
+                } else {
+                    !isExcluded
+                }
             }
             .filter { it.id.name != context.packageName }
 
@@ -157,7 +179,7 @@ class AppScanner @Inject constructor(
         val expendablesFromAppData: Map<InstallId, Collection<ExpendablesFilter.Match>> =
             buildSearchMap(allCurrentPkgs)
                 .onEach { log(TAG) { "Searchmap contains ${it.value.size} pathes for ${it.key}." } }
-                .let { readAppDirs(it) }
+                .let { readAppDirs(it, exclusionLimited) }
 
         val inaccessibleCaches = determineInaccessibleCaches(allCurrentPkgs)
         log(TAG) { "Determined ${inaccessibleCaches.size} in accessible caches" }
@@ -178,12 +200,16 @@ class AppScanner @Inject constructor(
                 log(TAG) { "Guesstimated external cache size as ${inaccessible.publicSize}" }
             }
 
-            AppJunk(
+            val isExclusionLimited = exclusionLimited.contains(pkg.installId)
+            val junk = AppJunk(
                 pkg = pkg,
                 userProfile = if (includeOtherUsers) allUsers.singleOrNull { it.handle == pkg.userHandle } else null,
                 expendables = byFilterType,
                 inaccessibleCache = inaccessible,
+                isExclusionLimited = isExclusionLimited,
             )
+
+            if (isExclusionLimited) junk.limitToTrimBlastRadius() else junk
         }
 
         log(TAG) { "Found ${expendablesFromAppData.size} apps with expendable files" }
@@ -191,7 +217,7 @@ class AppScanner @Inject constructor(
         updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_filtering)
         updateProgressCount(Progress.Count.Indeterminate())
 
-        val prunedAppJunks = postProcessorModule.postProcess(appJunks)
+        val prunedAppJunks = postProcessorModule.postProcess(appJunks).pruneOrphanedExclusionLimited()
         log(TAG, INFO) { "After purging empties we have ${prunedAppJunks.size} apps." }
 
         prunedAppJunks.forEach { appJunk ->
@@ -413,7 +439,8 @@ class AppScanner @Inject constructor(
 
     // internal: exercised directly by AppScannerTest, the public scan() needs the full pkg/area setup
     internal suspend fun readAppDirs(
-        searchPathsOfInterest: Map<AreaInfo, Collection<InstallId>>
+        searchPathsOfInterest: Map<AreaInfo, Collection<InstallId>>,
+        exclusionLimited: Set<InstallId> = emptySet(),
     ): Map<InstallId, Collection<ExpendablesFilter.Match>> {
         updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_searching)
         updateProgressSecondary(CaString.EMPTY)
@@ -436,6 +463,9 @@ class AppScanner @Inject constructor(
 
             val ownersOfInterest = possibleOwners
                 .filter { searchPath.userHandle == systemUser.handle || it.userHandle == searchPath.userHandle }
+                // A match goes to the first owner whose filter hits. Limited owners go last so a
+                // co-owned path keeps being attributed to the owner that reports it today.
+                .sortedBy { exclusionLimited.contains(it) }
                 .onEach { if (Bugs.isTrace) log(TAG, VERBOSE) { "Owners of interest for $target: \n${it.pkgId}" } }
 
             val walkFlow = try {

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkElement.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkElement.kt
@@ -8,6 +8,8 @@ import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
 internal sealed interface AppJunkElement {
     data object Header : AppJunkElement
 
+    data object ExclusionLimited : AppJunkElement
+
     data class Inaccessible(
         val cache: InaccessibleCache,
     ) : AppJunkElement
@@ -31,6 +33,8 @@ internal fun buildAppJunkElements(
 ): List<AppJunkElement> {
     val out = mutableListOf<AppJunkElement>()
     out.add(AppJunkElement.Header)
+
+    if (junk.isExclusionLimited) out.add(AppJunkElement.ExclusionLimited)
 
     junk.inaccessibleCache?.let { out.add(AppJunkElement.Inaccessible(it)) }
 

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPage.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkPage.kt
@@ -105,6 +105,10 @@ internal fun AppJunkPage(
                     )
                 }
 
+                AppJunkElement.ExclusionLimited -> item(key = "exclusion-limited", contentType = "exclusion-limited") {
+                    AppJunkExclusionLimitedCard()
+                }
+
                 is AppJunkElement.Inaccessible -> item(key = "inaccessible", contentType = "inaccessible") {
                     AppJunkInaccessibleRow(
                         cache = element.cache,
@@ -252,6 +256,29 @@ private fun AppJunkPageHeaderCard(
                 enabled = wholeScopeActionsEnabled,
                 onExclude = onExcludeJunk,
                 onDelete = onDeleteJunk,
+                showExclude = !junk.isExclusionLimited,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AppJunkExclusionLimitedCard() {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.appcleaner_exclusion_limited_title),
+                style = MaterialTheme.typography.titleSmall,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.appcleaner_exclusion_limited_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
@@ -468,5 +495,13 @@ private fun AppJunkPagePreview() {
             onDeleteFile = { _, _ -> },
             onToggleCollapse = {},
         )
+    }
+}
+
+@Preview2
+@Composable
+private fun AppJunkExclusionLimitedCardPreview() {
+    PreviewWrapper {
+        AppJunkExclusionLimitedCard()
     }
 }

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/items/AppCleanerListRow.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/list/items/AppCleanerListRow.kt
@@ -19,8 +19,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.coil.AppIconImage
+import eu.darken.sdmse.appcleaner.R
 import eu.darken.sdmse.appcleaner.ui.list.AppCleanerListViewModel
 import eu.darken.sdmse.appcleaner.ui.preview.previewAppCleanerRow
+import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
 import eu.darken.sdmse.common.R as CommonR
 import eu.darken.sdmse.common.compose.SelectableListRow
 import eu.darken.sdmse.common.compose.SelectableListRowIconBox
@@ -105,6 +107,14 @@ fun AppCleanerListRow(
                 )
                 if (junk.isSystemApp) SystemAppChip()
             }
+            if (junk.isExclusionLimited) {
+                Text(
+                    modifier = Modifier.padding(top = 2.dp),
+                    text = stringResource(R.string.appcleaner_exclusion_limited_row_hint),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.tertiary,
+                )
+            }
         }
     }
 }
@@ -132,6 +142,21 @@ private fun AppCleanerListRowSelectedPreview() {
             row = previewAppCleanerRow(),
             selected = true,
             selectionActive = true,
+            onClick = {},
+            onLongClick = {},
+            onDetailsClick = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun AppCleanerListRowExclusionLimitedPreview() {
+    PreviewWrapper {
+        AppCleanerListRow(
+            row = previewAppCleanerRow(junk = previewAppJunk(isExclusionLimited = true)),
+            selected = false,
+            selectionActive = false,
             onClick = {},
             onLongClick = {},
             onDetailsClick = {},

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/preview/AppCleanerPreviewData.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/ui/preview/AppCleanerPreviewData.kt
@@ -88,11 +88,13 @@ internal fun previewAppJunk(
     pkg: Installed = previewInstalled(),
     expendables: Map<kotlin.reflect.KClass<out ExpendablesFilter>, Collection<ExpendablesFilter.Match>>? = previewExpendables(),
     inaccessibleCache: InaccessibleCache? = previewInaccessibleCache(),
+    isExclusionLimited: Boolean = false,
 ): AppJunk = AppJunk(
     pkg = pkg,
     userProfile = null,
     expendables = expendables,
     inaccessibleCache = inaccessibleCache,
+    isExclusionLimited = isExclusionLimited,
 )
 
 internal fun previewAppCleanerRow(

--- a/app-tool-appcleaner/src/main/res/values/strings.xml
+++ b/app-tool-appcleaner/src/main/res/values/strings.xml
@@ -81,6 +81,9 @@
 
     <string name="appcleaner_item_caches_inaccessible_title">Default caches</string>
     <string name="appcleaner_item_caches_inaccessible_body">Public and private default caches. Not directly accessible, but can be deleted indirectly (e.g. via accessibility service).</string>
+    <string name="appcleaner_exclusion_limited_row_hint">Excluded, but cleaning all apps at once still clears these caches</string>
+    <string name="appcleaner_exclusion_limited_title">Excluded app</string>
+    <string name="appcleaner_exclusion_limited_body">You excluded this app from AppCleaner. Clearing caches for all apps at once uses Shizuku\'s system-wide cache trim, which can\'t leave individual apps out, so this app\'s cached data is cleared along with everything else. Only the cached data shown here is affected, everything else the exclusion covers stays hidden and untouched.</string>
     <string name="appcleaner_automation_unavailable_title">Accessibility service unavailable</string>
     <string name="appcleaner_automation_unavailable_body">Clearing inaccessible caches requires SD Maid\'s accessibility service, but it was unavailable. If you don\'t want to use it: Disable the option "Include inaccessible caches".</string>
     <string name="appcleaner_delete_confirmation_message_x">Delete expendable files for %s?</string>

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensionsTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerExtensionsTest.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.appcleaner.core
 
 import eu.darken.sdmse.appcleaner.core.automation.errors.LockedAppCacheException
 import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
+import eu.darken.sdmse.appcleaner.ui.preview.previewInaccessibleCache
 import eu.darken.sdmse.automation.core.errors.DisabledAppException
 import eu.darken.sdmse.automation.core.errors.InvalidSystemStateException
 import eu.darken.sdmse.automation.core.errors.NoSettingsWindowException
@@ -72,6 +73,49 @@ class AppCleanerExtensionsTest : BaseTest() {
     fun `hasActionableData is false when Data is null`() {
         val data: AppCleaner.Data? = null
         data.hasActionableData shouldBe false
+    }
+
+    private fun limitedJunk(inaccessible: Boolean = true) = previewAppJunk(
+        inaccessibleCache = if (inaccessible) previewInaccessibleCache() else null,
+        isExclusionLimited = true,
+    )
+
+    @Test
+    fun `hasTrimEligibleTargets is true for a normal junk with an inaccessible cache`() {
+        listOf(previewAppJunk()).hasTrimEligibleTargets() shouldBe true
+    }
+
+    @Test
+    fun `hasTrimEligibleTargets ignores exclusion-limited junks`() {
+        listOf(limitedJunk()).hasTrimEligibleTargets() shouldBe false
+    }
+
+    @Test
+    fun `hasTrimEligibleTargets is false without any inaccessible cache`() {
+        listOf(previewAppJunk(inaccessibleCache = null)).hasTrimEligibleTargets() shouldBe false
+    }
+
+    @Test
+    fun `pruneOrphanedExclusionLimited keeps limited junks next to a trim-eligible junk`() {
+        val normal = previewAppJunk()
+        val limited = limitedJunk()
+
+        listOf(normal, limited).pruneOrphanedExclusionLimited() shouldBe listOf(normal, limited)
+    }
+
+    @Test
+    fun `pruneOrphanedExclusionLimited drops limited junks without a trim-eligible junk`() {
+        val normal = previewAppJunk(inaccessibleCache = null)
+        val limited = limitedJunk()
+
+        listOf(normal, limited).pruneOrphanedExclusionLimited() shouldBe listOf(normal)
+    }
+
+    @Test
+    fun `pruneOrphanedExclusionLimited leaves a collection without limited junks alone`() {
+        val junks = listOf(previewAppJunk(inaccessibleCache = null))
+
+        junks.pruneOrphanedExclusionLimited() shouldBe junks
     }
 
     @Test

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppCleanerTest.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.appcleaner.core
 
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
 import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPublicFilter
+import eu.darken.sdmse.appcleaner.core.forensics.filter.ThumbnailsFilter
 import eu.darken.sdmse.appcleaner.core.scanner.AppScanner
 import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
 import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerOneClickTask
@@ -1140,6 +1141,133 @@ class AppCleanerTest : BaseTest() {
         result.shouldBeInstanceOf<eu.darken.sdmse.appcleaner.core.tasks.AppCleanerSchedulerTask.Success>()
         result.affectedCount shouldBe 12
         result.affectedPaths.size shouldBe 2
+    }
+
+    // ─────────────────────────── exclusion-limited junks ───────────────────────────
+
+    private fun pkgExclusionFor(junk: AppJunk) = listOf(
+        PkgExclusion(
+            pkgId = junk.identifier.pkgId,
+            tags = setOf(Exclusion.Tag.APPCLEANER),
+        ),
+    )
+
+    private fun thumbnailMatch(path: LocalPath): ExpendablesFilter.Match = ExpendablesFilter.Match.Deletion(
+        identifier = ThumbnailsFilter::class,
+        lookup = LocalPathLookup(
+            lookedUp = path,
+            fileType = FileType.FILE,
+            size = 1024L,
+            modifiedAt = Instant.EPOCH,
+            target = null,
+        ),
+    )
+
+    private fun inaccessibleOnlyJunk(pkgName: String, isExclusionLimited: Boolean = false) = previewAppJunk(
+        pkg = previewInstalled(pkgName = pkgName, label = pkgName),
+        expendables = null,
+        inaccessibleCache = previewInaccessibleCache(pkgName = pkgName),
+        isExclusionLimited = isExclusionLimited,
+    )
+
+    @Test
+    fun `exclude narrows a junk to the trim blast radius while the trim can still run`() = runTest2 {
+        val target = previewAppJunk(
+            pkg = previewInstalled(pkgName = "com.target", label = "com.target"),
+            expendables = previewExpendables() + mapOf(
+                ThumbnailsFilter::class to listOf(thumbnailMatch(LocalPath.build("thumbs", "a.png"))),
+            ),
+            inaccessibleCache = null,
+        )
+        val keep = inaccessibleOnlyJunk("com.keep")
+        val setup = setupCleaner(useAdb = true, scanResults = listOf(target, keep))
+        setup.cleaner.submit(AppCleanerScanTask())
+        coEvery { setup.exclusionManager.save(any()) } returns pkgExclusionFor(target)
+
+        setup.cleaner.exclude(setOf(target.identifier))
+
+        val junks = setup.cleaner.dataFromState()!!.junks.associateBy { it.identifier }
+        junks.keys.toList() shouldContainExactlyInAnyOrder listOf(target.identifier, keep.identifier)
+        val narrowed = junks.getValue(target.identifier)
+        narrowed.isExclusionLimited shouldBe true
+        narrowed.expendables!!.keys shouldBe setOf(DefaultCachesPublicFilter::class)
+    }
+
+    @Test
+    fun `exclude removes the junk outright when ADB is unusable`() = runTest2 {
+        val target = inaccessibleOnlyJunk("com.target")
+        val keep = inaccessibleOnlyJunk("com.keep")
+        val setup = setupCleaner(useAdb = false, scanResults = listOf(target, keep))
+        setup.cleaner.submit(AppCleanerScanTask())
+        coEvery { setup.exclusionManager.save(any()) } returns pkgExclusionFor(target)
+
+        setup.cleaner.exclude(setOf(target.identifier))
+
+        setup.cleaner.dataFromState()!!.junks.map { it.identifier } shouldBe listOf(keep.identifier)
+    }
+
+    @Test
+    fun `a snapshot whose last trim-eligible junk is gone drops its exclusion-limited entries`() = runTest2 {
+        val limited = inaccessibleOnlyJunk("com.limited", isExclusionLimited = true)
+        val target = inaccessibleOnlyJunk("com.target")
+        val setup = setupCleaner(useAdb = true, scanResults = listOf(limited, target))
+        setup.cleaner.submit(AppCleanerScanTask())
+        coEvery { setup.exclusionManager.save(any()) } returns pkgExclusionFor(target)
+
+        // Excluding the only junk that would make the trim run leaves nothing to warn about.
+        setup.cleaner.exclude(setOf(target.identifier))
+
+        setup.cleaner.dataFromState()!!.junks shouldBe emptyList()
+    }
+
+    @Test
+    fun `a targeted clean that consumes the last trim-eligible junk drops the limited entries`() = runTest2 {
+        val normal = inaccJunk("com.normal", itemCount = 3, theoreticalPaths = emptySet())
+        val limited = inaccessibleOnlyJunk("com.limited", isExclusionLimited = true)
+        val setup = setupCleaner(scanResults = listOf(normal, limited))
+        val rebuilt = rebuildWithDeleter(setup, acsDeleter(succesful = setOf(installId("com.normal"))))
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        rebuilt.cleaner.submit(
+            AppCleanerProcessingTask(
+                targetPkgs = setOf(normal.identifier),
+                onlyInaccessible = true,
+            ),
+        )
+
+        rebuilt.cleaner.state.first().data!!.junks shouldBe emptyList()
+    }
+
+    @Test
+    fun `a whole-tool clean without a trim leaves an exclusion-limited junk alone`() = runTest2 {
+        val limitedPath = LocalPath.build("limited", "cache", "a.bin")
+        val limited = previewAppJunk(
+            pkg = previewInstalled(pkgName = "com.limited", label = "com.limited"),
+            expendables = mapOf(DefaultCachesPublicFilter::class to listOf(deletionMatch(limitedPath))),
+            inaccessibleCache = null,
+            isExclusionLimited = true,
+        )
+        val normal = previewAppJunk(
+            pkg = previewInstalled(pkgName = "com.normal", label = "com.normal"),
+            expendables = previewExpendables(),
+            inaccessibleCache = previewInaccessibleCache(pkgName = "com.normal"),
+        )
+        val setup = setupCleaner(scanResults = listOf(limited, normal))
+        // rebuildWithDeleter wires an AdbManager that reports ADB as unusable, so no trim will run.
+        val rebuilt = rebuildWithDeleter(
+            setup,
+            acsDeleter(succesful = emptySet()),
+            filterFactories = setOf(deletingFilterFactory()),
+        )
+
+        rebuilt.cleaner.submit(AppCleanerScanTask())
+        val result = rebuilt.cleaner.submit(AppCleanerProcessingTask())
+
+        result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        val after = rebuilt.cleaner.state.first().data!!.junks.associateBy { it.identifier }
+        after.getValue(limited.identifier).expendables!!.values.flatten().map { it.path } shouldBe listOf(limitedPath)
+        after.getValue(normal.identifier).expendables.orEmpty().values.flatten() shouldBe emptyList()
+        result.affectedPaths shouldBe normal.expendables!!.values.flatten().map { it.path }.toSet()
     }
 
     // ─────────────────────────── delete-path coverage gap ───────────────────────────

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppJunkTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/AppJunkTest.kt
@@ -1,0 +1,94 @@
+package eu.darken.sdmse.appcleaner.core
+
+import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilterIdentifier
+import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPrivateFilter
+import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPublicFilter
+import eu.darken.sdmse.appcleaner.core.forensics.filter.ThumbnailsFilter
+import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
+import eu.darken.sdmse.appcleaner.ui.preview.previewInaccessibleCache
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Instant
+
+class AppJunkTest : BaseTest() {
+
+    private fun match(
+        identifier: ExpendablesFilterIdentifier,
+        path: String,
+    ): ExpendablesFilter.Match = ExpendablesFilter.Match.Deletion(
+        identifier = identifier,
+        lookup = LocalPathLookup(
+            lookedUp = LocalPath.build(path),
+            fileType = FileType.FILE,
+            size = 1024L,
+            modifiedAt = Instant.EPOCH,
+            target = null,
+        ),
+    )
+
+    @Test
+    fun `limitToTrimBlastRadius keeps only the default cache filters`() {
+        val publicMatch = match(DefaultCachesPublicFilter::class, "/public")
+        val privateMatch = match(DefaultCachesPrivateFilter::class, "/private")
+        val thumbnailMatch = match(ThumbnailsFilter::class, "/thumbnail")
+
+        val narrowed = previewAppJunk(
+            expendables = mapOf(
+                DefaultCachesPublicFilter::class to listOf(publicMatch),
+                DefaultCachesPrivateFilter::class to listOf(privateMatch),
+                ThumbnailsFilter::class to listOf(thumbnailMatch),
+            ),
+        ).limitToTrimBlastRadius()!!
+
+        narrowed.expendables!!.keys.toList() shouldContainExactlyInAnyOrder listOf(
+            DefaultCachesPublicFilter::class,
+            DefaultCachesPrivateFilter::class,
+        )
+        narrowed.expendables!!.values.flatten() shouldContainExactlyInAnyOrder listOf(publicMatch, privateMatch)
+    }
+
+    @Test
+    fun `limitToTrimBlastRadius flags the junk and keeps the inaccessible cache`() {
+        val cache = previewInaccessibleCache()
+        val junk = previewAppJunk(
+            expendables = mapOf(DefaultCachesPublicFilter::class to listOf(match(DefaultCachesPublicFilter::class, "/public"))),
+            inaccessibleCache = cache,
+        )
+
+        val narrowed = junk.limitToTrimBlastRadius()!!
+
+        narrowed.isExclusionLimited shouldBe true
+        narrowed.inaccessibleCache shouldBe cache
+        junk.isExclusionLimited shouldBe false
+    }
+
+    @Test
+    fun `limitToTrimBlastRadius keeps an inaccessible-only junk`() {
+        val narrowed = previewAppJunk(
+            expendables = mapOf(ThumbnailsFilter::class to listOf(match(ThumbnailsFilter::class, "/thumbnail"))),
+            inaccessibleCache = previewInaccessibleCache(),
+        ).limitToTrimBlastRadius()!!
+
+        narrowed.expendables shouldBe null
+        narrowed.isExclusionLimited shouldBe true
+    }
+
+    @Test
+    fun `limitToTrimBlastRadius returns null without at-risk content`() {
+        previewAppJunk(
+            expendables = mapOf(ThumbnailsFilter::class to listOf(match(ThumbnailsFilter::class, "/thumbnail"))),
+            inaccessibleCache = null,
+        ).limitToTrimBlastRadius() shouldBe null
+
+        previewAppJunk(
+            expendables = null,
+            inaccessibleCache = null,
+        ).limitToTrimBlastRadius() shouldBe null
+    }
+}

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/ExclusionLimitedRegressionTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/ExclusionLimitedRegressionTest.kt
@@ -1,0 +1,428 @@
+package eu.darken.sdmse.appcleaner.core
+
+import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+import eu.darken.sdmse.appcleaner.core.forensics.filter.DefaultCachesPublicFilter
+import eu.darken.sdmse.appcleaner.core.scanner.AppScanner
+import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCache
+import eu.darken.sdmse.appcleaner.core.scanner.InaccessibleCacheProvider
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerProcessingTask
+import eu.darken.sdmse.appcleaner.core.tasks.AppCleanerScanTask
+import eu.darken.sdmse.appcleaner.ui.preview.previewAppJunk
+import eu.darken.sdmse.appcleaner.ui.preview.previewInstalled
+import eu.darken.sdmse.automation.core.AutomationSubmitter
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.coroutine.DispatcherProvider
+import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.GatewaySwitch
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.common.files.local.LocalPathLookup
+import eu.darken.sdmse.common.forensics.FileForensics
+import eu.darken.sdmse.common.pkgs.NoSettingsDetector
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.common.shell.ShellOps
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.common.user.UserManager2
+import eu.darken.sdmse.common.user.UserProfile2
+import eu.darken.sdmse.exclusion.core.ExclusionManager
+import eu.darken.sdmse.setup.SetupModule
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.maps.shouldNotContainKey
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coJustRun
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.plus
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+import javax.inject.Provider
+
+/**
+ * Regression coverage for how exclusion-limited junks are treated during a clean: they only exist
+ * in the results because the device-global ADB cache trim reaches them anyway.
+ */
+class ExclusionLimitedRegressionTest : BaseTest() {
+
+    private val keepAliveScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    @AfterEach
+    fun stopKeepAliveScope() {
+        keepAliveScope.coroutineContext[Job]?.cancel()
+    }
+
+    private val testHandle = UserHandle2(handleId = 0)
+    private val testUser = UserProfile2(handle = testHandle)
+
+    private fun installId(pkgName: String): InstallId =
+        InstallId(pkgId = Pkg.Id(name = pkgName), userHandle = testHandle)
+
+    private fun cacheFor(pkgName: String, itemCount: Int, totalSize: Long) = InaccessibleCache(
+        identifier = installId(pkgName),
+        isSystemApp = false,
+        itemCount = itemCount,
+        totalSize = totalSize,
+        publicSize = null,
+        theoreticalPaths = emptySet(),
+    )
+
+    private fun publicCacheMatch(path: LocalPath): ExpendablesFilter.Match = ExpendablesFilter.Match.Deletion(
+        identifier = DefaultCachesPublicFilter::class,
+        lookup = LocalPathLookup(
+            lookedUp = path,
+            fileType = FileType.FILE,
+            size = 1024L,
+            modifiedAt = Instant.EPOCH,
+            target = null,
+        ),
+    )
+
+    private fun currentState(complete: Boolean): SetupModule.State.Current = object : SetupModule.State.Current {
+        override val type: SetupModule.Type = SetupModule.Type.INVENTORY
+        override val isComplete: Boolean = complete
+    }
+
+    private fun mockUpgradeRepo(): UpgradeRepo {
+        val info = mockk<UpgradeRepo.Info>().apply {
+            every { isPro } returns true
+            every { isSettled } returns true
+            every { error } returns null
+        }
+        return mockk<UpgradeRepo>(relaxed = true) {
+            every { upgradeInfo } returns MutableStateFlow(info)
+        }
+    }
+
+    /** A filter that reports every target it is handed as deleted, running [onProcess] first. */
+    private fun deletingFilterFactory(onProcess: () -> Unit = {}): ExpendablesFilter.Factory {
+        val filter = mockk<ExpendablesFilter>(relaxUnitFun = true).apply {
+            every { identifier } returns DefaultCachesPublicFilter::class
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coJustRun { initialize() }
+            coEvery { process(any(), any()) } answers {
+                onProcess()
+                ExpendablesFilter.ProcessResult(
+                    success = firstArg<Collection<ExpendablesFilter.Match>>(),
+                    failed = emptyList(),
+                )
+            }
+        }
+        return mockk<ExpendablesFilter.Factory>().apply {
+            coEvery { isEnabled() } returns true
+            coEvery { create() } returns filter
+        }
+    }
+
+    private fun acsDeleter(succesful: Set<InstallId>): InaccessibleDeleter =
+        mockk<InaccessibleDeleter>(relaxUnitFun = true).apply {
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coEvery {
+                deleteInaccessible(any(), any(), any(), any(), any())
+            } returns InaccessibleDeleter.InaccDelResult(
+                succesful = succesful,
+                failed = emptyMap(),
+                freedBytes = emptyMap(),
+            )
+        }
+
+    /** Mirrors `AppCleanerTest.setupCleaner`, but lets the ADB flow and the deleter be supplied. */
+    private fun buildCleaner(
+        scanResults: List<AppJunk>,
+        adbFlow: Flow<Boolean>,
+        deleter: InaccessibleDeleter,
+        filterFactories: Set<ExpendablesFilter.Factory> = emptySet(),
+    ): AppCleaner {
+        val fileForensics = mockk<FileForensics>().apply {
+            every { sharedResource } returns SharedResource.createKeepAlive("ff", keepAliveScope)
+        }
+        val gatewaySwitch = mockk<GatewaySwitch>().apply {
+            every { sharedResource } returns SharedResource.createKeepAlive("gw", keepAliveScope)
+        }
+        val pkgOps = mockk<PkgOps>().apply {
+            every { sharedResource } returns SharedResource.createKeepAlive("po", keepAliveScope)
+        }
+        val shellOps = mockk<ShellOps>().apply {
+            every { sharedResource } returns SharedResource.createKeepAlive("so", keepAliveScope)
+        }
+        val rootManager = mockk<RootManager>().apply {
+            every { useRoot } returns flowOf(false)
+        }
+        val adbManager = mockk<AdbManager>().apply {
+            every { useAdb } returns adbFlow
+        }
+        val exclusionManager = mockk<ExclusionManager>().apply {
+            every { exclusions } returns flowOf(emptyList())
+            coEvery { save(any()) } returns emptyList()
+            coJustRun { remove(any()) }
+        }
+        val inventorySetup = mockk<SetupModule>().apply {
+            every { state } returns flowOf(currentState(true))
+        }
+        val usageStatsSetup = mockk<SetupModule>().apply {
+            every { state } returns flowOf(currentState(true))
+        }
+        val scanner = mockk<AppScanner>(relaxUnitFun = true).apply {
+            every { progress } returns MutableStateFlow<Progress.Data?>(null)
+            every { updateProgress(any()) } just Runs
+            coEvery { scan(any()) } returns scanResults
+        }
+        return AppCleaner(
+            appScope = keepAliveScope,
+            fileForensics = fileForensics,
+            appScannerProvider = Provider { scanner },
+            inaccessibleDeleterProvider = Provider { deleter },
+            exclusionManager = exclusionManager,
+            gatewaySwitch = gatewaySwitch,
+            pkgOps = pkgOps,
+            usageStatsSetupModule = usageStatsSetup,
+            rootManager = rootManager,
+            adbManager = adbManager,
+            shellOps = shellOps,
+            filterFactories = filterFactories,
+            appInventorySetupModule = inventorySetup,
+            upgradeRepo = mockUpgradeRepo(),
+        )
+    }
+
+    /** A real [InaccessibleDeleter] sharing [adbFlow] with the cleaner that drives it. */
+    private fun buildRealDeleter(
+        adbFlow: Flow<Boolean>,
+        pkgOps: PkgOps,
+        cacheProvider: InaccessibleCacheProvider,
+        dispatcher: CoroutineDispatcher = Dispatchers.Unconfined,
+    ): InaccessibleDeleter {
+        val dispatcherProvider = object : DispatcherProvider {
+            override val Default: CoroutineDispatcher = dispatcher
+            override val Main: CoroutineDispatcher = dispatcher
+            override val MainImmediate: CoroutineDispatcher = dispatcher
+            override val Unconfined: CoroutineDispatcher = dispatcher
+            override val IO: CoroutineDispatcher = dispatcher
+        }
+        val userManager = mockk<UserManager2>().apply {
+            coEvery { currentUser() } returns testUser
+        }
+        val adbManager = mockk<AdbManager>().apply {
+            every { useAdb } returns adbFlow
+        }
+        val noSettingsDetector = mockk<NoSettingsDetector>().apply {
+            coEvery { getUnreachableReason(any()) } returns null
+        }
+        return InaccessibleDeleter(
+            dispatcherProvider = dispatcherProvider,
+            userManager = userManager,
+            automationManager = mockk<AutomationSubmitter>(relaxed = true),
+            adbManager = adbManager,
+            pkgOps = pkgOps,
+            inaccessibleCacheProvider = cacheProvider,
+            rootManager = mockk<RootManager>(relaxed = true),
+            settings = mockk<AppCleanerSettings>(relaxed = true),
+            automationSetupModule = mockk<SetupModule>(relaxed = true),
+            noSettingsDetector = noSettingsDetector,
+        )
+    }
+
+    // ─────────────────────────── fixture control ───────────────────────────
+
+    /**
+     * Positive control for the accessible-deletion fixture: the same wiring, but the junk carrying
+     * the accessible matches is NOT exclusion-limited. Its match must be deleted. If this goes red
+     * the accessible-deletion pipeline in this file is broken and the sibling test proves nothing.
+     */
+    @Test
+    fun `control - a normal junk's accessible matches are deleted on a whole-tool clean`() = runTest2 {
+        val adbFlag = MutableStateFlow(true)
+        val path = LocalPath.build("storage", "emulated", "0", "Android", "data", "com.example.plain", "cache", "a.bin")
+        val plain = previewAppJunk(
+            pkg = previewInstalled(pkgName = "com.example.plain", label = "plain"),
+            expendables = mapOf(DefaultCachesPublicFilter::class to listOf(publicCacheMatch(path))),
+            inaccessibleCache = cacheFor("com.example.plain", itemCount = 1, totalSize = 60_000L),
+        )
+        val cacheProvider = mockk<InaccessibleCacheProvider>().apply {
+            coEvery { determineCache(any()) } returns null
+        }
+        val cleaner = buildCleaner(
+            scanResults = listOf(plain),
+            adbFlow = adbFlag,
+            deleter = buildRealDeleter(adbFlag, mockk<PkgOps>(relaxed = true), cacheProvider),
+            filterFactories = setOf(deletingFilterFactory { adbFlag.value = false }),
+        )
+
+        cleaner.submit(AppCleanerScanTask())
+        val result = cleaner.submit(AppCleanerProcessingTask(useAutomation = false))
+
+        result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        result.affectedPaths shouldContain (path as APath)
+    }
+
+    // ─────────────────── accessible deletion vs. the trim ───────────────────
+
+    /**
+     * Whether the trim runs is only known inside `InaccessibleDeleter`, minutes after the
+     * accessible stage started walking files. The drop is staged by flipping the shared ADB flow
+     * while the companion junk's accessible files are processed, so the trim that would have
+     * justified touching the limited junk never runs.
+     */
+    @Test
+    fun `an exclusion-limited junk's accessible matches survive a whole-tool clean whose trim never runs`() =
+        runTest2 {
+            val adbFlag = MutableStateFlow(true)
+            val limitedPath =
+                LocalPath.build("storage", "emulated", "0", "Android", "data", "com.example.limited", "cache", "blob.bin")
+            val limited = previewAppJunk(
+                pkg = previewInstalled(pkgName = "com.example.limited", label = "limited"),
+                expendables = mapOf(DefaultCachesPublicFilter::class to listOf(publicCacheMatch(limitedPath))),
+                inaccessibleCache = cacheFor("com.example.limited", itemCount = 1, totalSize = 60_000L),
+                isExclusionLimited = true,
+            )
+            val normalPath =
+                LocalPath.build("storage", "emulated", "0", "Android", "data", "com.example.normal", "cache", "n.bin")
+            val normal = previewAppJunk(
+                pkg = previewInstalled(pkgName = "com.example.normal", label = "normal"),
+                expendables = mapOf(DefaultCachesPublicFilter::class to listOf(publicCacheMatch(normalPath))),
+                inaccessibleCache = cacheFor("com.example.normal", itemCount = 1, totalSize = 50_000L),
+            )
+            val cacheProvider = mockk<InaccessibleCacheProvider>().apply {
+                coEvery { determineCache(any()) } returns null
+            }
+            val deleterPkgOps = mockk<PkgOps>(relaxed = true)
+            val cleaner = buildCleaner(
+                scanResults = listOf(limited, normal),
+                adbFlow = adbFlag,
+                deleter = buildRealDeleter(adbFlag, deleterPkgOps, cacheProvider),
+                // ADB availability drops while the accessible stage runs: read 1 saw it, read 2 won't.
+                filterFactories = setOf(deletingFilterFactory { adbFlag.value = false }),
+            )
+
+            cleaner.submit(AppCleanerScanTask())
+            val result = cleaner.submit(AppCleanerProcessingTask(useAutomation = false))
+
+            result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+            // Precondition of the scenario: read 2 saw the drop, so the trim -- the only reason the
+            // limited junk was in the snapshot at all -- never ran.
+            coVerify(exactly = 0) { deleterPkgOps.trimCaches(any(), any(), any()) }
+            result.affectedPaths shouldNotContain (limitedPath as APath)
+            // Pins the staging: the flag only flips because this junk's files are processed.
+            result.affectedPaths shouldContain (normalPath as APath)
+        }
+
+    // ─────────────────── trim failures vs. limited junks ───────────────────
+
+    /**
+     * `trimCachesWithAdb` records a failure for any candidate whose post-trim cache query comes
+     * back null. A limited junk is kept out of the per-app clearing stage, so no clearing attempt
+     * was ever made for it and it must not carry a clearing error.
+     */
+    @Test
+    fun `an unconfirmed exclusion-limited junk is not reported as a failed clearing attempt`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val normalPkg = mockk<eu.darken.sdmse.common.pkgs.features.Installed>().apply {
+            every { id } returns Pkg.Id("com.example.normal")
+            every { userHandle } returns testHandle
+            every { installId } returns installId("com.example.normal")
+            every { packageName } returns "com.example.normal"
+            every { label } returns null
+        }
+        val limitedPkg = mockk<eu.darken.sdmse.common.pkgs.features.Installed>().apply {
+            every { id } returns Pkg.Id("com.example.limited")
+            every { userHandle } returns testHandle
+            every { installId } returns installId("com.example.limited")
+            every { packageName } returns "com.example.limited"
+            every { label } returns null
+        }
+        val normal = AppJunk(
+            pkg = normalPkg,
+            userProfile = testUser,
+            expendables = null,
+            inaccessibleCache = cacheFor("com.example.normal", itemCount = 1, totalSize = 50_000L),
+        )
+        val limited = AppJunk(
+            pkg = limitedPkg,
+            userProfile = testUser,
+            expendables = null,
+            inaccessibleCache = cacheFor("com.example.limited", itemCount = 1, totalSize = 60_000L),
+            isExclusionLimited = true,
+        )
+
+        val pkgOps = mockk<PkgOps>().apply {
+            coEvery { trimCaches(any(), any(), any()) } returns Unit
+        }
+        val cacheProvider = mockk<InaccessibleCacheProvider>().apply {
+            // The trim cleared this one and the query can see it.
+            coEvery { determineCache(normalPkg) } returns cacheFor("com.example.normal", itemCount = 0, totalSize = 0L)
+            // The query for the limited app fails, so the trim cannot confirm it.
+            coEvery { determineCache(limitedPkg) } returns null
+        }
+        val deleter = buildRealDeleter(MutableStateFlow(true), pkgOps, cacheProvider, dispatcher)
+
+        val result = deleter.deleteInaccessible(
+            snapshot = AppCleaner.Data(junks = listOf(normal, limited)),
+            targetPkgs = null,
+            useAutomation = false,
+            isBackground = false,
+        )
+
+        result.failed shouldNotContainKey limited.identifier
+    }
+
+    // ─────────────────── affectedCount vs. pruning ───────────────────
+
+    /**
+     * `pruneOrphanedExclusionLimited()` drops an exclusion-limited junk that lost its last
+     * trim-eligible companion. That is bookkeeping, nothing was deleted for it, so its `itemCount`
+     * must not be reported as items cleaned.
+     */
+    @Test
+    fun `affectedCount excludes a pruned exclusion-limited junk's items`() = runTest2 {
+        val normal = previewAppJunk(
+            pkg = previewInstalled(pkgName = "com.example.normal", label = "normal"),
+            expendables = null,
+            inaccessibleCache = cacheFor("com.example.normal", itemCount = 12, totalSize = 50_000L),
+        )
+        val limited = previewAppJunk(
+            pkg = previewInstalled(pkgName = "com.example.limited", label = "limited"),
+            expendables = null,
+            inaccessibleCache = cacheFor("com.example.limited", itemCount = 7, totalSize = 60_000L),
+            isExclusionLimited = true,
+        )
+        val cleaner = buildCleaner(
+            scanResults = listOf(normal, limited),
+            adbFlow = MutableStateFlow(true),
+            // The trim confirms the normal junk only. The limited junk is left alone, and the
+            // pruning then drops it because nothing trim-eligible remains.
+            deleter = acsDeleter(succesful = setOf(installId("com.example.normal"))),
+        )
+
+        cleaner.submit(AppCleanerScanTask())
+        val result = cleaner.submit(AppCleanerProcessingTask(onlyInaccessible = true))
+
+        result.shouldBeInstanceOf<AppCleanerProcessingTask.Success>()
+        // Only the normal junk's 12 items were actually cleaned.
+        result.affectedCount shouldBe 12
+    }
+}

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/scanner/AppScannerTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/scanner/AppScannerTest.kt
@@ -1,8 +1,14 @@
 package eu.darken.sdmse.appcleaner.core.scanner
 
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
 import eu.darken.sdmse.appcleaner.core.AppCleanerSettings
 import eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+import eu.darken.sdmse.common.adb.AdbManager
 import eu.darken.sdmse.common.areas.DataArea
+import eu.darken.sdmse.common.areas.DataAreaManager
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
 import eu.darken.sdmse.common.files.FileType
@@ -12,13 +18,25 @@ import eu.darken.sdmse.common.files.Segments
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.LocalPathLookup
 import eu.darken.sdmse.common.forensics.AreaInfo
+import eu.darken.sdmse.common.clutter.ClutterRepo
 import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.PkgRepo
+import eu.darken.sdmse.common.pkgs.container.NormalPkg
 import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.InstallerInfo
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.common.user.UserProfile2
+import eu.darken.sdmse.exclusion.core.ExclusionManager
+import eu.darken.sdmse.exclusion.core.types.Exclusion
+import eu.darken.sdmse.exclusion.core.types.PkgExclusion
+import eu.darken.sdmse.exclusion.core.types.UserExclusion
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -36,8 +54,8 @@ import testhelpers.mockDataStoreValue
 import java.time.Instant
 
 /**
- * Direct coverage for [AppScanner.readAppDirs], the streaming search path walk. The public scan()
- * entry needs the full pkg/area setup and is exercised via AppCleanerTest with a mocked scanner.
+ * Direct coverage for [AppScanner.readAppDirs], the streaming search path walk, and for how
+ * [AppScanner.scan] treats excluded packages when the ADB cache trim can reach them anyway.
  */
 class AppScannerTest : BaseTest() {
 
@@ -94,6 +112,7 @@ class AppScannerTest : BaseTest() {
             inaccessibleCacheProvider = mockk(),
             userManager = userManager,
             pkgOps = mockk(),
+            adbManager = mockk(),
         ).also { it.initialize() }
     }
 
@@ -209,5 +228,172 @@ class AppScannerTest : BaseTest() {
         val results = s.readAppDirs(mapOf(areaInfo() to listOf(installId)))
 
         results.shouldBeEmpty()
+    }
+
+    // ─────────────────────────── scan(): excluded packages ───────────────────────────
+
+    private fun normalPkg(pkgName: String): NormalPkg = NormalPkg(
+        packageInfo = PackageInfo().apply {
+            packageName = pkgName
+            applicationInfo = ApplicationInfo().apply { this.packageName = pkgName }
+        },
+        installerInfo = InstallerInfo(),
+        userHandle = UserHandle2(handleId = 0),
+    )
+
+    private fun inaccessibleCache(pkgName: String) = InaccessibleCache(
+        identifier = InstallId(pkgId = pkgName.toPkgId(), userHandle = UserHandle2(handleId = 0)),
+        isSystemApp = false,
+        itemCount = 3,
+        totalSize = 1024L,
+        publicSize = null,
+        theoreticalPaths = emptySet(),
+    )
+
+    /**
+     * The whole `scan()` collaborator set. Data areas are empty, so no search paths and no
+     * accessible matches are produced and the only content is what `determineCache` returns.
+     */
+    private suspend fun scanScanner(
+        pkgs: List<NormalPkg>,
+        excluded: Set<String> = emptySet(),
+        caches: Set<String> = emptySet(),
+        useAdb: Boolean = true,
+        useRoot: Boolean = false,
+        includeInaccessible: Boolean = true,
+        defaultCachesPublic: Boolean = true,
+        defaultCachesPrivate: Boolean = true,
+    ): AppScanner {
+        every { settings.minCacheAgeMs } returns mockDataStoreValue(0L)
+        every { settings.includeSystemAppsEnabled } returns mockDataStoreValue(true)
+        every { settings.includeRunningAppsEnabled } returns mockDataStoreValue(false)
+        every { settings.includeOtherUsersEnabled } returns mockDataStoreValue(false)
+        every { settings.includeInaccessibleEnabled } returns mockDataStoreValue(includeInaccessible)
+        every { settings.filterDefaultCachesPublicEnabled } returns mockDataStoreValue(defaultCachesPublic)
+        every { settings.filterDefaultCachesPrivateEnabled } returns mockDataStoreValue(defaultCachesPrivate)
+
+        coEvery { userManager.currentUser() } returns UserProfile2(handle = UserHandle2(handleId = 0))
+        coEvery { userManager.allUsers() } returns setOf(UserProfile2(handle = UserHandle2(handleId = 0)))
+
+        val packageManager = mockk<PackageManager>().apply {
+            every { getPackageInfo(any<String>(), any<Int>()) } returns PackageInfo()
+        }
+        val context = mockk<Context>().apply {
+            every { this@apply.packageName } returns "eu.darken.sdmse"
+            every { this@apply.packageManager } returns packageManager
+        }
+
+        val factory = object : ExpendablesFilter.Factory {
+            override suspend fun isEnabled(): Boolean = true
+            override suspend fun create(): ExpendablesFilter = FakeFilter { null }
+        }
+
+        return AppScanner(
+            areaManager = mockk<DataAreaManager>().apply {
+                every { state } returns flowOf(DataAreaManager.State(areas = emptySet()))
+            },
+            gatewaySwitch = gatewaySwitch,
+            filterFactories = setOf(factory),
+            postProcessorModule = mockk<PostProcessorModule>().apply {
+                coEvery { postProcess(any()) } answers { firstArg() }
+            },
+            context = context,
+            fileForensics = mockk(),
+            rootManager = mockk<RootManager>().apply {
+                every { this@apply.useRoot } returns flowOf(useRoot)
+            },
+            exclusionManager = mockk<ExclusionManager>().apply {
+                every { exclusions } returns flowOf(
+                    excluded.map {
+                        UserExclusion(
+                            PkgExclusion(
+                                pkgId = it.toPkgId(),
+                                tags = setOf(Exclusion.Tag.APPCLEANER),
+                            )
+                        )
+                    }
+                )
+            },
+            pkgRepo = mockk<PkgRepo>().apply {
+                every { data } returns flowOf(PkgRepo.PkgData.from(pkgs))
+            },
+            clutterRepo = mockk<ClutterRepo>().apply {
+                coEvery { getMarkerForPkg(any()) } returns emptySet()
+            },
+            settings = settings,
+            inaccessibleCacheProvider = mockk<InaccessibleCacheProvider>().apply {
+                coEvery { determineCache(any()) } answers {
+                    val pkgName = firstArg<Installed>().packageName
+                    if (caches.contains(pkgName)) inaccessibleCache(pkgName) else null
+                }
+            },
+            userManager = userManager,
+            pkgOps = mockk(),
+            adbManager = mockk<AdbManager>().apply {
+                every { this@apply.useAdb } returns flowOf(useAdb)
+            },
+        ).also { it.initialize() }
+    }
+
+    private val excludedPkg = normalPkg("com.excluded")
+    private val includedPkg = normalPkg("com.normal")
+
+    @Test fun `an excluded package is dropped when ADB is unavailable`() = runTest {
+        val s = scanScanner(
+            pkgs = listOf(excludedPkg, includedPkg),
+            excluded = setOf("com.excluded"),
+            caches = setOf("com.excluded", "com.normal"),
+            useAdb = false,
+        )
+
+        s.scan().map { it.pkg.packageName } shouldContainExactlyInAnyOrder listOf("com.normal")
+    }
+
+    @Test fun `an excluded package is dropped when the trim preconditions fail`() = runTest {
+        suspend fun scanWith(
+            useRoot: Boolean = false,
+            includeInaccessible: Boolean = true,
+            defaultCachesPublic: Boolean = true,
+            defaultCachesPrivate: Boolean = true,
+        ) = scanScanner(
+            pkgs = listOf(excludedPkg, includedPkg),
+            excluded = setOf("com.excluded"),
+            caches = setOf("com.excluded", "com.normal"),
+            useRoot = useRoot,
+            includeInaccessible = includeInaccessible,
+            defaultCachesPublic = defaultCachesPublic,
+            defaultCachesPrivate = defaultCachesPrivate,
+        ).scan().map { it.pkg.packageName }
+
+        scanWith(useRoot = true) shouldContainExactlyInAnyOrder emptyList()
+        scanWith(includeInaccessible = false) shouldContainExactlyInAnyOrder emptyList()
+        scanWith(defaultCachesPublic = false) shouldContainExactlyInAnyOrder emptyList()
+        scanWith(defaultCachesPrivate = false) shouldContainExactlyInAnyOrder emptyList()
+    }
+
+    @Test fun `an excluded package surfaces as exclusion-limited when the trim would reach it`() = runTest {
+        val s = scanScanner(
+            pkgs = listOf(excludedPkg, includedPkg),
+            excluded = setOf("com.excluded"),
+            caches = setOf("com.excluded", "com.normal"),
+        )
+
+        val junks = s.scan().associateBy { it.pkg.packageName }
+
+        junks.keys.toList() shouldContainExactlyInAnyOrder listOf("com.excluded", "com.normal")
+        junks.getValue("com.excluded").isExclusionLimited shouldBe true
+        junks.getValue("com.excluded").inaccessibleCache shouldBe inaccessibleCache("com.excluded")
+        junks.getValue("com.excluded").expendables shouldBe null
+        junks.getValue("com.normal").isExclusionLimited shouldBe false
+    }
+
+    @Test fun `an excluded package is dropped when no other package would trigger the trim`() = runTest {
+        val s = scanScanner(
+            pkgs = listOf(excludedPkg, includedPkg),
+            excluded = setOf("com.excluded"),
+            caches = setOf("com.excluded"),
+        )
+
+        s.scan() shouldContainExactlyInAnyOrder emptyList()
     }
 }

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkElementBuilderTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/ui/details/page/AppJunkElementBuilderTest.kt
@@ -28,9 +28,11 @@ class AppJunkElementBuilderTest : BaseTest() {
     private fun mockJunk(
         expendables: Map<ExpendablesFilterIdentifier, Collection<ExpendablesFilter.Match>>?,
         inaccessibleCache: InaccessibleCache? = null,
+        isExclusionLimited: Boolean = false,
     ): AppJunk = mockk {
         every { this@mockk.expendables } returns expendables
         every { this@mockk.inaccessibleCache } returns inaccessibleCache
+        every { this@mockk.isExclusionLimited } returns isExclusionLimited
     }
 
     @Test
@@ -48,6 +50,20 @@ class AppJunkElementBuilderTest : BaseTest() {
         )
         rows shouldBe listOf(
             AppJunkElement.Header,
+            AppJunkElement.Inaccessible(cache),
+        )
+    }
+
+    @Test
+    fun `an exclusion-limited junk gets its notice between Header and Inaccessible`() {
+        val cache = mockk<InaccessibleCache>(relaxed = true)
+        val rows = buildAppJunkElements(
+            mockJunk(expendables = null, inaccessibleCache = cache, isExclusionLimited = true),
+            collapsed = emptySet(),
+        )
+        rows shouldBe listOf(
+            AppJunkElement.Header,
+            AppJunkElement.ExclusionLimited,
             AppJunkElement.Inaccessible(cache),
         )
     }


### PR DESCRIPTION
## What changed

Excluding an app from AppCleaner keeps it out of scan results, but a "clean everything" run with
Shizuku enabled could still empty that app's cache. Clearing caches for all apps at once uses a
system-wide cache trim that has no way to skip individual apps: it is fast, and it is all-or-nothing.

Rather than give up the fast path, AppCleaner now says so up front. An excluded app whose caches
that trim would reach is shown in the results with a short line marking it as excluded but still in
range of a clean-all, and its details page explains why. The entry lists only the caches the trim
can actually reach, so everything else the exclusion protects stays hidden and untouched.

This only appears when it can actually happen: Shizuku or ADB available, no root, inaccessible
caches enabled, and at least one non-excluded app that makes the trim run at all. Cleaning that app
on its own is unaffected.

## Technical Context

- Root cause: the package exclusion is applied only in the scanner's candidate filter. The ADB
  branch of the inaccessible-cache deleter issues a device-global trim, and no layer from
  `pkgOps.trimCaches` down to the platform call accepts a package list, so nothing below the scanner
  can honour the exclusion. The accessibility path only appears to honour it because it acts per
  package.
- Disclosure rather than suppression: the platform call's only scoping knob is a storage volume, the
  per-package cache clear on the ADB tier has never had a live caller, and suppressing the trim
  would invalidate `SchedulerAppCleanerAdvisorImpl`'s assumption that ADB coverage makes
  accessibility unnecessary.
- Whole-tool cleans deliberately neither hand these entries to the accessibility fallback nor delete
  their files directly; the trim is the only thing that touches them. Driving an excluded app's
  settings page is an action the exclusion previously ruled out outright, and if Shizuku disappears
  between scan and clean, nothing should touch the app at all.
- `pruneOrphanedExclusionLimited` enforces the invariant that such an entry exists only alongside a
  normal entry that keeps the trim reachable, applied at every write to the scan snapshot. Without
  it, a targeted clean consuming the last normal target leaves the excluded entry as the sole reason
  the trim fires, i.e. the warning causing the thing it warns about.
- Closest review deserved by two hunks: the reconciliation block in `AppCleaner.kt` is mostly a
  dedent, lifting the map body into a `reconciledJunks` local so the cleaned-item count is taken
  before invariant pruning rather than after; and the owner ordering in `AppScanner.readAppDirs`,
  which keeps a file on a co-owned search path attributed to the non-excluded owner that reports it
  today.

Known limitation: an excluded *system* app is not surfaced, because the include-system-apps filter
(off by default) runs before the exclusion check. The trim reaches those caches too.

Closes #2729
