### PR TITLE
AppControl: Fix wrong status and false Enable results for removed apps

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PkgExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PkgExtensions.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.net.toUri
 import eu.darken.sdmse.common.pkgs.container.ArchivedPkg
+import eu.darken.sdmse.common.pkgs.container.HiddenPkg
 import eu.darken.sdmse.common.pkgs.container.LibraryPkg
 import eu.darken.sdmse.common.pkgs.container.UninstalledPkg
 import eu.darken.sdmse.common.pkgs.features.InstallDetails
@@ -26,8 +27,11 @@ val Pkg.isUninstalled: Boolean
 val Pkg.isLibrary: Boolean
     get() = this is LibraryPkg
 
+val Pkg.isHidden: Boolean
+    get() = this is HiddenPkg
+
 val Pkg.isInstalled: Boolean
-    get() = !isArchived && !isUninstalled
+    get() = !isArchived && !isUninstalled && !isHidden
 
 val Pkg.isEnabled: Boolean
     get() = this is InstallDetails && this.isEnabled

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/container/HiddenPkg.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/container/HiddenPkg.kt
@@ -1,15 +1,19 @@
 package eu.darken.sdmse.common.pkgs.container
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.graphics.drawable.Drawable
 import androidx.appcompat.content.res.AppCompatResources
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.ca.cache
+import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.io.R
 import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.features.InstallDetails
 import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.features.InstallerInfo
 import eu.darken.sdmse.common.pkgs.getLabel2
 import eu.darken.sdmse.common.pkgs.loadIconFromArchive
 import eu.darken.sdmse.common.pkgs.toPkgId
@@ -17,10 +21,22 @@ import eu.darken.sdmse.common.user.UserHandle2
 
 data class HiddenPkg(
     override val packageInfo: PackageInfo,
-    override val userHandle: UserHandle2
-) : Installed {
+    override val userHandle: UserHandle2,
+    override val installerInfo: InstallerInfo = InstallerInfo(),
+    val apkPath: APath? = null,
+) : Installed, InstallDetails {
 
     override val id: Pkg.Id = packageInfo.packageName.toPkgId()
+
+    override val isSystemApp: Boolean
+        get() {
+            val fromFlags = applicationInfo?.run { flags and ApplicationInfo.FLAG_SYSTEM != 0 }
+            if (fromFlags == true) return true
+            // getPackageArchiveInfo() does not populate FLAG_SYSTEM (same limitation LibraryPkg
+            // documents), so for an archive-parsed instance the partition is the only signal.
+            apkPath?.let { path -> return SYSTEM_PARTITIONS.any { path.path.startsWith(it) } }
+            return fromFlags ?: true
+        }
 
     override val label: CaString = caString { context ->
         context.packageManager.getLabel2(id) ?: id.name
@@ -32,4 +48,15 @@ data class HiddenPkg(
     }
 
     override fun toString(): String = "HiddenPkg(packageName=$packageName, userHandle=$userHandle)"
+
+    companion object {
+        private val SYSTEM_PARTITIONS = listOf(
+            "/system/",
+            "/system_ext/",
+            "/product/",
+            "/vendor/",
+            "/odm/",
+            "/apex/",
+        )
+    }
 }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsHost.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsHost.kt
@@ -200,6 +200,9 @@ class PkgOpsHost @Inject constructor(
                 }
             }
             log(TAG, INFO) { "setApplicationEnabledSetting result: $result" }
+            if (result.exitCode != FlowProcess.ExitCode.OK) {
+                throw IllegalStateException("pm $command failed (${result.exitCode}): ${result.errors}")
+            }
         }
 
         log(TAG, VERBOSE) { "setApplicationEnabledSetting($id, $newState, $flags) succesful" }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/pkgs/PkgExtensionsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/pkgs/PkgExtensionsTest.kt
@@ -4,6 +4,7 @@ import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.SharedLibraryInfo
 import eu.darken.sdmse.common.files.APath
+import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.pkgs.container.ArchivedPkg
 import eu.darken.sdmse.common.pkgs.container.HiddenPkg
 import eu.darken.sdmse.common.pkgs.container.LibraryPkg
@@ -67,8 +68,22 @@ class PkgExtensionsTest : BaseTest() {
         )
     }
 
