### PR TITLE
General: Add Crowdin screenshots and context for the upgrade screens

### DIFF
--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -51,3 +51,9 @@ caString { getString(R.plurals.xxx, count, count) }
 - `app/src/main/res/values-*/strings.xml`: Translated strings for other languages
 - `app/src/foss/res/values-*/strings.xml`: FOSS flavor specific strings
 - `app/src/gplay/res/values-*/strings.xml`: Google Play flavor specific strings
+
+## Translator Context on Crowdin
+
+String context, character limits and file context are managed on Crowdin through the android-translation
+plugin's `crowdin-annotate` skill. XML comments in `values/strings.xml` no longer reach translators once a
+string's context has been written on Crowdin; change it there.

--- a/app/src/screenshotTestFossDebug/kotlin/eu/darken/sdmse/screenshots/CrowdinScreenshots.kt
+++ b/app/src/screenshotTestFossDebug/kotlin/eu/darken/sdmse/screenshots/CrowdinScreenshots.kt
@@ -1,0 +1,45 @@
+package eu.darken.sdmse.screenshots
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.upgrade.ui.FossUpgradeView
+import eu.darken.sdmse.common.upgrade.ui.UpgradeScreen
+import java.time.Instant
+
+// Renders for Crowdin's translator context, uploaded by the android-translation plugin. Unlike
+// PlayStoreLocales these render en-US only: auto-tagging matches the source language, so the other
+// locales would be uploads nobody reads. copy_screenshots.sh ignores these names.
+@Preview(locale = "en", name = "en-US", device = DS)
+private annotation class CrowdinLocale
+
+@PreviewTest
+@CrowdinLocale
+@Composable
+fun FossUpgradePitch() {
+    PreviewWrapper {
+        UpgradeScreen(view = FossUpgradeView.PITCH)
+    }
+}
+
+@PreviewTest
+@CrowdinLocale
+@Composable
+fun FossUpgradeStatusFree() {
+    PreviewWrapper {
+        UpgradeScreen(view = FossUpgradeView.STATUS_FREE)
+    }
+}
+
+@PreviewTest
+@CrowdinLocale
+@Composable
+fun FossUpgradeStatusUpgraded() {
+    PreviewWrapper {
+        UpgradeScreen(
+            view = FossUpgradeView.STATUS_UPGRADED,
+            supporterSince = Instant.parse("2025-03-12T10:15:00Z"),
+        )
+    }
+}

