### PR TITLE
General: Stop Play refunding Pro subscriptions bought outside the app

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepo.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/upgrade/UpgradeRepo.kt
@@ -12,6 +12,12 @@ interface UpgradeRepo {
 
     suspend fun refresh()
 
+    /**
+     * Called once per process from `App.onCreate()`, after Hilt injection completed, to let a
+     * flavour schedule its background work. Implementations must not throw for scheduling failures.
+     */
+    suspend fun onAppStart() = Unit
+
     interface Info {
         val type: Type
 

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoFoss.kt
@@ -119,6 +119,10 @@ class UpgradeRepoFoss @Inject constructor(
         refreshTrigger.value = UUID.randomUUID()
     }
 
+    override suspend fun onAppStart() {
+        log(TAG) { "onAppStart(): nothing to schedule" }
+    }
+
     data class Info(
         override val isPro: Boolean = false,
         override val upgradedAt: Instant? = null,

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplay.kt
@@ -387,6 +387,17 @@ class UpgradeRepoGplay @Inject constructor(
         }
     }
 
+    override suspend fun onAppStart() {
+        log(TAG) { "onAppStart()" }
+        try {
+            ackScheduler.armPeriodicSweep()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "Failed to arm periodic ack sweep: ${e.asLog()}" }
+        }
+    }
+
     // Explicit "Restore purchase": query Play now and evaluate Pro from the returned data in the same
     // coroutine (real happens-before), so we never read a stale upgradeInfo replay. Billing errors
     // propagate so the caller can distinguish "not owned" from "Play unavailable".

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/work/PurchaseAckScheduler.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/work/PurchaseAckScheduler.kt
@@ -2,9 +2,12 @@ package eu.darken.sdmse.common.upgrade.core.billing.work
 
 import androidx.work.BackoffPolicy
 import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.Operation
+import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.await
 import androidx.work.workDataOf
@@ -20,11 +23,13 @@ import javax.inject.Provider
 import javax.inject.Singleton
 
 /**
- * Arms the [PurchaseAckWorker] safety net. Two triggers:
+ * Arms the [PurchaseAckWorker] safety net. Three triggers:
  * - a billing flow is about to launch (armed and awaited BEFORE the Play sheet, so the WorkManager
  *   DB transaction lands even if the process dies around the sheet),
  * - an ack pass discovered unacknowledged purchases (called directly, pre-attempt, from
- *   BillingManager's runAckPass).
+ *   BillingManager's runAckPass),
+ * - every process start arms a periodic sweep that covers purchases made outside the app (Play
+ *   Store resubscribe), which no in-process trigger can see.
  */
 @Singleton
 class PurchaseAckScheduler @Inject constructor(
@@ -60,6 +65,25 @@ class PurchaseAckScheduler @Inject constructor(
         initialDelayMs = DISCOVERY_DELAY_MS,
     )
 
+    // Covers what no in-process trigger can: a purchase made outside the app (Play Store
+    // resubscribe) whose 3-day ack deadline can pass without the user ever opening SD Maid.
+    suspend fun armPeriodicSweep() {
+        val request = PeriodicWorkRequestBuilder<PurchaseAckWorker>(PERIODIC_INTERVAL_HOURS, TimeUnit.HOURS).apply {
+            setConstraints(
+                Constraints.Builder().apply {
+                    setRequiredNetworkType(NetworkType.CONNECTED)
+                }.build()
+            )
+            setBackoffCriteria(BackoffPolicy.EXPONENTIAL, BACKOFF_DELAY_MS, TimeUnit.MILLISECONDS)
+            setInputData(workDataOf(PurchaseAckWorker.KEY_MODE to PurchaseAckWorker.MODE_PERIODIC))
+        }.build()
+
+        val operation = workManager.get()
+            .enqueueUniquePeriodicWork(WORK_NAME_PERIODIC, ExistingPeriodicWorkPolicy.UPDATE, request)
+        operation.awaitBounded()
+        log(TAG) { "armPeriodicSweep(): armed, interval=${PERIODIC_INTERVAL_HOURS}h" }
+    }
+
     private suspend fun arm(
         name: String,
         policy: ExistingWorkPolicy,
@@ -85,15 +109,18 @@ class PurchaseAckScheduler @Inject constructor(
             setInputData(workDataOf(PurchaseAckWorker.KEY_EXPIRES_AT to expiresAt))
         }.build()
 
-        // Await the enqueue: the caller arms this because the process may die at any moment — a
-        // fire-and-forget enqueue could be lost with it. Cancellable and BOUNDED: every caller
-        // needs a durable enqueue without an unbounded stall — a WorkManager that never settles
-        // must become an exception (handled fail-open by every caller) instead of a hang (which on
-        // the launch lane would park the purchase and its busy guard forever).
-        val operation = workManager.get().enqueueUniqueWork(name, policy, request)
-        withTimeoutOrNull(ENQUEUE_TIMEOUT_MS) { operation.await() }
-            ?: throw IllegalStateException("WorkManager enqueue did not settle within ${ENQUEUE_TIMEOUT_MS}ms")
+        workManager.get().enqueueUniqueWork(name, policy, request).awaitBounded()
         log(TAG) { "arm($policy): safety net armed, expiresAt=$expiresAt" }
+    }
+
+    // Await the enqueue: the caller arms this because the process may die at any moment — a
+    // fire-and-forget enqueue could be lost with it. Cancellable and BOUNDED: every caller needs a
+    // durable enqueue without an unbounded stall — a WorkManager that never settles must become an
+    // exception (handled fail-open by every caller) instead of a hang (which on the launch lane
+    // would park the purchase and its busy guard forever).
+    private suspend fun Operation.awaitBounded() {
+        withTimeoutOrNull(ENQUEUE_TIMEOUT_MS) { await() }
+            ?: throw IllegalStateException("WorkManager enqueue did not settle within ${ENQUEUE_TIMEOUT_MS}ms")
     }
 
     companion object {
@@ -104,10 +131,17 @@ class PurchaseAckScheduler @Inject constructor(
         private val WORK_NAME_LAUNCH = "${BuildConfigWrap.APPLICATION_ID}.gplay.purchase-ack.launch.v1"
         private val WORK_NAME_RESCUE = "${BuildConfigWrap.APPLICATION_ID}.gplay.purchase-ack.rescue.v1"
 
+        // No version suffix: this lane is enqueued with UPDATE, which replaces the spec in place
+        // (keeping the next-run time), so it migrates itself. KEEP would be wrong here — periodic
+        // work never completes, so KEEP would ignore every later request under this name and a
+        // changed interval, constraint, input or worker class would silently do nothing.
+        private val WORK_NAME_PERIODIC = "${BuildConfigWrap.APPLICATION_ID}.gplay.purchase-ack.periodic"
+
         private const val LAUNCH_DELAY_MS = 30 * 60 * 1000L
         private const val DISCOVERY_DELAY_MS = 60 * 1000L
         private const val BACKOFF_DELAY_MS = 30 * 60 * 1000L
         private const val ENQUEUE_TIMEOUT_MS = 10 * 1000L
+        private const val PERIODIC_INTERVAL_HOURS = 12L
 
         val TAG: String = logTag("Upgrade", "Gplay", "Billing", "AckScheduler")
     }

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/work/PurchaseAckWorker.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/work/PurchaseAckWorker.kt
@@ -37,37 +37,90 @@ class PurchaseAckWorker @AssistedInject constructor(
 
     override suspend fun doWork(): Result {
         val expiresAt = inputData.getLong(KEY_EXPIRES_AT, 0L)
-        log(TAG) { "doWork(): attempt=$runAttemptCount, expiresAt=$expiresAt" }
+        val mode = inputData.getString(KEY_MODE)
+        log(TAG) { "doWork(): attempt=$runAttemptCount, mode=$mode, expiresAt=$expiresAt" }
 
-        if (!isWorthSweeping(System.currentTimeMillis(), expiresAt)) {
-            // Past Play's refund deadline (or malformed input): retrying can't achieve anything.
-            // failure() is deliberate over success() — it is visible in WorkManager diagnostics,
-            // and a completed state lets a later KEEP enqueue insert fresh work.
-            log(TAG, WARN) { "doWork(): deadline passed, giving up" }
-            return Result.failure()
+        return run(
+            mode = mode,
+            expiresAt = expiresAt,
+            runAttemptCount = runAttemptCount,
+            now = System::currentTimeMillis,
+        ) {
+            // Bounded well below WorkManager's 10-minute execution limit, but generous enough for
+            // the connection wait plus the per-purchase inline retries. A sweep that ran out of
+            // time is a transient outcome, not a verdict. External cancellation propagates out of
+            // doWork — it must never be converted into success.
+            withTimeoutOrNull(SWEEP_TIMEOUT_MS) {
+                billingManager.ensureAllAcknowledged()
+            }
         }
-
-        // Bounded well below WorkManager's 10-minute execution limit, but generous enough for the
-        // connection wait plus the per-purchase inline retries. A sweep that ran out of time is a
-        // transient outcome, not a verdict. External cancellation propagates out of doWork — it
-        // must never be converted into success.
-        val sweep = withTimeoutOrNull(SWEEP_TIMEOUT_MS) {
-            billingManager.ensureAllAcknowledged()
-        }
-        log(TAG, INFO) { "doWork(): sweep=$sweep" }
-
-        return mapSweep(sweep, System.currentTimeMillis(), expiresAt)
     }
 
     companion object {
         // Persisted in WorkManager's request data — keep the key stable while old work may exist.
         const val KEY_EXPIRES_AT = "purchase.ack.expiresAt"
 
+        // Also persisted: absent means MODE_DEADLINE, so requests enqueued by older builds keep
+        // their behaviour.
+        const val KEY_MODE = "purchase.ack.mode"
+        const val MODE_DEADLINE = "deadline"
+        const val MODE_PERIODIC = "periodic"
+
         private const val SWEEP_TIMEOUT_MS = 4 * 60 * 1000L
+
+        private const val PERIODIC_MAX_ATTEMPTS = 3
+
+        // Pure so the routing is unit-testable without a WorkerParameters harness.
+        internal suspend fun run(
+            mode: String?,
+            expiresAt: Long,
+            runAttemptCount: Int,
+            now: () -> Long,
+            sweep: suspend () -> BillingManager.AckSweepResult?,
+        ): Result {
+            if (mode == MODE_PERIODIC) {
+                val result = sweep()
+                log(TAG, INFO) { "doWork(): sweep=$result" }
+                val mapped = mapPeriodicSweep(result, runAttemptCount)
+                if (mapped is Result.Failure && result != BillingManager.AckSweepResult.PERMANENT_FAILURE) {
+                    log(TAG, WARN) {
+                        "Periodic ack sweep gave up for this period after $PERIODIC_MAX_ATTEMPTS attempts"
+                    }
+                }
+                return mapped
+            }
+
+            if (!isWorthSweeping(now(), expiresAt)) {
+                // Past Play's refund deadline (or malformed input): retrying can't achieve anything.
+                // failure() is deliberate over success() — it is visible in WorkManager diagnostics,
+                // and a completed state lets a later KEEP enqueue insert fresh work.
+                log(TAG, WARN) { "doWork(): deadline passed, giving up" }
+                return Result.failure()
+            }
+
+            val result = sweep()
+            log(TAG, INFO) { "doWork(): sweep=$result" }
+
+            return mapSweep(result, now(), expiresAt)
+        }
 
         // Pure so the retry/expiry decision is unit-testable without a WorkManager test harness.
         internal fun isWorthSweeping(now: Long, expiresAt: Long): Boolean =
             expiresAt > 0L && now < expiresAt
+
+        // For periodic work WorkManager treats success and failure identically for scheduling: both
+        // reset the request to ENQUEUED for the next period and reset the attempt count (2.11,
+        // WorkerWrapper.handleResult), only its own result log line differs. Retries within a period
+        // are bounded so a Play outage can't chain backoff retries across the whole interval — the
+        // next period is the retry.
+        internal fun mapPeriodicSweep(
+            sweep: BillingManager.AckSweepResult?,
+            runAttemptCount: Int,
+        ): Result = when (sweep) {
+            BillingManager.AckSweepResult.COMPLETE -> Result.success()
+            BillingManager.AckSweepResult.PERMANENT_FAILURE -> Result.failure()
+            else -> if (runAttemptCount + 1 < PERIODIC_MAX_ATTEMPTS) Result.retry() else Result.failure()
+        }
 
         internal fun mapSweep(
             sweep: BillingManager.AckSweepResult?,

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/work/PurchaseAckWorker.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/work/PurchaseAckWorker.kt
@@ -81,13 +81,15 @@ class PurchaseAckWorker @AssistedInject constructor(
             if (mode == MODE_PERIODIC) {
                 val result = sweep()
                 log(TAG, INFO) { "doWork(): sweep=$result" }
-                val mapped = mapPeriodicSweep(result, runAttemptCount)
-                if (mapped is Result.Failure && result != BillingManager.AckSweepResult.PERMANENT_FAILURE) {
+                val exhausted = result != BillingManager.AckSweepResult.COMPLETE &&
+                    result != BillingManager.AckSweepResult.PERMANENT_FAILURE &&
+                    runAttemptCount + 1 >= PERIODIC_MAX_ATTEMPTS
+                if (exhausted) {
                     log(TAG, WARN) {
                         "Periodic ack sweep gave up for this period after $PERIODIC_MAX_ATTEMPTS attempts"
                     }
                 }
-                return mapped
+                return mapPeriodicSweep(result, runAttemptCount)
             }
 
             if (!isWorthSweeping(now(), expiresAt)) {

--- a/app/src/main/java/eu/darken/sdmse/App.kt
+++ b/app/src/main/java/eu/darken/sdmse/App.kt
@@ -27,6 +27,7 @@ import eu.darken.sdmse.common.debug.memory.MemoryMonitor
 import eu.darken.sdmse.common.debug.recorder.core.RecorderModule
 import eu.darken.sdmse.common.storage.StorageRescue
 import eu.darken.sdmse.common.updater.UpdateService
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.shortcuts.ShortcutManager
@@ -65,6 +66,7 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var taskResultNotifier: TaskResultNotifier
     @Inject lateinit var storageRescue: StorageRescue
     @Inject lateinit var widgetRefreshCoordinator: WidgetRefreshCoordinator
+    @Inject lateinit var upgradeRepo: UpgradeRepo
 
     private val logCatLogger = LogCatLogger()
 
@@ -120,6 +122,7 @@ open class App : Application(), Configuration.Provider {
         taskStatsCoordinator.start()
         taskResultNotifier.start()
         spaceMonitorControl.start()
+        appScope.launch { upgradeRepo.onAppStart() }
         lowSpaceMonitor.start(appScope)
         widgetRefreshCoordinator.start()
 

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1054,6 +1054,19 @@ class UpgradeRepoGplayTest : BaseTest() {
         coVerify { billingManager.startIapFlow(any(), any(), null) }
     }
 
+    @Test fun `onAppStart arms the periodic ack sweep`() = runTest2 {
+        repo(lastProAt = 0L).onAppStart()
+
+        coVerify(exactly = 1) { ackScheduler.armPeriodicSweep() }
+    }
+
+    @Test fun `onAppStart swallows a scheduler failure`() = runTest2 {
+        coEvery { ackScheduler.armPeriodicSweep() } throws RuntimeException("workmanager broken")
+
+        // Fail-open: process start must never be taken down by a scheduling problem.
+        repo(lastProAt = 0L).onAppStart()
+    }
+
 
     // endregion
 }

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/work/PurchaseAckSchedulerTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/work/PurchaseAckSchedulerTest.kt
@@ -1,8 +1,12 @@
 package eu.darken.sdmse.common.upgrade.core.billing.work
 
+import androidx.work.BackoffPolicy
+import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.Operation
+import androidx.work.PeriodicWorkRequest
 import androidx.work.WorkManager
 import com.google.common.util.concurrent.ListenableFuture
 import io.kotest.matchers.shouldBe
@@ -29,6 +33,9 @@ class PurchaseAckSchedulerTest : BaseTest() {
     private val workManager = mockk<WorkManager>().apply {
         every {
             enqueueUniqueWork(any<String>(), any<ExistingWorkPolicy>(), any<OneTimeWorkRequest>())
+        } returns operation
+        every {
+            enqueueUniquePeriodicWork(any<String>(), any<ExistingPeriodicWorkPolicy>(), any<PeriodicWorkRequest>())
         } returns operation
     }
 
@@ -60,6 +67,36 @@ class PurchaseAckSchedulerTest : BaseTest() {
         // pending rescue for a purchase that already exists.
         name.captured shouldEndWith ".gplay.purchase-ack.rescue.v1"
         policy.captured shouldBe ExistingWorkPolicy.KEEP
+    }
+
+    @Test fun `a process start arms the periodic sweep`() = runTest2 {
+        create().armPeriodicSweep()
+
+        val name = slot<String>()
+        val policy = slot<ExistingPeriodicWorkPolicy>()
+        val request = slot<PeriodicWorkRequest>()
+        verify(exactly = 1) {
+            workManager.enqueueUniquePeriodicWork(capture(name), capture(policy), capture(request))
+        }
+        name.captured shouldEndWith ".gplay.purchase-ack.periodic"
+        // UPDATE, not KEEP: periodic work never completes, so KEEP would ignore every later request
+        // and a changed spec would silently never reach the device.
+        policy.captured shouldBe ExistingPeriodicWorkPolicy.UPDATE
+
+        val spec = request.captured.workSpec
+        spec.input.getString(PurchaseAckWorker.KEY_MODE) shouldBe PurchaseAckWorker.MODE_PERIODIC
+        spec.intervalDuration shouldBe 12 * 60 * 60 * 1000L
+        spec.constraints.requiredNetworkType shouldBe NetworkType.CONNECTED
+        spec.backoffPolicy shouldBe BackoffPolicy.EXPONENTIAL
+        spec.backoffDelayDuration shouldBe 30 * 60 * 1000L
+    }
+
+    @Test fun `the periodic arm leaves the one-time lanes untouched`() = runTest2 {
+        create().armPeriodicSweep()
+
+        verify(exactly = 0) {
+            workManager.enqueueUniqueWork(any<String>(), any<ExistingWorkPolicy>(), any<OneTimeWorkRequest>())
+        }
     }
 
     @Test fun `a passed deadline schedules nothing`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/work/PurchaseAckWorkerTest.kt
+++ b/app/src/testGplay/java/eu/darken/sdmse/common/upgrade/core/billing/work/PurchaseAckWorkerTest.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
 
 class PurchaseAckWorkerTest : BaseTest() {
 
@@ -38,5 +39,80 @@ class PurchaseAckWorkerTest : BaseTest() {
             .shouldBeInstanceOf<Result.Failure>()
         PurchaseAckWorker.mapSweep(null, now = 200L, expiresAt = 200L)
             .shouldBeInstanceOf<Result.Failure>()
+    }
+
+    @Test fun `a periodic sweep that completed succeeds`() {
+        PurchaseAckWorker.mapPeriodicSweep(AckSweepResult.COMPLETE, runAttemptCount = 0)
+            .shouldBeInstanceOf<Result.Success>()
+    }
+
+    @Test fun `a permanently rejected periodic ack stops the retries`() {
+        PurchaseAckWorker.mapPeriodicSweep(AckSweepResult.PERMANENT_FAILURE, runAttemptCount = 0)
+            .shouldBeInstanceOf<Result.Failure>()
+    }
+
+    @Test fun `transient periodic outcomes retry within the period, then wait for the next one`() {
+        PurchaseAckWorker.mapPeriodicSweep(AckSweepResult.RETRY, runAttemptCount = 0)
+            .shouldBeInstanceOf<Result.Retry>()
+        PurchaseAckWorker.mapPeriodicSweep(null, runAttemptCount = 0)
+            .shouldBeInstanceOf<Result.Retry>()
+        PurchaseAckWorker.mapPeriodicSweep(AckSweepResult.RETRY, runAttemptCount = 1)
+            .shouldBeInstanceOf<Result.Retry>()
+        PurchaseAckWorker.mapPeriodicSweep(null, runAttemptCount = 1)
+            .shouldBeInstanceOf<Result.Retry>()
+        // Attempts exhausted: the next period is the retry, a Play outage must not chain backoff
+        // retries across the whole interval.
+        PurchaseAckWorker.mapPeriodicSweep(AckSweepResult.RETRY, runAttemptCount = 2)
+            .shouldBeInstanceOf<Result.Failure>()
+        PurchaseAckWorker.mapPeriodicSweep(null, runAttemptCount = 2)
+            .shouldBeInstanceOf<Result.Failure>()
+    }
+
+    @Test fun `work without a mode keeps the deadline gate`() = runTest2 {
+        var swept = false
+        val result = PurchaseAckWorker.run(
+            mode = null,
+            expiresAt = 0L,
+            runAttemptCount = 0,
+            now = { 100L },
+        ) {
+            swept = true
+            AckSweepResult.COMPLETE
+        }
+
+        result.shouldBeInstanceOf<Result.Failure>()
+        swept shouldBe false
+    }
+
+    @Test fun `deadline work sweeps and maps by deadline`() = runTest2 {
+        var swept = false
+        val result = PurchaseAckWorker.run(
+            mode = PurchaseAckWorker.MODE_DEADLINE,
+            expiresAt = 200L,
+            runAttemptCount = 0,
+            now = { 100L },
+        ) {
+            swept = true
+            AckSweepResult.RETRY
+        }
+
+        swept shouldBe true
+        result.shouldBeInstanceOf<Result.Retry>()
+    }
+
+    @Test fun `periodic work sweeps without a deadline`() = runTest2 {
+        var swept = false
+        val result = PurchaseAckWorker.run(
+            mode = PurchaseAckWorker.MODE_PERIODIC,
+            expiresAt = 0L,
+            runAttemptCount = 0,
+            now = { 100L },
+        ) {
+            swept = true
+            AckSweepResult.COMPLETE
+        }
+
+        swept shouldBe true
+        result.shouldBeInstanceOf<Result.Success>()
     }
 }


### PR DESCRIPTION
## What changed

Pro subscriptions started from the Google Play Store itself, for example by tapping "Resubscribe" on an expired subscription in Play's subscription list, could be refunded and revoked by Google three days later if SD Maid wasn't opened in between. Play requires every new subscription purchase to be confirmed by the app, and a purchase made outside the app only got confirmed the next time SD Maid ran.

The Google Play version now confirms such purchases on its own, in the background, about twice a day. Opening the app is no longer needed to keep a subscription bought through the Play Store. The FOSS version is unaffected.

Limits: Android only runs this background work while the app isn't force-stopped, and some manufacturers restrict background work aggressively. Updating or rebooting re-enables it.

## Technical Context

- Root cause: Play voided 12 `upgrade.pro` purchases as `unacknowledged_purchase` in the last 30 days, all subscriptions and none of the 4680 one-time purchases. The acknowledgement path is identical for both product types, so the asymmetry points at Play's out-of-app resubscribe flow. Both existing safety-net lanes are one-time requests armed only from the in-app buy tap or from an ack pass that already saw the purchase in-process, so nothing covered a purchase made while the process was dead.
- Approach: a third, periodic lane on the existing `PurchaseAckWorker` that reuses `BillingManager.ensureAllAcknowledged()`. Server-side acknowledgement via RTDN would be the complete fix but needs a backend this app doesn't have.
- The periodic request uses `ExistingPeriodicWorkPolicy.UPDATE` and an unversioned unique name on purpose: periodic work never completes, so `KEEP` would ignore every later spec change. The two one-time lanes keep their `.v1` names and `KEEP`/`REPLACE` semantics.
- Worth a close look: the worker's routing is now a pure `run()` function keyed on a persisted `mode` input; requests enqueued by older builds carry no mode and must resolve to the old deadline behaviour byte-for-byte (`PurchaseAckWorkerTest` pins this). Each cold periodic run queries Play twice (connect loop plus sweep), accepted as cheap local cache reads.
- Verified on a Pixel 7a with a license-tester account: the request is enqueued at app start, the worker runs in periodic mode against real Play, and a subscription resubscribed in the Play Store with the app process killed was acknowledged once the scheduled job woke the process. Which of the two in-process acknowledgement paths wins that race is not observable from logs and doesn't matter for the outcome.