-    private fun hiddenPkg() = HiddenPkg(
-        packageInfo = packageInfo(packageName = "test.hidden"),
+    private fun hiddenPkg(
+        enabled: Boolean = true,
+        systemFlag: Boolean = false,
+        apkPath: APath? = null,
+    ) = HiddenPkg(
+        packageInfo = packageInfo(
+            packageName = "test.hidden",
+            enabled = enabled,
+            flags = if (systemFlag) ApplicationInfo.FLAG_SYSTEM else 0,
+        ),
+        userHandle = userHandle,
+        apkPath = apkPath,
+    )
+
+    private fun hiddenPkgWithoutAppInfo() = HiddenPkg(
+        packageInfo = PackageInfo().apply { packageName = "test.hidden" },
         userHandle = userHandle,
     )
 
@@ -99,10 +114,42 @@ class PkgExtensionsTest : BaseTest() {
         libraryPkg(enabled = false).isEnabled shouldBe false
     }
 
-    @Test fun `HiddenPkg is not InstallDetails and reports isEnabled=false`() {
-        // HiddenPkg intentionally does not implement InstallDetails, so the
-        // extension short-circuits to false. Preserves the pre-existing behavior.
-        hiddenPkg().isEnabled shouldBe false
+    @Test fun `HiddenPkg reports the per-user enabled state`() {
+        hiddenPkg(enabled = true).isEnabled shouldBe true
+        hiddenPkg(enabled = false).isEnabled shouldBe false
+    }
+
+    @Test fun `HiddenPkg reports isSystemApp from FLAG_SYSTEM`() {
+        hiddenPkg(systemFlag = true).isSystemApp shouldBe true
+        hiddenPkg(systemFlag = false).isSystemApp shouldBe false
+    }
+
+    @Test fun `HiddenPkg falls back to the partition when FLAG_SYSTEM is absent`() {
+        // The archive-parsed construction path has no FLAG_SYSTEM, so the APK location decides.
+        hiddenPkg(
+            systemFlag = false,
+            apkPath = LocalPath.build("/system/priv-app/Test/Test.apk"),
+        ).isSystemApp shouldBe true
+        hiddenPkg(
+            systemFlag = false,
+            apkPath = LocalPath.build("/data/app/test.hidden-1/base.apk"),
+        ).isSystemApp shouldBe false
+    }
+
+    @Test fun `HiddenPkg without applicationInfo keeps the InstallDetails defaults`() {
+        // Not claiming to be disabled and not claiming to be a user app is the safe read here.
+        hiddenPkgWithoutAppInfo().isEnabled shouldBe true
+        hiddenPkgWithoutAppInfo().isSystemApp shouldBe true
+    }
+
+    @Test fun `HiddenPkg reports isHidden=true and isInstalled=false`() {
+        hiddenPkg().isHidden shouldBe true
+        hiddenPkg().isInstalled shouldBe false
+    }
+
+    @Test fun `NormalPkg reports isHidden=false and isInstalled=true`() {
+        normalPkg(enabled = true).isHidden shouldBe false
+        normalPkg(enabled = true).isInstalled shouldBe true
     }
 
     @Test fun `ArchivedPkg hardcodes isEnabled=false`() {

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsHostTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/pkgs/pkgops/ipc/PkgOpsHostTest.kt
@@ -1,0 +1,79 @@
+package eu.darken.sdmse.common.pkgs.pkgops.ipc
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.flowshell.core.cmd.FlowCmd
+import eu.darken.flowshell.core.process.FlowProcess
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.pkgops.ProcessScanner
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.shell.SharedShell
+import eu.darken.sdmse.common.user.UserHandle2
+import io.kotest.assertions.throwables.shouldThrow
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * Robolectric is mandatory: [PkgOpsHost] extends the generated AIDL Binder stub.
+ *
+ * Only the secondary-user branch of [PkgOpsHost.setApplicationEnabledSetting] is covered: the
+ * current-user branch goes straight to `PackageManager.setApplicationEnabledSetting`, which needs
+ * privileges Robolectric does not model.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class PkgOpsHostTest : BaseTest() {
+
+    private val otherUser = InstallId("eu.thlab.test".toPkgId(), UserHandle2(handleId = 1))
+
+    @After
+    fun cleanup() {
+        unmockkAll()
+    }
+
+    private fun host(exitCode: FlowProcess.ExitCode): PkgOpsHost {
+        val sharedShell = mockk<SharedShell>().apply {
+            coEvery { useRes<FlowCmd.Result>(any()) } returns FlowCmd.Result(
+                original = FlowCmd("pm enable"),
+                exitCode = exitCode,
+                output = emptyList(),
+                errors = listOf("Failure"),
+            )
+        }
+        return PkgOpsHost(
+            context = ApplicationProvider.getApplicationContext<Context>(),
+            sharedShell = sharedShell,
+            processScanner = mockk<ProcessScanner>(),
+        )
+    }
+
+    @Test
+    fun `a successful pm call on a secondary user returns normally`() {
+        host(FlowProcess.ExitCode.OK).setApplicationEnabledSetting(
+            id = otherUser,
+            newState = PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+            flags = 0,
+        )
+    }
+
+    @Test
+    fun `a failing pm call on a secondary user throws`() {
+        // Without this the caller records the toggle as successful purely because nothing threw.
+        shouldThrow<UnsupportedOperationException> {
+            host(FlowProcess.ExitCode(1)).setApplicationEnabledSetting(
+                id = otherUser,
+                newState = PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                flags = 0,
+            )
+        }
+    }
+}

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/NoSettingsDetector.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/NoSettingsDetector.kt
@@ -34,6 +34,8 @@ class NoSettingsDetector @Inject constructor(
     }
 
     suspend fun getUnreachableReason(pkg: Installed): Reason? = when {
+        // Not installed for this user: there is no settings page to open, and no way to get one
+        pkg.isHidden -> Reason.NO_SETTINGS_PAGE
         pkg.hasNoSettings -> Reason.NO_SETTINGS_PAGE
         // On One UI (Samsung) the settings page of disabled apps can't be opened
         !pkg.isEnabled && effectiveRomType() == RomType.ONEUI -> Reason.DISABLED_APP

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/NotInstalledPkgsSource.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/NotInstalledPkgsSource.kt
@@ -150,6 +150,7 @@ class NotInstalledPkgsSource @Inject constructor(
                 pkgInfo.isHidden(handle) -> HiddenPkg(
                     packageInfo = pkgInfo,
                     userHandle = handle,
+                    installerInfo = installerData[pkgInfo] ?: InstallerInfo(),
                 ).also { log(TAG, VERBOSE) { "HiddenPkg: $it" } }
 
                 else -> null

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/ShellLookUpPkgsSource.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/ShellLookUpPkgsSource.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.common.pkgs.sources
 
+import android.content.pm.PackageManager
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -18,6 +19,7 @@ import eu.darken.sdmse.common.pkgs.PkgDataSource
 import eu.darken.sdmse.common.pkgs.container.HiddenPkg
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.pkgs.toPkgId
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.root.canUseRootNow
 import eu.darken.sdmse.common.shell.ShellOps
@@ -97,6 +99,19 @@ class ShellLookUpPkgsSource @Inject constructor(
                     return@mapNotNull null
                 }
 
+                val stateBacked = pkgOps.queryPkg(
+                    pkgName.toPkgId(),
+                    PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong(),
+                    user.handle,
+                )
+                if (stateBacked != null) {
+                    log(TAG, VERBOSE) { "State backed info for $pkgName: $stateBacked" }
+                    return@mapNotNull HiddenPkg(
+                        packageInfo = stateBacked,
+                        userHandle = user.handle,
+                    )
+                }
+
                 val sourcePath = LocalPath.build(rawPath)
                 log(TAG, VERBOSE) { "Reading archive $sourcePath" }
                 val apkInfo = pkgOps.viewArchive(sourcePath)
@@ -114,6 +129,7 @@ class ShellLookUpPkgsSource @Inject constructor(
                 HiddenPkg(
                     packageInfo = apkInfo.packageInfo,
                     userHandle = user.handle,
+                    apkPath = sourcePath,
                 )
             }
     }

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/ShellLookUpPkgsSource.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/sources/ShellLookUpPkgsSource.kt
@@ -99,11 +99,16 @@ class ShellLookUpPkgsSource @Inject constructor(
                     return@mapNotNull null
                 }
 
-                val stateBacked = pkgOps.queryPkg(
-                    pkgName.toPkgId(),
-                    PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong(),
-                    user.handle,
-                )
+                val stateBacked = try {
+                    pkgOps.queryPkg(
+                        pkgName.toPkgId(),
+                        PackageManager.MATCH_UNINSTALLED_PACKAGES.toLong(),
+                        user.handle,
+                    )
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "State backed lookup failed for $pkgName: ${e.asLog()}" }
+                    null
+                }
                 if (stateBacked != null) {
                     log(TAG, VERBOSE) { "State backed info for $pkgName: $stateBacked" }
                     return@mapNotNull HiddenPkg(

--- a/app-common-pkgs/src/test/java/eu/darken/sdmse/common/pkgs/sources/ShellLookUpPkgsSourceTest.kt
+++ b/app-common-pkgs/src/test/java/eu/darken/sdmse/common/pkgs/sources/ShellLookUpPkgsSourceTest.kt
@@ -1,0 +1,104 @@
+package eu.darken.sdmse.common.pkgs.sources
+
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.pkgs.container.HiddenPkg
+import eu.darken.sdmse.common.pkgs.container.PkgArchive
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.shell.ShellOps
+import eu.darken.sdmse.common.shell.ipc.ShellOpsStreamEvent
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.common.user.UserManager2
+import eu.darken.sdmse.common.user.UserProfile2
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class ShellLookUpPkgsSourceTest : BaseTest() {
+
+    private val userHandle = UserHandle2(handleId = 0)
+    private val pkgName = "com.example.foo"
+    private val apkPath = "/product/app/Foo/Foo.apk"
+
+    /**
+     * A relaxed mock, not a bare `PackageInfo()`: the source logs `"...: $stateBacked"`, and
+     * `PackageInfo.toString()` throws "not mocked" against the stub android.jar. Fields are read
+     * off the instance directly, so assigning them still works.
+     */
+    private fun packageInfo(name: String) = mockk<PackageInfo>(relaxed = true).apply {
+        packageName = name
+        applicationInfo = ApplicationInfo().apply { this.packageName = name }
+    }
+
+    private fun create(
+        queryPkgAnswer: suspend () -> PackageInfo?,
+    ): ShellLookUpPkgsSource {
+        val pkgOps = mockk<PkgOps>().apply {
+            // A relaxed mock would swallow the lambda, and with it the entire body of getPkgs().
+            coEvery { useRes<Collection<Installed>>(any()) } coAnswers {
+                firstArg<suspend (Any) -> Collection<Installed>>().invoke(Unit)
+            }
+            coEvery { queryPkgs(any(), any(), any()) } returns emptySet()
+            coEvery { queryPkg(any(), any(), any(), any()) } coAnswers { queryPkgAnswer() }
+            coEvery { viewArchive(any(), any()) } returns PkgArchive(
+                id = pkgName.toPkgId(),
+                packageInfo = packageInfo(pkgName),
+            )
+        }
+        val rootManager = mockk<RootManager>().apply {
+            every { useRoot } returns flowOf(true)
+        }
+        val adbManager = mockk<AdbManager>().apply {
+            every { useAdb } returns flowOf(false)
+        }
+        val userManager = mockk<UserManager2>().apply {
+            coEvery { allUsers() } returns setOf(UserProfile2(handle = userHandle))
+        }
+        val shellOps = mockk<ShellOps>().apply {
+            every { executeStream(any(), any()) } returns flowOf(
+                ShellOpsStreamEvent.Stdout("package:$apkPath=$pkgName"),
+                ShellOpsStreamEvent.Exit(0),
+            )
+        }
+        return ShellLookUpPkgsSource(
+            pkgOps = pkgOps,
+            rootManager = rootManager,
+            adbManager = adbManager,
+            userManager = userManager,
+            shellOps = shellOps,
+        )
+    }
+
+    @Test
+    fun `a successful state backed lookup supplies the package info`() = runTest {
+        val result = create(queryPkgAnswer = { packageInfo(pkgName) }).getPkgs()
+
+        result.size shouldBe 1
+        result.single().shouldBeInstanceOf<HiddenPkg>().id shouldBe pkgName.toPkgId()
+    }
+
+    @Test
+    fun `a failing state backed lookup falls back to the archive instead of aborting the scan`() = runTest {
+        // Every other per-entry step in getPkgs() degrades gracefully (bad exit code skips the user,
+        // a null archive or a package-name mismatch skips the entry). queryPkg is the one unguarded
+        // call, so a single throwing package must not take the whole scan with it.
+        val result = create(
+            queryPkgAnswer = { throw IllegalStateException("pm query blew up") },
+        ).getPkgs()
+
+        result.size shouldBe 1
+        val hidden = result.single().shouldBeInstanceOf<HiddenPkg>()
+        hidden.id shouldBe pkgName.toPkgId()
+        hidden.apkPath?.path shouldBe apkPath
+    }
+}

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
@@ -189,11 +189,30 @@ class AppControl @Inject constructor(
         val enabled = mutableSetOf<InstallId>()
         val disabled = mutableSetOf<InstallId>()
         val failed = mutableSetOf<InstallId>()
-        updateProgressCount(Progress.Count.Percent(task.targets.size))
+        val skipped = mutableSetOf<InstallId>()
+
+        val (togglable, untogglable) = task.targets
+            .map { it to snapshot.apps.single { app -> app.installId == it } }
+            .partition { (_, target) -> target.canBeToggled }
+
+        untogglable.forEach { (targetId, target) ->
+            log(TAG, INFO) { "Skipping $targetId, it can't be toggled: ${target.pkg}" }
+            skipped.add(targetId)
+        }
+
+        if (togglable.isEmpty()) {
+            log(TAG, INFO) { "Nothing to toggle, ${skipped.size} targets were skipped" }
+            return AppControlToggleTask.Result(enabled, disabled, failed, skipped)
+        }
+
+        updateProgressCount(Progress.Count.Percent(togglable.size))
+
+        // Which state each target was asked to end up in, so the post-refresh data can be checked
+        // against it instead of trusting that `changePackageState` not throwing means it worked.
+        val intendedStates = mutableMapOf<InstallId, Boolean>()
 
         componentToggler.useRes {
-            task.targets.forEach { targetId ->
-                val target = snapshot.apps.single { it.installId == targetId }
+            togglable.forEach { (targetId, target) ->
                 val oldState = target.pkg.isEnabled
                 val newState = !oldState
                 log(TAG) { "Toggeling $targetId enabled state $oldState -> $newState" }
@@ -207,6 +226,7 @@ class AppControl @Inject constructor(
                 try {
                     componentToggler.changePackageState(target.installId, newState)
                     if (newState) enabled.add(targetId) else disabled.add(targetId)
+                    intendedStates[targetId] = newState
                     log(TAG, INFO) { "State successfully changed to $newState" }
                 } catch (e: Exception) {
                     log(TAG, ERROR) { "Failed to change state for $targetId: ${e.asLog()}" }
@@ -223,24 +243,47 @@ class AppControl @Inject constructor(
 
         appScan.refresh()
 
+        val affectedPkgs = (enabled.map { it.pkgId } + disabled.map { it.pkgId } + failed.map { it.pkgId }).toSet()
+        val updatedPkgs = affectedPkgs.map {
+            appScan.app(
+                pkgId = it,
+                user = if (snapshot.hasIncludedMultiUser) null else userManager.currentUser().handle,
+                includeSize = snapshot.hasInfoSize,
+                includeActive = snapshot.hasInfoActive,
+                includeUsage = snapshot.hasInfoScreenTime,
+            )
+        }.flatten()
+
+        intendedStates.forEach { (targetId, intended) ->
+            val fresh = updatedPkgs.firstOrNull { it.installId == targetId }
+            val verified = when {
+                fresh == null -> {
+                    log(TAG, WARN) { "Can't verify $targetId, it's gone from the refreshed data" }
+                    false
+                }
+
+                fresh.pkg.isEnabled != intended -> {
+                    log(TAG, WARN) { "$targetId reports enabled=${fresh.pkg.isEnabled}, expected $intended" }
+                    false
+                }
+
+                else -> true
+            }
+            if (!verified) {
+                enabled.remove(targetId)
+                disabled.remove(targetId)
+                failed.add(targetId)
+            }
+        }
+
         internalData.value = snapshot.copy(
             apps = run {
-                val affectedPkgs = enabled.map { it.pkgId } + disabled.map { it.pkgId } + failed.map { it.pkgId }
                 val cleanedSnapshot = snapshot.apps.filterNot { affectedPkgs.contains(it.id) }
-                val updatedPkgs = affectedPkgs.map {
-                    appScan.app(
-                        pkgId = it,
-                        user = if (snapshot.hasIncludedMultiUser) null else userManager.currentUser().handle,
-                        includeSize = snapshot.hasInfoSize,
-                        includeActive = snapshot.hasInfoActive,
-                        includeUsage = snapshot.hasInfoScreenTime,
-                    )
-                }.flatten()
-                cleanedSnapshot + updatedPkgs
+                (cleanedSnapshot + updatedPkgs).distinctBy { it.installId }
             }
         )
 
-        return AppControlToggleTask.Result(enabled, disabled, failed)
+        return AppControlToggleTask.Result(enabled, disabled, failed, skipped)
     }
 
     private suspend fun performUninstall(task: UninstallTask): UninstallTask.Result {

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
@@ -74,7 +74,8 @@ class AppScan @Inject constructor(
     }
 
     private suspend fun getSize(id: InstallId): PkgOps.SizeStats? {
-        return sizeCache?.get(id) ?: pkgOps.querySizeStats(id)
+        sizeCache?.let { if (it.containsKey(id)) return it[id] }
+        return pkgOps.querySizeStats(id)
     }
 
     private suspend fun getActive(id: InstallId): Boolean? {

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/toggle/AppControlToggleTask.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/toggle/AppControlToggleTask.kt
@@ -27,7 +27,7 @@ data class AppControlToggleTask(
         override val affectedPkgs: Map<Pkg.Id, AffectedPkg.Action>
             get() = enabled.associate { it.pkgId to AffectedPkg.Action.ENABLED } + disabled.associate { it.pkgId to AffectedPkg.Action.DISABLED }
 
-        // The list screen's snackbar only renders primaryInfo, so every outcome has to be in here
+        // Composition is pinned by AppControlTest."primaryInfo carries every outcome of a mixed selection"
         override val primaryInfo: CaString
             get() = caString {
                 val toggled = enabled.size + disabled.size

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/toggle/AppControlToggleTask.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/toggle/AppControlToggleTask.kt
@@ -21,17 +21,35 @@ data class AppControlToggleTask(
         private val enabled: Set<InstallId>,
         private val disabled: Set<InstallId>,
         private val failed: Set<InstallId>,
+        private val skipped: Set<InstallId> = emptySet(),
     ) : AppControlTask.Result, ReportDetails.AffectedPkgs {
 
         override val affectedPkgs: Map<Pkg.Id, AffectedPkg.Action>
             get() = enabled.associate { it.pkgId to AffectedPkg.Action.ENABLED } + disabled.associate { it.pkgId to AffectedPkg.Action.DISABLED }
 
+        // The list screen's snackbar only renders primaryInfo, so every outcome has to be in here
         override val primaryInfo: CaString
             get() = caString {
-                getQuantityString2(
-                    eu.darken.sdmse.appcontrol.R.plurals.appcontrol_toggle_result_message_x,
-                    enabled.size + disabled.size
+                val toggled = enabled.size + disabled.size
+                val clauses = listOfNotNull(
+                    toggled.takeIf { it > 0 }?.let {
+                        getQuantityString2(eu.darken.sdmse.appcontrol.R.plurals.appcontrol_toggle_result_message_x, it)
+                    },
+                    failed.size.takeIf { it > 0 }?.let {
+                        getQuantityString2(eu.darken.sdmse.common.R.plurals.result_x_failed, it)
+                    },
+                    skipped.size.takeIf { it > 0 }?.let {
+                        getQuantityString2(eu.darken.sdmse.appcontrol.R.plurals.appcontrol_toggle_result_skipped_x, it)
+                    },
                 )
+                when {
+                    clauses.isEmpty() -> getQuantityString2(
+                        eu.darken.sdmse.appcontrol.R.plurals.appcontrol_toggle_result_message_x,
+                        toggled,
+                    )
+
+                    else -> clauses.joinToString(", ")
+                }
             }
 
         override val secondaryInfo: CaString?

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppInfoTagsRow.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppInfoTagsRow.kt
@@ -24,6 +24,7 @@ import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.pkgs.isArchived
 import eu.darken.sdmse.common.pkgs.isDebuggable
 import eu.darken.sdmse.common.pkgs.isEnabled
+import eu.darken.sdmse.common.pkgs.isHidden
 import eu.darken.sdmse.common.pkgs.isLibrary
 import eu.darken.sdmse.common.pkgs.isSystemApp
 import eu.darken.sdmse.common.pkgs.isUninstalled
@@ -40,12 +41,14 @@ fun AppInfoTagsRow(
     val debug = appInfo.pkg.isDebuggable
     val archived = appInfo.pkg.isArchived
     val uninstalled = appInfo.pkg.isUninstalled
+    val notInstalled = appInfo.pkg.isHidden
     val disabled = !appInfo.pkg.isEnabled
     val apkBase = appInfo.exportType == AppExportType.APK
     val apkBundle = appInfo.exportType == AppExportType.BUNDLE
 
     val anyVisible =
-        active || library || system || debug || archived || uninstalled || disabled || apkBase || apkBundle
+        active || library || system || debug || archived || uninstalled || notInstalled || disabled ||
+                apkBase || apkBundle
     if (!anyVisible) return
 
     FlowRow(
@@ -77,6 +80,13 @@ fun AppInfoTagsRow(
         if (uninstalled) {
             Tag(
                 text = stringResource(R.string.appcontrol_tag_uninstalled),
+                background = MaterialTheme.colorScheme.tertiaryContainer,
+                contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+        }
+        if (notInstalled) {
+            Tag(
+                text = stringResource(R.string.appcontrol_tag_not_installed),
                 background = MaterialTheme.colorScheme.tertiaryContainer,
                 contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
             )

--- a/app-tool-appcontrol/src/main/res/values/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values/strings.xml
@@ -81,6 +81,10 @@
         <item quantity="one">%d app was toggled</item>
         <item quantity="other">%d apps were toggled</item>
     </plurals>
+    <plurals name="appcontrol_toggle_result_skipped_x">
+        <item quantity="one">%d app cannot be enabled or disabled</item>
+        <item quantity="other">%d apps cannot be enabled or disabled</item>
+    </plurals>
     <string name="appcontrol_settings_module_sizing_enabled_label">Determine sizes</string>
     <string name="appcontrol_settings_module_sizing_enabled_description">Get a rough estimate of each app\'s size.</string>
     <string name="appcontrol_settings_module_activity_enabled_label">Determine activity</string>

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppControlTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppControlTest.kt
@@ -1,16 +1,21 @@
 package eu.darken.sdmse.appcontrol.core
 
+import android.content.Context
+import android.content.res.Resources
 import eu.darken.sdmse.appcontrol.core.archive.ArchiveSupport
 import eu.darken.sdmse.appcontrol.core.export.AppExportTask
 import eu.darken.sdmse.appcontrol.core.export.AppExporter
 import eu.darken.sdmse.appcontrol.core.forcestop.ForceStopper
 import eu.darken.sdmse.appcontrol.core.restore.Restorer
+import eu.darken.sdmse.appcontrol.core.toggle.AppControlToggleTask
 import eu.darken.sdmse.appcontrol.core.toggle.ComponentToggler
 import eu.darken.sdmse.appcontrol.core.uninstall.Uninstaller
 import eu.darken.sdmse.appcontrol.core.archive.Archiver
 import eu.darken.sdmse.automation.core.AutomationSubmitter
 import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.features.InstallDetails
 import eu.darken.sdmse.common.pkgs.features.InstallId
 import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.root.RootManager
@@ -19,10 +24,12 @@ import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.common.user.UserProfile2
 import eu.darken.sdmse.setup.SetupModule
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coJustRun
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -77,6 +84,7 @@ class AppControlTest : BaseTest() {
     private class Setup(
         val appControl: AppControl,
         val appScan: AppScan,
+        val componentToggler: ComponentToggler,
     )
 
     private fun setupAppControl(
@@ -129,7 +137,10 @@ class AppControlTest : BaseTest() {
             coEvery { currentUser() } returns UserProfile2(handle = systemUserHandle)
         }
 
-        val componentToggler = mockk<ComponentToggler>(relaxed = true)
+        val componentToggler = mockk<ComponentToggler>(relaxed = true).apply {
+            // A relaxed mock would swallow the lambda, and with it the whole toggle loop.
+            coEvery { useRes<Unit>(any()) } coAnswers { firstArg<suspend (Any) -> Unit>().invoke(Unit) }
+        }
         val forceStopper = mockk<ForceStopper>(relaxed = true)
         val uninstaller = mockk<Uninstaller>(relaxed = true)
         val archiver = mockk<Archiver>(relaxed = true)
@@ -156,7 +167,7 @@ class AppControlTest : BaseTest() {
             automationManager = automationSubmitter,
             appScan = appScan,
         )
-        return Setup(appControl = appControl, appScan = appScan)
+        return Setup(appControl = appControl, appScan = appScan, componentToggler = componentToggler)
     }
 
     private fun buildScanTask(
@@ -381,6 +392,222 @@ class AppControlTest : BaseTest() {
         exportResult.success.map { it.installId } shouldBe listOf(first.installId, third.installId)
         // The third export starts at 2, i.e. the missing target advanced the counter like any other.
         progressAtSave shouldBe listOf(0L, 2L)
+    }
+
+    // ─────────────────────────── performToggle ───────────────────────────
+
+    private fun toggleApp(
+        pkgName: String,
+        enabled: Boolean,
+        canBeToggled: Boolean,
+        user: UserHandle2 = systemUserHandle,
+    ): AppInfo {
+        val pkgId = Pkg.Id(pkgName)
+        val pkg = mockk<Installed>(relaxed = true, moreInterfaces = arrayOf(InstallDetails::class)).apply {
+            every { id } returns pkgId
+            every { packageName } returns pkgName
+            every { label } returns null
+            every { userHandle } returns user
+            every { installId } returns InstallId(pkgId, user)
+            every { (this@apply as InstallDetails).isEnabled } returns enabled
+        }
+        return AppInfo(
+            pkg = pkg,
+            isActive = null,
+            sizes = null,
+            usage = null,
+            userProfile = null,
+            canBeToggled = canBeToggled,
+            canBeStopped = false,
+            canBeExported = false,
+            canBeDeleted = false,
+            canBeArchived = false,
+            canBeRestored = false,
+        )
+    }
+
+    /** Answers the post-refresh re-query with whatever [fresh] holds for the requested pkgId. */
+    private fun Setup.stubReQuery(vararg fresh: AppInfo) {
+        coEvery { appScan.app(any(), any(), any(), any(), any()) } answers {
+            fresh.filter { it.id == firstArg<Pkg.Id>() }.toSet()
+        }
+    }
+
+    /**
+     * Resolves a [CaString] without Robolectric by faking the plural lookup that
+     * `Context.getQuantityString2` performs, tagging each clause with its resource.
+     */
+    private fun CaString.resolve(): String {
+        val res = mockk<Resources>().apply {
+            every { getQuantityString(any(), any(), *anyVararg()) } answers {
+                val quantity = secondArg<Int>()
+                val name = when (firstArg<Int>()) {
+                    eu.darken.sdmse.appcontrol.R.plurals.appcontrol_toggle_result_message_x -> "toggled"
+                    eu.darken.sdmse.appcontrol.R.plurals.appcontrol_toggle_result_skipped_x -> "skipped"
+                    eu.darken.sdmse.common.R.plurals.result_x_failed -> "failed"
+                    else -> "unknown"
+                }
+                "$quantity $name"
+            }
+        }
+        return get(mockk<Context>().apply { every { resources } returns res })
+    }
+
+    @Test
+    fun `a target that cannot be toggled is skipped instead of dispatched`() = runTest2 {
+        // The reported symptom: a package that is not installed for this user was submitted to
+        // changePackageState anyway and then reported as successfully enabled.
+        val hidden = toggleApp("eu.thlab.hidden", enabled = true, canBeToggled = false)
+        val setup = setupAppControl(appsReturnedByScan = setOf(hidden))
+        setup.appControl.submit(buildScanTask())
+
+        val result = setup.appControl.submit(AppControlToggleTask(targets = setOf(hidden.installId)))
+
+        coVerify(exactly = 0) { setup.componentToggler.changePackageState(any(), any()) }
+        result shouldBe AppControlToggleTask.Result(
+            enabled = emptySet(),
+            disabled = emptySet(),
+            failed = emptySet(),
+            skipped = setOf(hidden.installId),
+        )
+    }
+
+    @Test
+    fun `an all-skipped task returns without refreshing the package cache`() = runTest2 {
+        // Nothing changed, so a full package repository rebuild is wasted work, and a failure
+        // inside it would throw away the skip report.
+        val hidden = toggleApp("eu.thlab.hidden", enabled = true, canBeToggled = false)
+        val setup = setupAppControl(appsReturnedByScan = setOf(hidden))
+        setup.appControl.submit(buildScanTask())
+
+        setup.appControl.submit(AppControlToggleTask(targets = setOf(hidden.installId)))
+
+        coVerify(exactly = 0) { setup.appScan.refresh() }
+    }
+
+    @Test
+    fun `a mixed selection dispatches only the togglable target`() = runTest2 {
+        val hidden = toggleApp("eu.thlab.hidden", enabled = true, canBeToggled = false)
+        val normal = toggleApp("eu.thlab.normal", enabled = true, canBeToggled = true)
+        // Hoisted: reading them inside a verify block would register as calls to verify.
+        val hiddenId = hidden.installId
+        val normalId = normal.installId
+        val setup = setupAppControl(appsReturnedByScan = setOf(hidden, normal))
+        setup.appControl.submit(buildScanTask())
+        setup.stubReQuery(toggleApp("eu.thlab.normal", enabled = false, canBeToggled = true))
+
+        val result = setup.appControl.submit(AppControlToggleTask(targets = setOf(hiddenId, normalId)))
+
+        coVerify(exactly = 1) { setup.componentToggler.changePackageState(normalId, false) }
+        coVerify(exactly = 0) { setup.componentToggler.changePackageState(hiddenId, any()) }
+        result shouldBe AppControlToggleTask.Result(
+            enabled = emptySet(),
+            disabled = setOf(normalId),
+            failed = emptySet(),
+            skipped = setOf(hiddenId),
+        )
+    }
+
+    @Test
+    fun `a toggle the refreshed data confirms is reported as toggled`() = runTest2 {
+        val target = toggleApp("eu.thlab.normal", enabled = false, canBeToggled = true)
+        val setup = setupAppControl(appsReturnedByScan = setOf(target))
+        setup.appControl.submit(buildScanTask())
+        setup.stubReQuery(toggleApp("eu.thlab.normal", enabled = true, canBeToggled = true))
+
+        val result = setup.appControl.submit(AppControlToggleTask(targets = setOf(target.installId)))
+
+        result shouldBe AppControlToggleTask.Result(
+            enabled = setOf(target.installId),
+            disabled = emptySet(),
+            failed = emptySet(),
+            skipped = emptySet(),
+        )
+    }
+
+    @Test
+    fun `a toggle the refreshed data contradicts is demoted to failed`() = runTest2 {
+        // changePackageState not throwing is not evidence that the state actually changed.
+        val target = toggleApp("eu.thlab.normal", enabled = false, canBeToggled = true)
+        val setup = setupAppControl(appsReturnedByScan = setOf(target))
+        setup.appControl.submit(buildScanTask())
+        setup.stubReQuery(toggleApp("eu.thlab.normal", enabled = false, canBeToggled = true))
+
+        val result = setup.appControl.submit(AppControlToggleTask(targets = setOf(target.installId)))
+
+        result shouldBe AppControlToggleTask.Result(
+            enabled = emptySet(),
+            disabled = emptySet(),
+            failed = setOf(target.installId),
+            skipped = emptySet(),
+        )
+    }
+
+    @Test
+    fun `a toggle that cannot be verified at all is failed too`() = runTest2 {
+        val target = toggleApp("eu.thlab.normal", enabled = false, canBeToggled = true)
+        val setup = setupAppControl(appsReturnedByScan = setOf(target))
+        setup.appControl.submit(buildScanTask())
+        setup.stubReQuery()
+
+        val result = setup.appControl.submit(AppControlToggleTask(targets = setOf(target.installId)))
+
+        result shouldBe AppControlToggleTask.Result(
+            enabled = emptySet(),
+            disabled = emptySet(),
+            failed = setOf(target.installId),
+            skipped = emptySet(),
+        )
+    }
+
+    @Test
+    fun `two users of one package do not produce duplicate entries`() = runTest2 {
+        // The re-query is per pkgId and returns every user, so an undeduplicated rebuild lists each
+        // user twice - after which the next toggle's single{} lookup throws.
+        val otherUserHandle = UserHandle2(handleId = 10)
+        val first = toggleApp("eu.thlab.normal", enabled = false, canBeToggled = true)
+        val second = toggleApp("eu.thlab.normal", enabled = false, canBeToggled = true, user = otherUserHandle)
+        val setup = setupAppControl(useRoot = true, appsReturnedByScan = setOf(first, second))
+        setup.appControl.submit(buildScanTask(includeMultiUser = true))
+        setup.stubReQuery(
+            toggleApp("eu.thlab.normal", enabled = true, canBeToggled = true),
+            toggleApp("eu.thlab.normal", enabled = true, canBeToggled = true, user = otherUserHandle),
+        )
+
+        setup.appControl.submit(
+            AppControlToggleTask(targets = setOf(first.installId, second.installId)),
+        )
+
+        val apps = setup.appControl.dataFromState()!!.apps
+        apps.map { it.installId } shouldContainExactlyInAnyOrder listOf(first.installId, second.installId)
+    }
+
+    @Test
+    fun `primaryInfo carries the skipped count`() = runTest2 {
+        val hidden = toggleApp("eu.thlab.hidden", enabled = true, canBeToggled = false)
+        val setup = setupAppControl(appsReturnedByScan = setOf(hidden))
+        setup.appControl.submit(buildScanTask())
+
+        val result = setup.appControl.submit(AppControlToggleTask(targets = setOf(hidden.installId)))
+
+        result.primaryInfo.resolve() shouldBe "1 skipped"
+    }
+
+    @Test
+    fun `primaryInfo carries every outcome of a mixed selection`() = runTest2 {
+        // The list screen's snackbar renders primaryInfo alone, so a skip that only lands in
+        // secondaryInfo is invisible there.
+        val hidden = toggleApp("eu.thlab.hidden", enabled = true, canBeToggled = false)
+        val normal = toggleApp("eu.thlab.normal", enabled = true, canBeToggled = true)
+        val setup = setupAppControl(appsReturnedByScan = setOf(hidden, normal))
+        setup.appControl.submit(buildScanTask())
+        setup.stubReQuery(toggleApp("eu.thlab.normal", enabled = false, canBeToggled = true))
+
+        val result = setup.appControl.submit(
+            AppControlToggleTask(targets = setOf(hidden.installId, normal.installId)),
+        )
+
+        result.primaryInfo.resolve() shouldBe "1 toggled, 1 skipped"
     }
 
     // ─────────────────────────── missingSetup derivation ───────────────────────────

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppControlTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppControlTest.kt
@@ -599,15 +599,21 @@ class AppControlTest : BaseTest() {
         // secondaryInfo is invisible there.
         val hidden = toggleApp("eu.thlab.hidden", enabled = true, canBeToggled = false)
         val normal = toggleApp("eu.thlab.normal", enabled = true, canBeToggled = true)
-        val setup = setupAppControl(appsReturnedByScan = setOf(hidden, normal))
+        val stubborn = toggleApp("eu.thlab.stubborn", enabled = true, canBeToggled = true)
+        val setup = setupAppControl(appsReturnedByScan = setOf(hidden, normal, stubborn))
         setup.appControl.submit(buildScanTask())
-        setup.stubReQuery(toggleApp("eu.thlab.normal", enabled = false, canBeToggled = true))
-
-        val result = setup.appControl.submit(
-            AppControlToggleTask(targets = setOf(hidden.installId, normal.installId)),
+        setup.stubReQuery(
+            // Refreshed to the intended post-toggle state, so it stays toggled.
+            toggleApp("eu.thlab.normal", enabled = false, canBeToggled = true),
+            // Still reporting the pre-toggle state, so the read-back demotes it to failed.
+            toggleApp("eu.thlab.stubborn", enabled = true, canBeToggled = true),
         )
 
-        result.primaryInfo.resolve() shouldBe "1 toggled, 1 skipped"
+        val result = setup.appControl.submit(
+            AppControlToggleTask(targets = setOf(hidden.installId, normal.installId, stubborn.installId)),
+        )
+
+        result.primaryInfo.resolve() shouldBe "1 toggled, 1 failed, 1 skipped"
     }
 
     // ─────────────────────────── missingSetup derivation ───────────────────────────

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppScanTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppScanTest.kt
@@ -1,0 +1,134 @@
+package eu.darken.sdmse.appcontrol.core
+
+import eu.darken.sdmse.appcontrol.core.archive.ArchiveSupport
+import eu.darken.sdmse.appcontrol.core.usage.UsageTool
+import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.PkgRepo
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.sharedresource.SharedResource
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.common.user.UserManager2
+import eu.darken.sdmse.common.user.UserProfile2
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.plus
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+/**
+ * Robolectric is mandatory: [PkgOps.querySizeStats] defaults its storage UUID to
+ * `StorageManager.UUID_DEFAULT`, which is null against the plain android.jar stub.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class AppScanTest : BaseTest() {
+
+    // AppScan owns a SharedResource.createKeepAlive(...) and adopts pkgOps' resource as a child,
+    // so both need a scope that outlives the individual test coroutine. Mirrors AppControlTest.
+    private val keepAliveScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined)
+
+    @After
+    fun cleanup() {
+        keepAliveScope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
+        unmockkAll()
+    }
+
+    private val user = UserHandle2(handleId = 0)
+
+    private fun pkg(pkgName: String): Installed {
+        val pkgId = Pkg.Id(pkgName)
+        return mockk<Installed>(relaxed = true).apply {
+            every { id } returns pkgId
+            every { packageName } returns pkgName
+            every { userHandle } returns user
+            every { installId } returns InstallId(pkgId, user)
+        }
+    }
+
+    private class Harness(
+        val appScan: AppScan,
+        val pkgOps: PkgOps,
+        val repoData: MutableStateFlow<PkgRepo.PkgData>,
+    )
+
+    private fun harness(pkgs: Collection<Installed>): Harness {
+        val repoData = MutableStateFlow(PkgRepo.PkgData.from(pkgs))
+        val pkgRepo = mockk<PkgRepo>().apply {
+            every { data } returns repoData
+        }
+        val pkgOps = mockk<PkgOps>().apply {
+            every { sharedResource } returns SharedResource.createKeepAlive("pkgOps", keepAliveScope)
+            coEvery { querySizeStats(any(), any()) } returns null
+        }
+        val userManager = mockk<UserManager2>().apply {
+            coEvery { allUsers() } returns setOf(UserProfile2(handle = user))
+        }
+        val appScan = AppScan(
+            appScope = keepAliveScope,
+            dispatcherProvider = TestDispatcherProvider(),
+            pkgRepo = pkgRepo,
+            pkgOps = pkgOps,
+            usageTool = mockk<UsageTool>(relaxed = true),
+            userManager = userManager,
+            archiveSupport = mockk<ArchiveSupport>(relaxed = true),
+        )
+        return Harness(appScan = appScan, pkgOps = pkgOps, repoData = repoData)
+    }
+
+    @Test
+    fun `a size the bulk prefetch stored as null is not queried again`() = runTest2 {
+        // The prefetch stores `id -> null` for a failed query. Reading that back as "no entry" makes
+        // every single-package lookup re-run the query that already failed.
+        val target = pkg("eu.thlab.target")
+        val targetId = target.installId
+        val harness = harness(listOf(target))
+
+        harness.appScan.allApps(user = null, includeUsage = false, includeActive = false, includeSize = true)
+        harness.appScan.app(
+            pkgId = Pkg.Id("eu.thlab.target"),
+            user = null,
+            includeUsage = false,
+            includeActive = false,
+            includeSize = true,
+        )
+
+        coVerify(exactly = 1) { harness.pkgOps.querySizeStats(targetId, any()) }
+    }
+
+    @Test
+    fun `a size that the prefetch never saw is queried on the single package path`() = runTest2 {
+        val known = pkg("eu.thlab.known")
+        val late = pkg("eu.thlab.late")
+        val lateId = late.installId
+        val harness = harness(listOf(known))
+
+        harness.appScan.allApps(user = null, includeUsage = false, includeActive = false, includeSize = true)
+
+        harness.repoData.value = PkgRepo.PkgData.from(listOf(known, late))
+        harness.appScan.app(
+            pkgId = Pkg.Id("eu.thlab.late"),
+            user = null,
+            includeUsage = false,
+            includeActive = false,
+            includeSize = true,
+        )
+
+        coVerify(exactly = 1) { harness.pkgOps.querySizeStats(lateId, any()) }
+    }
+}

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppInfoTagsRowTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppInfoTagsRowTest.kt
@@ -10,6 +10,7 @@ import eu.darken.sdmse.appcontrol.core.AppInfo
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.container.HiddenPkg
 import eu.darken.sdmse.common.pkgs.container.LibraryPkg
 import eu.darken.sdmse.common.pkgs.features.InstallDetails
 import eu.darken.sdmse.common.pkgs.features.InstallId
@@ -71,6 +72,66 @@ class AppInfoTagsRowTest : BaseComposeRobolectricTest() {
             every { (this@apply as InstallDetails).isDebuggable } returns false
             every { (this@apply as InstallDetails).installerInfo } returns InstallerInfo()
         }
+    }
+
+    private fun hiddenPkg(): HiddenPkg = HiddenPkg(
+        packageInfo = PackageInfo().apply {
+            packageName = "com.hidden.app"
+            applicationInfo = ApplicationInfo().apply {
+                packageName = "com.hidden.app"
+                // `pm uninstall -k --user N` clears FLAG_INSTALLED, it does not disable the package
+                enabled = true
+                flags = ApplicationInfo.FLAG_SYSTEM
+            }
+        },
+        userHandle = userHandle,
+    )
+
+    private fun normalPkg(): Installed {
+        val pkgId = Pkg.Id("com.user.app")
+        return mockk<Installed>(relaxed = true, moreInterfaces = arrayOf(InstallDetails::class)).apply {
+            every { id } returns pkgId
+            every { installId } returns InstallId(pkgId, userHandle)
+            every { packageName } returns "com.user.app"
+            every { (this@apply as InstallDetails).isEnabled } returns true
+            every { (this@apply as InstallDetails).isSystemApp } returns false
+            every { (this@apply as InstallDetails).isDebuggable } returns false
+            every { (this@apply as InstallDetails).installerInfo } returns InstallerInfo()
+        }
+    }
+
+    @Test
+    fun `a package that is not installed for this user renders the Not installed tag`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                AppInfoTagsRow(appInfo = appInfo(hiddenPkg()))
+            }
+        }
+
+        composeRule.onNodeWithText("Not installed").assertExists()
+    }
+
+    @Test
+    fun `a package that is not installed but enabled does not render the Disabled tag`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                AppInfoTagsRow(appInfo = appInfo(hiddenPkg()))
+            }
+        }
+
+        composeRule.onAllNodesWithText("Disabled").assertCountEquals(0)
+    }
+
+    @Test
+    fun `a plain enabled user app renders neither the Not installed nor the Disabled tag`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                AppInfoTagsRow(appInfo = appInfo(normalPkg()))
+            }
+        }
+
+        composeRule.onAllNodesWithText("Not installed").assertCountEquals(0)
+        composeRule.onAllNodesWithText("Disabled").assertCountEquals(0)
     }
 
     @Test


### PR DESCRIPTION
## What changed

Two problems in AppControl, both on devices where apps have been removed for a single user (the `pm uninstall -k --user 0` debloat route) rather than disabled.

Selecting such apps and tapping Enable reported success, ran a full package rescan, and left everything exactly as it was. AppControl now recognises that these apps cannot be toggled, skips them instead of pretending, and tells you how many were skipped. Toggles that do run are verified against the resulting state afterwards, so one that silently fails is reported as failed rather than as a success.

Those same apps were also presented as ordinary disabled user apps: a red "Disabled" chip, and they matched the "User apps" filter even when they live on the system partition. They now carry a "Not installed" tag, classify as system apps where that applies, and show up under the "Not installed" filter.

Two smaller fixes come along: a failed `pm enable` on a secondary user was reported as success, and app sizes that failed to load were queried a second time on every scan.

## Technical Context

- Root cause for both symptoms: `HiddenPkg` implemented `Installed` but not `InstallDetails`, so the `isEnabled` and `isSystemApp` extensions short-circuited to `false` for it — the "Disabled" chip and the "User apps" match were defaults, not measurements. Both values are per-user readable (`ApplicationInfo.enabled` comes from `PackageUserState`, `FLAG_SYSTEM` from the partition), so the type now implements `InstallDetails`. Verified on an API 33 device: after `pm uninstall -k --user 0`, `dumpsys package` reports `flags=[ SYSTEM … ]` with `User 0: installed=false … enabled=0`.
- The bulk toggle never consulted `canBeToggled`, which the single-app action sheet already honoured. The guard now sits in the task layer so both entry points are covered by one check, and every outcome count goes into the result's `primaryInfo` because the list screen's snackbar renders nothing else.
- **Accepted behaviour change, worth knowing before merging:** a per-user-removed system package now reports `isSystemApp = true`, so AppCleaner's default scan population no longer includes it (`includeSystemAppsEnabled` defaults to false). CorpseFinder does not pick these up either, because the package is still present in `PkgRepo`. Users who want that leftover data cleaned can enable "include system apps". This reduces what AppCleaner finds for exactly the users who debloat their device.
- `ShellLookUpPkgsSource` builds `HiddenPkg` from an APK archive parse, which carries no per-user state at all, so it now queries the package manager first and archive-parses only as a fallback — deriving the system flag from the partition path there, since `getPackageArchiveInfo` does not populate `FLAG_SYSTEM`. That new query is wrapped in a guard: it was the only per-item step in a loop otherwise built entirely on skip-on-failure, and an escaping exception is stored on the `PkgRepo` cache container, which then rethrows on every inventory access for every tool.
- Closest review warranted on `AppControl.performToggle`, where the skip partition, the early return, the read-back verification and the affected-package deduplication all interact inside one method.