--- a/app/src/screenshotTestGplayDebug/kotlin/eu/darken/sdmse/screenshots/CrowdinScreenshots.kt
+++ b/app/src/screenshotTestGplayDebug/kotlin/eu/darken/sdmse/screenshots/CrowdinScreenshots.kt
@@ -43,7 +43,10 @@ fun GplayUpgradeOwnedSub() {
                 subscriptionAction = SubscriptionAction.STANDARD,
                 subscriptionEnabled = false,
                 subscriptionPrice = "€9.99",
-                iapEnabled = false,
+                // toLoadedState computes this from the offer, not from ownership: a renewing
+                // subscriber still sees an enabled IAP flag. The switch offer is greyed out by
+                // isAutoRenewing further down, which is what this render is here to show.
+                iapEnabled = true,
                 iapPrice = "€12.99",
                 ownership = Ownership(
                     subscription = SubscriptionOwnership(isAutoRenewing = true),

--- a/app/src/screenshotTestGplayDebug/kotlin/eu/darken/sdmse/screenshots/CrowdinScreenshots.kt
+++ b/app/src/screenshotTestGplayDebug/kotlin/eu/darken/sdmse/screenshots/CrowdinScreenshots.kt
@@ -1,0 +1,54 @@
+package eu.darken.sdmse.screenshots
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.upgrade.ui.GplayUpgradeUiState
+import eu.darken.sdmse.common.upgrade.ui.Ownership
+import eu.darken.sdmse.common.upgrade.ui.SubscriptionAction
+import eu.darken.sdmse.common.upgrade.ui.SubscriptionOwnership
+import eu.darken.sdmse.common.upgrade.ui.UpgradeScreen
+
+// Renders for Crowdin's translator context, uploaded by the android-translation plugin. Unlike
+// PlayStoreLocales these render en-US only: auto-tagging matches the source language, so the other
+// locales would be uploads nobody reads. copy_screenshots.sh ignores these names.
+@Preview(locale = "en", name = "en-US", device = DS)
+private annotation class CrowdinLocale
+
+@PreviewTest
+@CrowdinLocale
+@Composable
+fun GplayUpgradeAcquisition() {
+    PreviewWrapper {
+        UpgradeScreen(
+            uiState = GplayUpgradeUiState.Loaded(
+                subscriptionAction = SubscriptionAction.TRIAL,
+                subscriptionEnabled = true,
+                subscriptionPrice = "€9.99",
+                iapEnabled = true,
+                iapPrice = "€12.99",
+            ),
+        )
+    }
+}
+
+@PreviewTest
+@CrowdinLocale
+@Composable
+fun GplayUpgradeOwnedSub() {
+    PreviewWrapper {
+        UpgradeScreen(
+            uiState = GplayUpgradeUiState.Loaded(
+                subscriptionAction = SubscriptionAction.STANDARD,
+                subscriptionEnabled = false,
+                subscriptionPrice = "€9.99",
+                iapEnabled = false,
+                iapPrice = "€12.99",
+                ownership = Ownership(
+                    subscription = SubscriptionOwnership(isAutoRenewing = true),
+                ),
+            ),
+        )
+    }
+}

--- a/fastlane/copy_screenshots.sh
+++ b/fastlane/copy_screenshots.sh
@@ -34,7 +34,10 @@ EXPECTED_PER_LOCALE=${#SLOT[@]}
 CLEAN=0
 [[ "${1:-}" == "--clean" ]] && CLEAN=1
 
-mapfile -t PNGS < <(find . -type d -name reference -path '*screenshotTest*' -prune -exec find {} -name '*.png' \; 2>/dev/null | sort)
+# The gplay variant renders the same Play Store screens as Foss (its reference dir fills up when
+# :app:updateGplayDebugScreenshotTest runs for the Crowdin renders). Both would map to the same
+# slot, so the store set stays Foss-only and gplay is excluded here.
+mapfile -t PNGS < <(find . -type d -name reference -path '*screenshotTest*' -not -path '*screenshotTestGplayDebug*' -prune -exec find {} -name '*.png' \; 2>/dev/null | sort)
 if [[ ${#PNGS[@]} -eq 0 ]]; then
   echo "ERROR: no rendered PNGs found. Run fastlane/generate_screenshots.sh first." >&2
   exit 1
@@ -47,6 +50,10 @@ declare -a JOBS         # "locale<TAB>slot<TAB>src"
 FAIL=0
 
 for src in "${PNGS[@]}"; do
+  # Crowdin translator-context renders (CrowdinScreenshots.kt) live in the same reference dirs but
+  # are not store screens: en-US only, no slot. Skip them before the manifest lookup below, which
+  # treats an unknown function as a hard error.
+  [[ "$src" == */CrowdinScreenshotsKt/* ]] && continue
   base="$(basename "$src" .png)"
   # <Func>_<locale>_<hash>_<idx> — Func has no underscore; locale may contain hyphens.
   func="${base%%_*}"


### PR DESCRIPTION
## What changed

Translators working on the upgrade and support screens now get pictures of the screens they are translating, plus a written explanation of what each string is and where it appears. Nothing in the app itself changes, and the Play Store screenshots are unaffected.

Two new screenshot definitions render the FOSS support screen (pitch, free status, upgraded status) and the Google Play upgrade screen (offers, active subscription) so those images can be attached to the strings on Crowdin.

## Technical Context

- The previews live in `screenshotTestFossDebug` and `screenshotTestGplayDebug` rather than the shared `app/src/screenshotTest`, because `UpgradeScreen` is a per-flavor composable and `GplayUpgradeUiState` is gplay-only; shared code would fail to compile for the other variant.
- They render en-US only through a private `@CrowdinLocale` annotation instead of `@PlayStoreLocales`. Crowdin auto-tagging matches source-language text, so the other seven locales would add renders nobody reads.
- `copy_screenshots.sh` needed two guards, and both are worth understanding before touching that script. It treats a function missing from its `SLOT` manifest as a hard error, so the new renders aborted the whole generate-then-copy workflow; they are now skipped by path rather than given a manifest slot, which would have put them in front of Play Store users. Separately, the gplay renders require `:app:updateGplayDebugScreenshotTest` (since `generate_screenshots.sh` drives only the Foss variant), and that fills the gplay reference dir with a second full set of the same store screens, tripping the duplicate-destination check on every locale; the store set is now explicitly Foss-only.
- The rules note is worded project-wide on purpose. Context has only been written for the two flavor files so far, but the "once a string's context has been written on Crowdin" clause scopes it correctly as more files get covered.
- Worth a close look: the fake states in both `CrowdinScreenshots.kt` files are hand-built rather than derived from a ViewModel, so a future change to `GplayUpgradeUiState` or `FossUpgradeView` will keep compiling while quietly rendering a state the app can no longer reach.