### PR TITLE
Fix: Repair the AppCleaner test build that was breaking CI on main

### DIFF
--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/ExclusionLimitedRegressionTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/ExclusionLimitedRegressionTest.kt
@@ -31,6 +31,7 @@ import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.common.user.UserProfile2
 import eu.darken.sdmse.exclusion.core.ExclusionManager
+import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.setup.SetupModule
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldNotContain
@@ -59,6 +60,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import testhelpers.mockDataStoreValue
 import java.time.Instant
 import javax.inject.Provider
 
@@ -242,6 +244,9 @@ class ExclusionLimitedRegressionTest : BaseTest() {
             inaccessibleCacheProvider = cacheProvider,
             rootManager = mockk<RootManager>(relaxed = true),
             settings = mockk<AppCleanerSettings>(relaxed = true),
+            generalSettings = mockk<GeneralSettings>().apply {
+                every { hasAcsConsent } returns mockDataStoreValue(true)
+            },
             automationSetupModule = mockk<SetupModule>(relaxed = true),
             noSettingsDetector = noSettingsDetector,
         )


### PR DESCRIPTION
## What changed

No user-facing behavior change. A unit test in the AppCleaner module was calling an internal constructor with one argument missing, so the module's tests could not be compiled at all. That broke the test job on `main` for every branch and pull request cut from it. This adds the missing argument.

## Technical Context

- Root cause is a parallel-branch race, not a logic error. `b30610ff` added a `generalSettings` parameter to `InaccessibleDeleter` and updated the one call site that existed at the time (`InaccessibleDeleterTest`). `ad05179` added `ExclusionLimitedRegressionTest` seven minutes later from a tree branched before `b30610ff`, so its call site was never updated and the test source set stopped compiling.
- The mock is `mockDataStoreValue(true)` rather than `mockk(relaxed = true)` because `InaccessibleDeleter` reads `generalSettings.hasAcsConsent.value()` unconditionally, ahead of the `useAutomation` branch. Every test in this file passes `useAutomation = false`, but that read still executes, and a relaxed mock's erased-generic `value()` is not dependable there. This mirrors how `InaccessibleDeleterTest` mocks the same setting.
- Test-only change; no production source is touched.