### PR TITLE
Squeezer: Remove leftover text that no screen shows

### DIFF
--- a/app-tool-squeezer/src/main/res/values-af-rZA/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-af-rZA/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Minimum lêerouderdom</string>
     <string name="squeezer_min_age_description">Sluit slegs lêers in wat ouer is as hierdie ouderdom.</string>
     <string name="squeezer_compression_settings_label">Algemeen</string>
-    <string name="squeezer_quality_label">Kwaliteit</string>
-    <string name="squeezer_quality_title">Kompressiekwaliteit</string>
     <string name="squeezer_quality_description">Laer kwaliteit beteken \'n kleiner lêergrootte maar verminderde visuele kwaliteit.</string>
-    <string name="squeezer_quality_example_format">Voorbeeld: %1$s beeld → bespaar ~%2$s teen %3$d%% kwaliteit</string>
-    <string name="squeezer_quality_warning_low">Laer kwaliteite kan sigbare artefakte veroorsaak.</string>
-    <string name="squeezer_quality_warning_high">Baie hoë kwaliteit bied minimale ruimtebesparings.</string>
     <string name="squeezer_types_category_label">Beeldinstellings</string>
     <string name="squeezer_video_settings_category_label">Video-instellings</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Bevestig kompressie</string>
     <string name="squeezer_preview_total_size">Totale grootte</string>
     <string name="squeezer_preview_estimated_savings">Beraamde besparing</string>
-    <string name="squeezer_compress_confirmation_title">Gekose items komprimeer?</string>
-    <string name="squeezer_compress_confirmation_message">Dit sal oorspronklike lêers vervang met gekomprimeerde weergawes. Hierdie aksie kan nie ongedaan gemaak word nie.</string>
     <string name="squeezer_history_title">Kompressiegeskiedenis</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d item (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Geen kompressiegeskiedenis nie</string>
     <string name="squeezer_history_clear_title">Vee kompressiegeskiedenis uit</string>
     <string name="squeezer_history_clear_message">Dit sal toelaat dat voorheen gekomprimeerde lêers weer gekomprimeer word. Die lêers self word nie geraak nie.</string>
-    <string name="squeezer_onboarding_title">Oor beeldkompressie</string>
-    <string name="squeezer_onboarding_message">Beeldkompressie verminder lêergrootte deur visuele detail te verwyder. Hierdie proses is onomkeerbaar - die oorspronklike kwaliteit kan nie herstel word nie.\n\nHier is \'n voorskou van hoe jou beelde sal lyk:</string>
     <string name="squeezer_onboarding_original_label">Oorspronklik</string>
     <string name="squeezer_onboarding_compressed_label">Na kompressie</string>
     <string name="squeezer_onboarding_video_original_label">Videoraam</string>
     <string name="squeezer_onboarding_video_compressed_label">Voorskou (benaderd)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Werklike videokwaliteit kan verskil</string>
-    <string name="squeezer_onboarding_quality_label">Kwaliteit: %d%%</string>
     <string name="squeezer_compare_action">Bekyk vergelyking</string>
     <string name="squeezer_no_example_found">Geen beelde gevind in gekose paaie nie.</string>
     <string name="squeezer_result_empty_message">Geen komprimeerbare media gevind nie.</string>
-    <string name="squeezer_setup_warning">Kompressie verminder kwaliteit permanent om bergingspasie te bespaar. Dit kan nie ongedaan gemaak word nie. Hersien jou instellings noukeurig voor jy begin.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d ligging kan nie vir kompressie gebruik word nie en is verwyder. Kompressie vereis direkte toegang tot interne berging.</item>
         <item quantity="other">%d liggings kan nie vir kompressie gebruik word nie en is verwyder. Kompressie vereis direkte toegang tot interne berging.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Ten minste %d dae oud</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Geskatte ~%d%% besparing vir JPEG-lêers</string>
-    <string name="squeezer_onboarding_got_it">Verstaan</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer druk jou foto\'s en video\'s weer saam sodat hulle minder plek inneem. Jy ruil \'n bietjie kwaliteit vir die ruimte wat jy bespaar. Elke item toon sy geraamde besparing, sodat jy kan besluit watter items die moeite werd is.</string>
     <string name="tour_squeezer_compress_body">Komprimeer alles op een keer hier, of tik \'n enkele item om slegs daardie een te verklein. Lank vashou om verskeie te kies. Jy sal altyd \'n voorskou sien voordat enigiets verander.</string>

--- a/app-tool-squeezer/src/main/res/values-am/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-am/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">ዝቅተኛ የፋይል ዕድሜ</string>
     <string name="squeezer_min_age_description">ከዚህ ዕድሜ በላይ ያሉ ፋይሎችን ብቻ አካትት።</string>
     <string name="squeezer_compression_settings_label">አጠቃላይ</string>
-    <string name="squeezer_quality_label">ጥራት</string>
-    <string name="squeezer_quality_title">የመጨመቅ ጥራት</string>
     <string name="squeezer_quality_description">ዝቅተኛ ጥራት ማለት ትንሽ የፋይል መጠን ነው፣ ነገር ግን የምስሉ ጥራት ይቀንሳል።</string>
-    <string name="squeezer_quality_example_format">ምሳሌ: %1$s ምስል → በ%3$d%% ጥራት ~%2$s ይቆጥባል</string>
-    <string name="squeezer_quality_warning_low">ዝቅ ያሉ ጥራቶች የሚታዩ ጉድለቶች ሊያስከትሉ ይችላሉ።</string>
-    <string name="squeezer_quality_warning_high">በጣም ከፍተኛ ጥራት ዝቅተኛ ቦታ ቁጠባ ይሰጣል።</string>
     <string name="squeezer_types_category_label">የምስል ቅንብሮች</string>
     <string name="squeezer_video_settings_category_label">የቪዲዮ ቅንብሮች</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">መጨመቅ ያረጋግጡ</string>
     <string name="squeezer_preview_total_size">ጠቅላላ መጠን</string>
     <string name="squeezer_preview_estimated_savings">የተገመተ ቁጠባ</string>
-    <string name="squeezer_compress_confirmation_title">የተመረጡ ንጥሎችን ትጨናንቃለህ?</string>
-    <string name="squeezer_compress_confirmation_message">ይህ ዋናዎቹን ፋይሎች በተጨናነቁ ስሪቶች ይተካቸዋል። ይህ እርምጃ ሊቀለበስ አይችልም።</string>
     <string name="squeezer_history_title">የመጨመቅ ታሪክ</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ንጥል (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">ምንም የመጨመቅ ታሪክ የለም</string>
     <string name="squeezer_history_clear_title">የመጨመቅ ታሪክ ያጽዱ</string>
     <string name="squeezer_history_clear_message">ይህ ቀደም ሲል የተጨናነቁ ፋይሎች እንደገና እንዲጨናነቁ ያስችላል። ፋይሎቹ ራሳቸው አይጎዳም።</string>
-    <string name="squeezer_onboarding_title">ስለ ምስል መጨመቅ</string>
-    <string name="squeezer_onboarding_message">የምስል መጨመቅ ምስላዊ ዝርዝርን በማስወገድ የፋይል መጠንን ይቀንሳል። ይህ ሂደት ሊቀለበስ አይችልም - ዋናው ጥራት ሊመለስ አይችልም።\n\nምስሎችዎ እንዴት እንደሚታዩ ቅድመ-ዕይታ ይኸውና:</string>
     <string name="squeezer_onboarding_original_label">ዋና</string>
     <string name="squeezer_onboarding_compressed_label">ከመጨመቅ በኋላ</string>
     <string name="squeezer_onboarding_video_original_label">የቪዲዮ ፍሬም</string>
     <string name="squeezer_onboarding_video_compressed_label">ቅድመ እይታ (ግምታዊ)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">ትክክለኛው የቪዲዮ ጥራት ሊለያይ ይችላል</string>
-    <string name="squeezer_onboarding_quality_label">ጥራት: %d%%</string>
     <string name="squeezer_compare_action">ንጽጽር ይመልከቱ</string>
     <string name="squeezer_no_example_found">በተመረጡ ዱካዎች ውስጥ ምንም ምስሎች አልተገኙም።</string>
     <string name="squeezer_result_empty_message">ሊጨናነቅ የሚችል ሚዲያ አልተገኘም።</string>
-    <string name="squeezer_setup_warning">መጨናነቅ የማከማቻ ቦታ ለመቆጠብ ጥራቱን ቋሚ በሆነ ሁኔታ ይቀንሳል። ይህ ሊቀለበስ አይችልም። ከመጀመርዎ በፊት ቅንብሮቻቸውን በጥንቃቄ ይገምግሙ።</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d ቦታ ለመጨናነቅ ጥቅም ላይ ሊውል አይችልም እና ተወግዷል። መጨናነቅ ወደ ውስጣዊ ማከማቻ ቀጥተኛ ፍቃድ ያስፈልጋል።</item>
         <item quantity="other">%d ቦታዎች ለመጨናነቅ ጥቅም ላይ ሊውሉ አይችሉም እና ተወግደዋል። መጨናነቅ ወደ ውስጣዊ ማከማቻ ቀጥተኛ ፍቃድ ያስፈልጋል።</item>
@@ -109,7 +98,6 @@
         <item quantity="other">ቢያንስ %d ቀናት የቆየ</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">ለ JPEG ፋይሎች ግምታውይ ~%d%% ቦታ ቅነሳ</string>
-    <string name="squeezer_onboarding_got_it">ገባኝ</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer ፎቶ እና ቪዲዮዎን እንደገና ይጭብርብራል ስለዚህ ቦታ ያኖራል። ትንሽ ጥራትን ለተመለሰው ቦታ ይለዋወጣሉ። እያንዳንዱ ሕዋስ ግምታዊ ቅነሳውን ያሳያል፣ ስለዚህ ምን ዋጋ ያለበት ልትወስኑ ይችላሉ።</string>
     <string name="tour_squeezer_compress_body">ሁሉንም በአንድ ጊዜ ይጨምቁ ወይም አንድ ነገር ይምቱ ትንሽ ለመወገድ። ብዙ ለመምረጥ ክብብ-ይጀኑ። ሁሉ ሊቀያር ቅድሚያ ሁሌ ድምድም ይታያሉ።</string>

--- a/app-tool-squeezer/src/main/res/values-ar/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ar/strings.xml
@@ -70,12 +70,7 @@
     <string name="squeezer_min_age_title">الحد الأدنى لعمر الملف</string>
     <string name="squeezer_min_age_description">تضمين الملفات الأقدم من هذا العمر فقط.</string>
     <string name="squeezer_compression_settings_label">عام</string>
-    <string name="squeezer_quality_label">الجودة</string>
-    <string name="squeezer_quality_title">جودة الضغط</string>
     <string name="squeezer_quality_description">الجودة المنخفضة تعني حجم ملف أصغر ولكن جودة بصرية أقل.</string>
-    <string name="squeezer_quality_example_format">مثال: صورة %1$s → توفير ~%2$s بجودة %3$d%%</string>
-    <string name="squeezer_quality_warning_low">الجودة المنخفضة قد تسبب تشوهات مرئية.</string>
-    <string name="squeezer_quality_warning_high">الجودة العالية جدًا توفر مساحة قليلة.</string>
     <string name="squeezer_types_category_label">إعدادات الصورة</string>
     <string name="squeezer_video_settings_category_label">إعدادات الفيديو</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -100,8 +95,6 @@
     <string name="squeezer_preview_dialog_title">تأكيد الضغط</string>
     <string name="squeezer_preview_total_size">الحجم الإجمالي</string>
     <string name="squeezer_preview_estimated_savings">التوفير المقدر</string>
-    <string name="squeezer_compress_confirmation_title">ضغط العناصر المحددة؟</string>
-    <string name="squeezer_compress_confirmation_message">سيتم استبدال الملفات الأصلية بنسخ مضغوطة. لا يمكن التراجع عن هذا الإجراء.</string>
     <string name="squeezer_history_title">سجل الضغط</string>
     <plurals name="squeezer_history_summary">
         <item quantity="zero">%1$d عناصر (%2$s)</item>
@@ -114,18 +107,14 @@
     <string name="squeezer_history_empty">لا يوجد سجل ضغط</string>
     <string name="squeezer_history_clear_title">مسح سجل الضغط</string>
     <string name="squeezer_history_clear_message">سيسمح هذا بضغط الملفات المضغوطة سابقًا مرة أخرى. الملفات نفسها لن تتأثر.</string>
-    <string name="squeezer_onboarding_title">حول ضغط الصور</string>
-    <string name="squeezer_onboarding_message">ضغط الصور يقلل حجم الملف عن طريق إزالة التفاصيل المرئية. هذه العملية لا رجعة فيها - لا يمكن استعادة الجودة الأصلية.\n\nإليك معاينة لكيفية ظهور صورك:</string>
     <string name="squeezer_onboarding_original_label">الأصلية</string>
     <string name="squeezer_onboarding_compressed_label">بعد الضغط</string>
     <string name="squeezer_onboarding_video_original_label">إطار الفيديو</string>
     <string name="squeezer_onboarding_video_compressed_label">معاينة (تقريبية)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">قد تختلف جودة الفيديو الفعلية</string>
-    <string name="squeezer_onboarding_quality_label">الجودة: %d%%</string>
     <string name="squeezer_compare_action">عرض المقارنة</string>
     <string name="squeezer_no_example_found">لم يتم العثور على صور في المسارات المحددة.</string>
     <string name="squeezer_result_empty_message">لم يتم العثور على وسائط قابلة للضغط.</string>
-    <string name="squeezer_setup_warning">يُقلّل الضغط من الجودة بشكل دائم لتوفير مساحة التخزين. لا يمكن التراجع عن ذلك. راجع إعداداتك بعناية قبل البدء.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="zero">لا توجد مواقع يمكن استخدامها للضغط وتمت إزالتها. يتطلب الضغط وصولاً مباشرًا إلى التخزين الداخلي.</item>
         <item quantity="one">لا يمكن استخدام موقع واحد للضغط وتمت إزالته. يتطلب الضغط وصولاً مباشرًا إلى التخزين الداخلي.</item>
@@ -153,7 +142,6 @@
         <item quantity="other">عمرها %d يوم على الأقل</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">توفير مقدر ~%d%% لملفات JPEG</string>
-    <string name="squeezer_onboarding_got_it">عُلم</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">يعيد Squeezer ضغط صورك ومقاطع الفيديو الخاصة بك حتى تشغل مساحة أقل. ستضحي بقليل من الجودة مقابل المساحة التي تحصل عليها. يعرض كل عنصر التوفير المقدر، حتى تتمكني من تحديد أي منها يستحق ذلك.</string>
     <string name="tour_squeezer_compress_body">اضغط كل شيء في نفس الوقت هنا، أو اضغط على عنصر واحد لتقليص حجم هذا العنصر فقط. اضغط لفترة طويلة لاختيار عدة عناصر. سترى دائماً معاينة قبل أي تغيير.</string>

--- a/app-tool-squeezer/src/main/res/values-az/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-az/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Minimum fayl yaşı</string>
     <string name="squeezer_min_age_description">Yalnız bu yaşdan köhnə faylları daxil edin.</string>
     <string name="squeezer_compression_settings_label">Ümumi</string>
-    <string name="squeezer_quality_label">Keyfiyyət</string>
-    <string name="squeezer_quality_title">Sıxışdırma keyfiyyəti</string>
     <string name="squeezer_quality_description">Aşağı keyfiyyət daha kiçik fayl ölçüsü deməkdir, lakin vizual keyfiyyəti azaldır.</string>
-    <string name="squeezer_quality_example_format">Nümunə: %1$s şəkil → %3$d%% keyfiyyətdə ~%2$s qənaət</string>
-    <string name="squeezer_quality_warning_low">Aşağı keyfiyyət görünən artefaktlara səbəb ola bilər.</string>
-    <string name="squeezer_quality_warning_high">Çox yüksək keyfiyyət minimum yer qənaəti təmin edir.</string>
     <string name="squeezer_types_category_label">Şəkil parametrləri</string>
     <string name="squeezer_video_settings_category_label">Video parametrləri</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Sıxışdırmanı təsdiqləyin</string>
     <string name="squeezer_preview_total_size">Ümumi ölçü</string>
     <string name="squeezer_preview_estimated_savings">Təxmini qənaət</string>
-    <string name="squeezer_compress_confirmation_title">Seçilmiş elementləri sıxışdırılsın?</string>
-    <string name="squeezer_compress_confirmation_message">Bu, orijinal faylları sıxışdırılmış versiyalarla əvəz edəcək. Bu əməliyyat geri qaytarrla biləməz.</string>
     <string name="squeezer_history_title">Sıxışdırma tarixçəsi</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Sıxışdırma tarixçəsi yoxdur</string>
     <string name="squeezer_history_clear_title">Sıxışdırma tarixçəsini təmizlə</string>
     <string name="squeezer_history_clear_message">Bu, əvvəllər sıxışdırılmış faylların yenidən sıxışdırılmasına icəazə verəcək. Faylların özlərinə təsir edilmir.</string>
-    <string name="squeezer_onboarding_title">Şəkil sıxışdırma haqqında</string>
-    <string name="squeezer_onboarding_message">Şəkil sıxışdırma vizual detalları silməklə fayl ölçüsünü azaldır. Bu proses geri dönməzdir - orijinal keyfiyyət bərpa edilə bilməz.\n\nŞəkillərinizin necə görünəcəyinin ön baxışı:</string>
     <string name="squeezer_onboarding_original_label">Orijinal</string>
     <string name="squeezer_onboarding_compressed_label">Sıxışdırmadan sonra</string>
     <string name="squeezer_onboarding_video_original_label">Video kadrı</string>
     <string name="squeezer_onboarding_video_compressed_label">Önizləmə (təxmini)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Faktiki video keyfiyyəti fərqlənə bilər</string>
-    <string name="squeezer_onboarding_quality_label">Keyfiyyət: %d%%</string>
     <string name="squeezer_compare_action">Müqayisəyə bax</string>
     <string name="squeezer_no_example_found">Seçilmiş yollarda şəkil tapılmadı.</string>
     <string name="squeezer_result_empty_message">Sıxışdırıla bilən media tapılmadı.</string>
-    <string name="squeezer_setup_warning">Sıxışdırma, yaddaş sahəsinə qənaət etmək üçün keyfiyyəti daimi olaraq azaldır. Bu geri qaytarrla biləməz. Başlamadan əvvəl parametrlərinizi diqqətlə nəzardən keçirin.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d yer sıxışdırma üçün istifadə edilə bilməz və silindi. Sıxışdırma daxili yaddaşa birbirə giriş tələb edir.</item>
         <item quantity="other">%d yer sıxışdırma üçün istifadə edilə bilməz və silindi. Sıxışdırma daxili yaddaşa birbirə giriş tələb edir.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Ən azı %d gün köhnə</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG faylları üçün təxminən ~%d%% qənaət</string>
-    <string name="squeezer_onboarding_got_it">Başa düşdüm</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer fotoşəkillərinizi və videolarınızı yenidən sıxlaşdırır ki, daha az yer tutsunlar. Bir az keyfiyyətdən imtina edərək aldığınız yerdən faydalanırsınız. Hər bir element təxmini qənaətini göstərir, buna görə hansının dəyər olduğuna qərar verə bilərsiniz.</string>
     <string name="tour_squeezer_compress_body">Burada hər şeyi bir dəfəyə sıxlaşdırın, və ya sadəcə onu kiçiltmək üçün tək bir elementə toxunun. Bir neçəsini seçmək üçün uzun basın. Hər şey dəyişdirilmədən əvvəl həmişə önizləməni görəcəksiniz.</string>

--- a/app-tool-squeezer/src/main/res/values-be/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-be/strings.xml
@@ -54,12 +54,7 @@
     <string name="squeezer_min_age_title">Мінімальны час стварэння файла</string>
     <string name="squeezer_min_age_description">Уключаць толькі файлы, старэйшыя за гэты ўзрост.</string>
     <string name="squeezer_compression_settings_label">Агульныя</string>
-    <string name="squeezer_quality_label">Якасць</string>
-    <string name="squeezer_quality_title">Якасць сціскання</string>
     <string name="squeezer_quality_description">Ніжэйшая якасць азначае меншы памер файла, але зніжаную візуальную якасць.</string>
-    <string name="squeezer_quality_example_format">Напрыклад: выява %1$s → сэканоміць ~%2$s з якасцю %3$d%%</string>
-    <string name="squeezer_quality_warning_low">Нізкая якасць можа прывесці да з\'яўлення бачных артэфактаў.</string>
-    <string name="squeezer_quality_warning_high">Вельмі высокая якасць забяспечвае мінімальную эканомію прасторы.</string>
     <string name="squeezer_types_category_label">Налады выяў</string>
     <string name="squeezer_video_settings_category_label">Налады відэа</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -84,8 +79,6 @@
     <string name="squeezer_preview_dialog_title">Пацвердзіць сцісканне</string>
     <string name="squeezer_preview_total_size">Агульны памер</string>
     <string name="squeezer_preview_estimated_savings">Меркаваная эканомія</string>
-    <string name="squeezer_compress_confirmation_title">Сціснуць выбраныя элементы?</string>
-    <string name="squeezer_compress_confirmation_message">Гэта заменіць арыгінальныя файлы сціснутымі версіямі. Гэтае дзеянне немагчыма адмяніць.</string>
     <string name="squeezer_history_title">Гісторыя сцісканняў</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d элемент (%2$s)</item>
@@ -96,18 +89,14 @@
     <string name="squeezer_history_empty">Няма гісторыі сцісканняў</string>
     <string name="squeezer_history_clear_title">Ачысціць гісторыю сцісканняў</string>
     <string name="squeezer_history_clear_message">Гэта дазволіць паўторна сціскаць раней сціснутыя файлы. Самі файлы не зменяцца.</string>
-    <string name="squeezer_onboarding_title">Аб сцісканні выяў</string>
-    <string name="squeezer_onboarding_message">Сцісканне выявы памяншае памер файла, выдаляючы візуальныя дэталі. Гэты працэс незваротны — першапачатковую якасць аднавіць немагчыма.\n\nВось папярэдні прагляд таго, як будуць выглядаць вашы выявы:</string>
     <string name="squeezer_onboarding_original_label">Арыгінал</string>
     <string name="squeezer_onboarding_compressed_label">Пасля сціскання</string>
     <string name="squeezer_onboarding_video_original_label">Кадр відэа</string>
     <string name="squeezer_onboarding_video_compressed_label">Папярэдні прагляд (прыблізна)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Фактычная якасць відэа можа адрознівацца</string>
-    <string name="squeezer_onboarding_quality_label">Якасць: %d%%</string>
     <string name="squeezer_compare_action">Паглядзець параўнанне</string>
     <string name="squeezer_no_example_found">У выбраных шляхах выявы не знойдзены.</string>
     <string name="squeezer_result_empty_message">Не знойдзена носьбіцаў для сціску.</string>
-    <string name="squeezer_setup_warning">Сціск назаўжды зніжае якасць для эканоміі месца на носьбіце. Гэтае дзеянне немагчыма адмяніць. Уважліва праверце налады перад пачаткам.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d месца не можа выкарыстоўвацца для сціску і было выдалена. Сціск патрабуе прамога доступу да ўнутранай памяці.</item>
         <item quantity="few">%d месцы не могуць выкарыстоўвацца для сціску і былі выдалены. Сціск патрабуе прамога доступу да ўнутранай памяці.</item>
@@ -131,7 +120,6 @@
         <item quantity="other">Не менш за %d дзён</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Ацэначная эканомія ~%d%% для файлаў JPEG</string>
-    <string name="squeezer_onboarding_got_it">Зразумела</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer паўторна сціскае вашы фота і відэа, каб яны займалі менш месца. Вы ахвяруеце крыху якасцу дзеля вернутага месца. Кожны элемент паказвае прыблізную эканомію, каб вы маглі вырашыць, ці варта гэта.</string>
     <string name="tour_squeezer_compress_body">Сціскайце усё адразу тут або націсніце на асобны элемент, каб сціснуць толькі яго. Доўгае націсканне, каб выбраць некалькі. Вы заўсёды ўбачыце папярэдні прагляд, перш чым што-небудзь зменіцца.</string>

--- a/app-tool-squeezer/src/main/res/values-bg/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-bg/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Минимална възраст на файла</string>
     <string name="squeezer_min_age_description">Включвайте само файлове, по-стари от тази възраст.</string>
     <string name="squeezer_compression_settings_label">Общи</string>
-    <string name="squeezer_quality_label">Качество</string>
-    <string name="squeezer_quality_title">Качество на компресия</string>
     <string name="squeezer_quality_description">По-ниското качество означава по-малък размер на файла, но намалено визуално качество.</string>
-    <string name="squeezer_quality_example_format">Пример: %1$s изображение → спестява ~%2$s при %3$d%% качество</string>
-    <string name="squeezer_quality_warning_low">По-ниските качества могат да причинят видими артефакти.</string>
-    <string name="squeezer_quality_warning_high">Много високото качество осигурява минимални спестявания на място.</string>
     <string name="squeezer_types_category_label">Настройки за изображения</string>
     <string name="squeezer_video_settings_category_label">Настройки за видео</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Потвърждаване на компресията</string>
     <string name="squeezer_preview_total_size">Общ размер</string>
     <string name="squeezer_preview_estimated_savings">Очаквани спестявания</string>
-    <string name="squeezer_compress_confirmation_title">Компресиране на избраните елементи?</string>
-    <string name="squeezer_compress_confirmation_message">Това ще замени оригиналните файлове с компресирани версии. Това действие не може да бъде отменено.</string>
     <string name="squeezer_history_title">История на компресията</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d елемент (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Няма история на компресията</string>
     <string name="squeezer_history_clear_title">Изчистване на историята на компресията</string>
     <string name="squeezer_history_clear_message">Това ще позволи на вече компресираните файлове да бъдат компресирани отново. Самите файлове не са засегнати.</string>
-    <string name="squeezer_onboarding_title">За компресията на изображения</string>
-    <string name="squeezer_onboarding_message">Компресията на изображения намалява размера на файла чрез премахване на визуални детайли. Този процес е необратим - оригиналното качество не може да бъде възстановено.\n\nЕто предварителен преглед на това как ще изглеждат вашите изображения:</string>
     <string name="squeezer_onboarding_original_label">Оригинал</string>
     <string name="squeezer_onboarding_compressed_label">След компресия</string>
     <string name="squeezer_onboarding_video_original_label">Видео кадър</string>
     <string name="squeezer_onboarding_video_compressed_label">Преглед (приблизителен)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Действителното качество на видеото може да се различава</string>
-    <string name="squeezer_onboarding_quality_label">Качество: %d%%</string>
     <string name="squeezer_compare_action">Преглед на сравнение</string>
     <string name="squeezer_no_example_found">Не са намерени изображения в избраните пътища.</string>
     <string name="squeezer_result_empty_message">Няма намерени медии за компресиране.</string>
-    <string name="squeezer_setup_warning">Компресирането намалява качеството завинаги, за да спести място за съхранение. Това не може да бъде отменено. Прегледайте внимателно настройките си, преди да започнете.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d местоположение не може да се използва за компресиране и беше премахнато. Компресирането изисква директен достъп до вътрешната памет.</item>
         <item quantity="other">%d местоположения не могат да се използват за компресиране и бяха премахнати. Компресирането изисква директен достъп до вътрешната памет.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Поне %d дни стар</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Прогнозни спестявания от ~%d%% за JPEG файлове</string>
-    <string name="squeezer_onboarding_got_it">Разбрах</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer прекомпресира снимките и видеата ви, за да заемат по-малко място. Жертвате малко качество срещу пространството, което си връщате. Всеки елемент показва прогнозното намаление, така че можете да решите какво си струва.</string>
     <string name="tour_squeezer_compress_body">Компресирайте всичко наведнъж тук, или докоснете един елемент, за да намалите само него. Задръжте натиснато, за да изберете няколко. Винаги ще видите преглед, преди да се промени нещо.</string>

--- a/app-tool-squeezer/src/main/res/values-bn-rBD/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-bn-rBD/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">সর্বনিম্ন ফাইল বয়স</string>
     <string name="squeezer_min_age_description">কেবল এই বয়সের চেয়ে পুরানো ফাইলগুলি অন্তর্ভুক্ত করুন।</string>
     <string name="squeezer_compression_settings_label">সাধারণ</string>
-    <string name="squeezer_quality_label">গুণমান</string>
-    <string name="squeezer_quality_title">সংকোচনের গুণমান</string>
     <string name="squeezer_quality_description">কম মান মানে ছোট ফাইলের আকার কিন্তু কম দৃশ্যমান মান।</string>
-    <string name="squeezer_quality_example_format">উদাহরণ: %1$s ছবি → %3$d%% গুণমানে ~%2$s সাশ্রয়</string>
-    <string name="squeezer_quality_warning_low">নিম্ন গুণমান দৃশ্যমান আর্টিফ্যাক্ট তৈরি করতে পারে।</string>
-    <string name="squeezer_quality_warning_high">অত্যন্ত উচ্চ গুণমান ন্যূনতম স্থান সাশ্রয় প্রদান করে।</string>
     <string name="squeezer_types_category_label">ছবির সেটিংস</string>
     <string name="squeezer_video_settings_category_label">ভিডিও সেটিংস</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">সংকোচন নিশ্চিত করুন</string>
     <string name="squeezer_preview_total_size">মোট আকার</string>
     <string name="squeezer_preview_estimated_savings">আনুমানিক সাশ্রয়</string>
-    <string name="squeezer_compress_confirmation_title">নির্বাচিত আইটেমগুলি সংকুচিত করবেন?</string>
-    <string name="squeezer_compress_confirmation_message">এটি মূল ফাইলগুলিকে সংকুচিত সংস্করণ দিয়ে প্রতিস্থাপন করবে। এই ক্রিয়াটি পূর্বাবস্থায় ফেরানো যাবে না।</string>
     <string name="squeezer_history_title">সংকোচন ইতিহাস</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d আইটেম (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">কোন সংকোচন ইতিহাস নেই</string>
     <string name="squeezer_history_clear_title">সংকোচন ইতিহাস মুছুন</string>
     <string name="squeezer_history_clear_message">এটি পূর্বে সংকুচিত ফাইলগুলিকে আবার সংকুচিত করার অনুমতি দেবে। ফাইলগুলি নিজেই প্রভাবিত হয় না।</string>
-    <string name="squeezer_onboarding_title">ছবি সংকোচন সম্পর্কে</string>
-    <string name="squeezer_onboarding_message">ছবি সংকোচন ভিজ্যুয়াল বিশদ অপসারণ করে ফাইলের আকার কমায়। এই প্রক্রিয়া অপরিবর্তনীয় - আসল গুণমান পুনরুদ্ধার করা যাবে না।\n\nআপনার ছবিগুলি কেমন দেখাবে তার একটি প্রিভিউ এখানে:</string>
     <string name="squeezer_onboarding_original_label">আসল</string>
     <string name="squeezer_onboarding_compressed_label">সংকোচনের পর</string>
     <string name="squeezer_onboarding_video_original_label">ভিডিও ফ্রেম</string>
     <string name="squeezer_onboarding_video_compressed_label">প্রিভিউ (আনুমানিক)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">প্রকৃত ভিডিও মান ভিন্ন হতে পারে</string>
-    <string name="squeezer_onboarding_quality_label">গুণমান: %d%%</string>
     <string name="squeezer_compare_action">তুলনা দেখুন</string>
     <string name="squeezer_no_example_found">নির্বাচিত পাথে কোনো ছবি পাওয়া যায়নি।</string>
     <string name="squeezer_result_empty_message">কোনো সংকোচনযোগ্য মিডিয়া পাওয়া যায়নি।</string>
-    <string name="squeezer_setup_warning">সংকোচন স্থায়ীভাবে স্টোরেজ স্থান বাঁচাতে মান কমিয়ে দেয়। এটি পূর্বাবস্থায় ফেরানো যাবে না। শুরু করার আগে আপনার সেটিংস সাবধানে পর্যালোচনা করুন।</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%dটি অবস্থান সংকোচনের জন্য ব্যবহার করা যাবে না এবং সরানো হয়েছে। সংকোচনের জন্য অভ্যন্তরীণ স্টোরেজে সরাসরি অ্যাক্সেস প্রয়োজন।</item>
         <item quantity="other">%dটি অবস্থান সংকোচনের জন্য ব্যবহার করা যাবে না এবং সরানো হয়েছে। সংকোচনের জন্য অভ্যন্তরীণ স্টোরেজে সরাসরি অ্যাক্সেস প্রয়োজন।</item>
@@ -109,7 +98,6 @@
         <item quantity="other">অন্তত %d দিন পুরনো</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG ফাইলগুলির জন্য আনুমানিক ~%d%% সঞ্চয়</string>
-    <string name="squeezer_onboarding_got_it">বুঝেছি</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer আপনার ফটো এবং ভিডিও পুনরায় সংকুচিত করে যাতে তারা কম জায়গা নেয়। আপনি একটু গুণমানের বিনিময়ে আরও জায়গা পান। প্রতিটি আইটেম তার অনুমানিত সাশ্রয় দেখায়, তাই আপনি সিদ্ধান্ত নিতে পারেন কোনটি সার্থক।</string>
     <string name="tour_squeezer_compress_body">এখানে সবকিছু একবারে সংকুচিত করুন, অথবা শুধুমাত্র সেই একটি সংকুচিত করতে একটি একক আইটেমে ট্যাপ করুন। বেশ কয়েকটি নির্বাচন করতে দীর্ঘ-প্রেস করুন। আপনি সর্বদা কিছু পরিবর্তনের আগে একটি পূর্বরূপ দেখবেন।</string>

--- a/app-tool-squeezer/src/main/res/values-ca/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ca/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Antiguitat mínima del fitxer</string>
     <string name="squeezer_min_age_description">Només inclou fitxers anteriors a aquesta antiguitat.</string>
     <string name="squeezer_compression_settings_label">General</string>
-    <string name="squeezer_quality_label">Qualitat</string>
-    <string name="squeezer_quality_title">Qualitat de compressió</string>
     <string name="squeezer_quality_description">Una qualitat més baixa significa una mida de fitxer més petita però una qualitat visual reduïda.</string>
-    <string name="squeezer_quality_example_format">Exemple: %1$s imatge → estalvia ~%2$s amb una qualitat del %3$d%%</string>
-    <string name="squeezer_quality_warning_low">Les qualitats inferiors poden causar artefactes visibles.</string>
-    <string name="squeezer_quality_warning_high">La qualitat molt alta proporciona un estalvi mínim d\'espai.</string>
     <string name="squeezer_types_category_label">Configuració d\'imatges</string>
     <string name="squeezer_video_settings_category_label">Configuració de vídeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Confirmeu la compressió</string>
     <string name="squeezer_preview_total_size">Mida total</string>
     <string name="squeezer_preview_estimated_savings">Estalvi estimat</string>
-    <string name="squeezer_compress_confirmation_title">Voleu comprimir els elements seleccionats?</string>
-    <string name="squeezer_compress_confirmation_message">Això substituïrà els fitxers originals per versions comprimides. Aquesta acció no es pot desfer.</string>
     <string name="squeezer_history_title">Historial de compressió</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Sense historial de compressió</string>
     <string name="squeezer_history_clear_title">Esborra l\'historial de compressió</string>
     <string name="squeezer_history_clear_message">Això permetrà que els fitxers prèviament comprimits es tornin a comprimir. Els fitxers en si no es veuen afectats.</string>
-    <string name="squeezer_onboarding_title">Quant a la compressió d\'imatges</string>
-    <string name="squeezer_onboarding_message">La compressió d\'imatges redueix la mida del fitxer eliminant detalls visuals. Aquest procés és irreversible: la qualitat original no es pot restaurar.\n\nAquí teniu una vista prèvia de com quedaran les vostres imatges:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Després de la compressió</string>
     <string name="squeezer_onboarding_video_original_label">Fotograma de vídeo</string>
     <string name="squeezer_onboarding_video_compressed_label">Previsualització (aproximada)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">La qualitat real del vídeo pot variar</string>
-    <string name="squeezer_onboarding_quality_label">Qualitat: %d%%</string>
     <string name="squeezer_compare_action">Mostra la comparació</string>
     <string name="squeezer_no_example_found">No s\'han trobat imatges a les rutes seleccionades.</string>
     <string name="squeezer_result_empty_message">No s\'han trobat fitxers multimèdia comprimibles.</string>
-    <string name="squeezer_setup_warning">La compressió reduïx permanentment la qualitat per estalviar espai d\'emmagatzematge. Això no es pot desfer. Reviseu la configuració acuradament abans de començar.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d ubicació no es pot utilitzar per a la compressió i s\'ha eliminat. La compressió requereix accés directe a l\'emmagatzematge intern.</item>
         <item quantity="other">%d ubicacions no es poden utilitzar per a la compressió i s\'han eliminat. La compressió requereix accés directe a l\'emmagatzematge intern.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Almenys %d dies d\'antiguitat</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Estalvi estimat d\'un %d%% per a fitxers JPEG</string>
-    <string name="squeezer_onboarding_got_it">Entesos</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer recomprimeix les vostres fotos i vídeos perquè ocupin menys espai. Canvieu una mica de qualitat per l\'espai que recupereu. Cada element mostra l\'estalvi estimat, perquè podeu decidir què en val la pena.</string>
     <string name="tour_squeezer_compress_body">Comprimeix-ho tot alhora aquí, o toca un element per reduir només aquest. Prem llargament per triar-ne diversos. Sempre veuràs una previsualització abans que res canviï.</string>

--- a/app-tool-squeezer/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ckb-rIR/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">کەمترین تەمەنی فایل</string>
     <string name="squeezer_min_age_description">تەنها فایلەکانی کۆنتر لەم تەمەنە لەخۆ بگرە.</string>
     <string name="squeezer_compression_settings_label">گشتی</string>
-    <string name="squeezer_quality_label">کوالیتی</string>
-    <string name="squeezer_quality_title">کوالیتی پەکاندن</string>
     <string name="squeezer_quality_description">کوالیتی نزم یانی قەبارەی فایل بچووکتر دەبێت بەڵام کوالیتی دیداری کەمتر دەبێت.</string>
-    <string name="squeezer_quality_example_format">نموونە: وێنەی %1$s → ~%2$s خەزن دەکات لە %3$d%% کوالیتیدا</string>
-    <string name="squeezer_quality_warning_low">کوالیتی کەمتر لەوانەیە بکاتە هۆی ئارتیفاکتی دیاریکراو.</string>
-    <string name="squeezer_quality_warning_high">کوالیتی زۆر بەرز کەمترین خەزنکردنی شوێن دابین دەکات.</string>
     <string name="squeezer_types_category_label">ڕێکخستنەکانی وێنە</string>
     <string name="squeezer_video_settings_category_label">ڕێکخستنەکانی ڤیدیۆ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">پشتڕاستکردنەوەی پەکاندن</string>
     <string name="squeezer_preview_total_size">قەبارەی سەرجەم</string>
     <string name="squeezer_preview_estimated_savings">خەزنکردنی خەمڵاندراو</string>
-    <string name="squeezer_compress_confirmation_title">دانەبژێردراوەکان بچووک بکرێتەوە؟</string>
-    <string name="squeezer_compress_confirmation_message">ئەمە فایلە بنەڕەتیەکان بە گەڕانەوەیەکی بچووک کراو دەگۆڕێت. ئەم کاری پێچەوانەی نابێت.</string>
     <string name="squeezer_history_title">مێژووی پەکاندن</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d بابەت (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">هیچ مێژووی پەکاندنێک نییە</string>
     <string name="squeezer_history_clear_title">مێژووی پەکاندن پاک بکەرەوە</string>
     <string name="squeezer_history_clear_message">ئەمە ڕێ دەدات فایلەکانی کە پێشتر بچووک کراوەتەوە دووبارە بچووک بکرێتەوە. فایلەکان خۆیان کاریگەریان لێ نابێت.</string>
-    <string name="squeezer_onboarding_title">دەربارەی پەکاندنی وێنە</string>
-    <string name="squeezer_onboarding_message">پەکاندنی وێنە قەبارەی فایل کەم دەکاتەوە بە لابردنی وردەکاری بینراو. ئەم پرۆسەیە گەڕاندنەوەی نییە - کوالیتی ڕەسەن نابێتەوە.\n\nئەمێتە پێشبینییەک لەوەی وێنەکانت چۆن دەبێتەوە:</string>
     <string name="squeezer_onboarding_original_label">ڕەسەن</string>
     <string name="squeezer_onboarding_compressed_label">پاش پەکاندن</string>
     <string name="squeezer_onboarding_video_original_label">فریمی ڤیدیۆ</string>
     <string name="squeezer_onboarding_video_compressed_label">پێشبینی (بە نزیکەیی)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">کوالیتی ڤیدیۆی ڕاستەقینە لەوانەیە جیاواز بێت</string>
-    <string name="squeezer_onboarding_quality_label">کوالیتی: %d%%</string>
     <string name="squeezer_compare_action">بەراوردکردن ببینە</string>
     <string name="squeezer_no_example_found">هیچ وێنەیەک لە ڕێگاکانی دیاریکراودا نەدۆزرایەوە.</string>
     <string name="squeezer_result_empty_message">هیچ میدیایەکی بچووک کراوەپەذیر نەدۆزرایەوە.</string>
-    <string name="squeezer_setup_warning">بچووک کردنەوە بەردەوام کوالیتی کەم دەکاتەوە بۆ خەزن کردنی شوێنی ساردەرگە. ئەمە پێچەوانەی نابێت. ڕێکخستنەکانت بە باشی پێش دەستپێکردن بکولێنەوە.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d شوێن ناتوانرێت بۆ بچووک کردنەوە بەکار بهێنرێت و لابرا. بچووک کردنەوە پێویستی بە دەستڕاگەیشتنی ڕاستەوخۆ بە ساردەرگەی ناوەکی هەیە.</item>
         <item quantity="other">%d شوێن ناتوانرێت بۆ بچووک کردنەوە بەکار بهێنرێت و لابرا. بچووک کردنەوە پێویستی بە دەستڕاگەیشتنی ڕاستەوخۆ بە ساردەرگەی ناوەکی هەیە.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">لانی کەم %d ڕۆژ کۆنن</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">پێشبینی ~%d%% خودن بۆ فایلەکانی JPEG</string>
-    <string name="squeezer_onboarding_got_it">تێگەیشتم</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer وێنە و ڤیدیۆکانت دووبارە کۆمپرێس دەکات بۆ ئەوەی کەمتر جێگا بگرن. تۆ کەمێک کوالیتی بە جێگای جێگایەک دەدەیت کە لێی دەگەڕێتەوە. هەر دانەیەک پشکنینی خەلاتکردنی تەخمینکراو دەدات، بۆیە دەتوانیت بڕیار بدەیت کام بە کەڵک دێت.</string>
     <string name="tour_squeezer_compress_body">هەموو شتێک یەکجار لێرە کۆپێچ بکە، یان یەک خالە دەست لێ بکە بۆ بچووککردنی تەنیا ئەو یەکە. پاڵ درێژ دەست لێبکە بۆ هەڵبژاردنی چەند. هەمیشە پێش ئەوەی هیچ شتێک بگۆڕێت پێشبینیەک دەبینی.</string>

--- a/app-tool-squeezer/src/main/res/values-cs/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-cs/strings.xml
@@ -54,12 +54,7 @@
     <string name="squeezer_min_age_title">Minimální stáří souboru</string>
     <string name="squeezer_min_age_description">Zahrnout pouze soubory, které jsou starší.</string>
     <string name="squeezer_compression_settings_label">Obecné</string>
-    <string name="squeezer_quality_label">Kvalita</string>
-    <string name="squeezer_quality_title">Kvalita komprese</string>
     <string name="squeezer_quality_description">Nižší kvalita znamená menší velikost souboru, ale sníženou vizuální kvalitu.</string>
-    <string name="squeezer_quality_example_format">Příklad: obrázek %1$s → ušetří ~%2$s v kvalitě %3$d %%</string>
-    <string name="squeezer_quality_warning_low">Nižší kvalita může způsobit viditelné artefakty.</string>
-    <string name="squeezer_quality_warning_high">Velmi vysoká kvalita nabídne minimální úspory prostoru.</string>
     <string name="squeezer_types_category_label">Nastavení obrázků</string>
     <string name="squeezer_video_settings_category_label">Nastavení videa</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -84,8 +79,6 @@
     <string name="squeezer_preview_dialog_title">Potvrdit kompresi</string>
     <string name="squeezer_preview_total_size">Celková velikost</string>
     <string name="squeezer_preview_estimated_savings">Odhadované úspory</string>
-    <string name="squeezer_compress_confirmation_title">Komprimovat vybrané položky?</string>
-    <string name="squeezer_compress_confirmation_message">Tato akce nahradí původní soubory zkomprimovanými verzemi. Tuto akci nelze vrátit zpět.</string>
     <string name="squeezer_history_title">Historie komprese</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d položka (%2$s)</item>
@@ -96,18 +89,14 @@
     <string name="squeezer_history_empty">Žádná historie komprese</string>
     <string name="squeezer_history_clear_title">Vyčistit historii kompresí</string>
     <string name="squeezer_history_clear_message">Toto umožní znovu zkomprimovat dříve zkomprimované soubory. Samotné soubory nejsou ovlivněny.</string>
-    <string name="squeezer_onboarding_title">O kompresi obrázků</string>
-    <string name="squeezer_onboarding_message">Komprese obrázků snižuje velikost souboru odstraněním vizuálních detailů. Tento proces je nevratný - původní kvalita nemůže být obnovena.\n\nZde je náhled, jak budou vaše obrázky vypadat:</string>
     <string name="squeezer_onboarding_original_label">Originál</string>
     <string name="squeezer_onboarding_compressed_label">Po kompresi</string>
     <string name="squeezer_onboarding_video_original_label">Snímek videa</string>
     <string name="squeezer_onboarding_video_compressed_label">Náhled (přibližný)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Skutečná kvalita videa se může lišit</string>
-    <string name="squeezer_onboarding_quality_label">Kvalita: %d%%</string>
     <string name="squeezer_compare_action">Zobrazit porovnání</string>
     <string name="squeezer_no_example_found">Nenalezeny obrázky ve vybraných cestách.</string>
     <string name="squeezer_result_empty_message">Nebyla nalezena žádná komprimovatelná média.</string>
-    <string name="squeezer_setup_warning">Komprese trvale snižuje kvalitu souboru, aby se ušetřil prostor v úložišti. Tuto akci nelze vrátit zpět. Před spuštěním pečlivě zkontrolujte nastavení.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d umístění nelze použít pro kompresi a bylo odstraněno. Komprese vyžaduje přímý přístup k internímu úložišti.</item>
         <item quantity="few">%d umístění nelze použít pro kompresi a byla odstraněna. Komprese vyžaduje přímý přístup k internímu úložišti.</item>
@@ -131,7 +120,6 @@
         <item quantity="other">Alespoň %d dnů staré</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Odhadovaná úspora ~%d%% pro JPEG soubory</string>
-    <string name="squeezer_onboarding_got_it">Rozumím</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Zmáčknutí médií zkomprimuje vaše fotografie a videa, aby zabíraly méně místa. Vyměňujete trochu kvality za prostor, který získáte zpět. Každá položka ukazuje odhadovanou úsporu, takže se můžete rozhodnout, co stojí za to.</string>
     <string name="tour_squeezer_compress_body">Komprimujte zde vše najednou, nebo klepněte na jednu položku pro její zmenšení. Dlouhým stisknutím vyberte více. Vždy se vám zobrazí náhled, než se cokoliv změní.</string>

--- a/app-tool-squeezer/src/main/res/values-da/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-da/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Minimum fil alder</string>
     <string name="squeezer_min_age_description">Medtag kun filer, der er ældre end denne alder.</string>
     <string name="squeezer_compression_settings_label">Generelt</string>
-    <string name="squeezer_quality_label">Kvalitet</string>
-    <string name="squeezer_quality_title">Kompressions kvalitet</string>
     <string name="squeezer_quality_description">Lavere kvalitet betyder mindre filstørrelse, men reduceret visuel kvalitet.</string>
-    <string name="squeezer_quality_example_format">Eksempel: %1$s billede → sparer ~%2$s ved %3$d%% kvalitet</string>
-    <string name="squeezer_quality_warning_low">Lavere kvaliteter kan forårsage synlige artefakter.</string>
-    <string name="squeezer_quality_warning_high">Meget høj kvalitet giver minimal pladsbesparelser.</string>
     <string name="squeezer_types_category_label">Billedindstillinger</string>
     <string name="squeezer_video_settings_category_label">Videoindstillinger</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Bekræft komprimering</string>
     <string name="squeezer_preview_total_size">Total størrelse</string>
     <string name="squeezer_preview_estimated_savings">Estimeret besparelse</string>
-    <string name="squeezer_compress_confirmation_title">Komprimer valgte elementer?</string>
-    <string name="squeezer_compress_confirmation_message">Dette vil erstatte de originale filer med komprimerede versioner. Denne handling kan ikke fortrydes.</string>
     <string name="squeezer_history_title">Komprimeringshistorik</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Ingen komprimeringshistorik</string>
     <string name="squeezer_history_clear_title">Ryd komprimeringshistorik</string>
     <string name="squeezer_history_clear_message">Dette vil tillade tidligere komprimerede filer at blive komprimeret igen. Filerne selv påvirkes ikke.</string>
-    <string name="squeezer_onboarding_title">Om Billedkomprimering</string>
-    <string name="squeezer_onboarding_message">Billedkomprimering reducerer filstørrelsen ved at fjerne visuelle detaljer. Denne proces er irreversibel - den originale kvalitet kan ikke genskabes.\n\nHer er en forhåndsvisning af, hvordan dine billeder vil se ud:</string>
     <string name="squeezer_onboarding_original_label">Oprindelig</string>
     <string name="squeezer_onboarding_compressed_label">Efter komprimering</string>
     <string name="squeezer_onboarding_video_original_label">Videobillede</string>
     <string name="squeezer_onboarding_video_compressed_label">Forhåndsvisning (omtrentlig)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Den faktiske videokvalitet kan variere</string>
-    <string name="squeezer_onboarding_quality_label">Kvalitet: %d%%</string>
     <string name="squeezer_compare_action">Vis sammenligning</string>
     <string name="squeezer_no_example_found">Ingen billeder fundet i valgte stier.</string>
     <string name="squeezer_result_empty_message">Ingen komprimerbart medie fundet.</string>
-    <string name="squeezer_setup_warning">Komprimering reducerer kvaliteten permanent for at spare lagerplads. Dette kan ikke fortrydes. Gennemgå dine indstillinger omhyggeligt, før du starter.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d placering kan ikke bruges til komprimering og blev fjernet. Komprimering kræver direkte adgang til det interne lager.</item>
         <item quantity="other">%d placeringer kan ikke bruges til komprimering og blev fjernet. Komprimering kræver direkte adgang til det interne lager.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Mindst %d dage gammel</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Estimeret ~%d%% besparelser for JPEG-filer</string>
-    <string name="squeezer_onboarding_got_it">Forstået</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer komprimerer dine fotos og videoer igen, så de fylder mindre. Du bytter lidt kvalitet for den plads, du får tilbage. Hvert element viser sin estimerede besparelse, så du kan beslutte, hvad der er værd det.</string>
     <string name="tour_squeezer_compress_body">Komprimer alt på én gang her, eller tryk på et enkelt element for kun at formindske det. Langt tryk for at vælge flere. Du ser altid en forhåndsvisning, før der sker noget.</string>

--- a/app-tool-squeezer/src/main/res/values-de/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-de/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Mindestdateialter</string>
     <string name="squeezer_min_age_description">Nur Dateien einschließen, die älter als dieses Alter sind.</string>
     <string name="squeezer_compression_settings_label">Allgemein</string>
-    <string name="squeezer_quality_label">Qualität</string>
-    <string name="squeezer_quality_title">Komprimierungsqualität</string>
     <string name="squeezer_quality_description">Niedrigere Qualität bedeutet kleinere Dateigröße, aber reduzierte visuelle Qualität.</string>
-    <string name="squeezer_quality_example_format">Beispiel: %1$s Bild → spart ~%2$s bei %3$d%% Qualität</string>
-    <string name="squeezer_quality_warning_low">Niedrigere Qualitäten können sichtbare Artefakte verursachen.</string>
-    <string name="squeezer_quality_warning_high">Sehr hohe Qualität bietet minimale Platzersparnis.</string>
     <string name="squeezer_types_category_label">Bildeinstellungen</string>
     <string name="squeezer_video_settings_category_label">Videoeinstellungen</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Komprimierung bestätigen</string>
     <string name="squeezer_preview_total_size">Gesamtgröße</string>
     <string name="squeezer_preview_estimated_savings">Geschätzte Ersparnis</string>
-    <string name="squeezer_compress_confirmation_title">Ausgewählte Elemente komprimieren?</string>
-    <string name="squeezer_compress_confirmation_message">Dadurch werden Originaldateien durch komprimierte Versionen ersetzt. Diese Aktion kann nicht rückgängig gemacht werden.</string>
     <string name="squeezer_history_title">Komprimierungsverlauf</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d Element (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Kein Komprimierungsverlauf</string>
     <string name="squeezer_history_clear_title">Komprimierungsverlauf löschen</string>
     <string name="squeezer_history_clear_message">Dies ermöglicht es, bereits komprimierte Dateien erneut zu komprimieren. Die Dateien selbst sind davon nicht betroffen.</string>
-    <string name="squeezer_onboarding_title">Über Bildkomprimierung</string>
-    <string name="squeezer_onboarding_message">Die Bildkomprimierung reduziert die Dateigröße durch das Entfernen visueller Details. Dieser Vorgang ist irreversibel – die ursprüngliche Qualität kann nicht wiederhergestellt werden.\n\nHier ist eine Vorschau, wie deine Bilder aussehen werden:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Nach Komprimierung</string>
     <string name="squeezer_onboarding_video_original_label">Videoframe</string>
     <string name="squeezer_onboarding_video_compressed_label">Vorschau (ungefähr)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Tatsächliche Videoqualität kann abweichen</string>
-    <string name="squeezer_onboarding_quality_label">Qualität: %d%%</string>
     <string name="squeezer_compare_action">Vergleich anzeigen</string>
     <string name="squeezer_no_example_found">Keine Bilder in den ausgewählten Pfaden gefunden.</string>
     <string name="squeezer_result_empty_message">Keine komprimierbaren Medien gefunden.</string>
-    <string name="squeezer_setup_warning">Die Komprimierung reduziert die Qualität dauerhaft, um Speicherplatz zu sparen. Dies kann nicht rückgängig gemacht werden. Überprüfe deine Einstellungen sorgfältig, bevor du beginnst.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d Speicherort kann nicht für die Komprimierung verwendet werden und wurde entfernt. Die Komprimierung erfordert direkten Zugriff auf den internen Speicher.</item>
         <item quantity="other">%d Speicherorte können nicht für die Komprimierung verwendet werden und wurden entfernt. Die Komprimierung erfordert direkten Zugriff auf den internen Speicher.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Mindestens %d Tage alt</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Geschätzte ~%d%% Einsparungen für JPEG-Dateien</string>
-    <string name="squeezer_onboarding_got_it">Verstanden</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer komprimiert deine Fotos und Videos erneut, damit sie weniger Platz beanspruchen. Du tauschst ein wenig Qualität gegen den gewonnenen Speicherplatz ein. Jedes Element zeigt seine geschätzte Einsparung, sodass du entscheiden kannst, was es dir wert ist.</string>
     <string name="tour_squeezer_compress_body">Komprimiere hier alles auf einmal oder tippe auf ein einzelnes Element, um nur dieses zu verkleinern. Halte gedrückt, um mehrere auszuwählen. Du siehst immer eine Vorschau, bevor sich etwas ändert.</string>

--- a/app-tool-squeezer/src/main/res/values-el/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-el/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Ελάχιστη ηλικία αρχείου</string>
     <string name="squeezer_min_age_description">Συμπερίληψη μόνο αρχείων παλαιότερων από αυτή την ηλικία.</string>
     <string name="squeezer_compression_settings_label">Γενικά</string>
-    <string name="squeezer_quality_label">Ποιότητα</string>
-    <string name="squeezer_quality_title">Ποιότητα συμπίεσης</string>
     <string name="squeezer_quality_description">Χαμηλότερη ποιότητα σημαίνει μικρότερο μέγεθος αρχείου αλλά μειωμένη οπτική ποιότητα.</string>
-    <string name="squeezer_quality_example_format">Παράδειγμα: %1$s εικόνα → εξοικονομεί ~%2$s σε %3$d%% ποιότητα</string>
-    <string name="squeezer_quality_warning_low">Χαμηλότερες ποιότητες μπορεί να προκαλέσουν ορατά τεχνουργήματα.</string>
-    <string name="squeezer_quality_warning_high">Πολύ υψηλή ποιότητα παρέχει ελάχιστη εξοικονόμηση χώρου.</string>
     <string name="squeezer_types_category_label">Ρυθμίσεις εικόνας</string>
     <string name="squeezer_video_settings_category_label">Ρυθμίσεις βίντεο</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Επιβεβαίωση συμπίεσης</string>
     <string name="squeezer_preview_total_size">Συνολικό μέγεθος</string>
     <string name="squeezer_preview_estimated_savings">Εκτιμώμενη εξοικονόμηση</string>
-    <string name="squeezer_compress_confirmation_title">Συμπίεση επιλεγμένων στοιχείων;</string>
-    <string name="squeezer_compress_confirmation_message">Αυτό θα αντικαταστήσει τα αρχικά αρχεία με συμπιεσμένες εκδόσεις. Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.</string>
     <string name="squeezer_history_title">Ιστορικό συμπίεσης</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d στοιχείο (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Κανένα ιστορικό συμπίεσης</string>
     <string name="squeezer_history_clear_title">Εκκαθάριση ιστορικού συμπίεσης</string>
     <string name="squeezer_history_clear_message">Αυτό θα επιτρέψει σε αρχεία που έχουν ήδη συμπιεστεί να συμπιεστούν ξανά. Τα ίδια τα αρχεία δεν επηρεάζονται.</string>
-    <string name="squeezer_onboarding_title">Σχετικά με τη Συμπίεση Εικόνων</string>
-    <string name="squeezer_onboarding_message">Η συμπίεση εικόνων μειώνει το μέγεθος αρχείου αφαιρώντας οπτική λεπτομέρεια. Αυτή η διαδικασία είναι μη αναστρέψιμη - η αρχική ποιότητα δεν μπορεί να αποκατασταθεί.\n\nΑκολουθεί μια προεπισκόπηση του πώς θα μοιάζουν οι εικόνες σας:</string>
     <string name="squeezer_onboarding_original_label">Πρωτότυπο</string>
     <string name="squeezer_onboarding_compressed_label">Μετά τη συμπίεση</string>
     <string name="squeezer_onboarding_video_original_label">Καρέ βίντεο</string>
     <string name="squeezer_onboarding_video_compressed_label">Προεπισκόπηση (κατά προσέγγιση)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Η πραγματική ποιότητα βίντεο μπορεί να διαφέρει</string>
-    <string name="squeezer_onboarding_quality_label">Ποιότητα: %d%%</string>
     <string name="squeezer_compare_action">Προβολή σύγκρισης</string>
     <string name="squeezer_no_example_found">Δεν βρέθηκαν εικόνες στις επιλεγμένες διαδρομές.</string>
     <string name="squeezer_result_empty_message">Δεν βρέθηκαν συμπιέσιμα αρχεία πολυμέσων.</string>
-    <string name="squeezer_setup_warning">Η συμπίεση μειώνει μόνιμα την ποιότητα για εξοικονόμηση αποθηκευτικού χώρου. Αυτό δεν μπορεί να αναιρεθεί. Ελέγξτε προσεκτικά τις ρυθμίσεις σας πριν ξεκινήσετε.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d τοποθεσία δεν μπορεί να χρησιμοποιηθεί για συμπίεση και αφαιρέθηκε. Η συμπίεση απαιτεί απευθείας πρόσβαση στον εσωτερικό χώρο αποθήκευσης.</item>
         <item quantity="other">%d τοποθεσίες δεν μπορούν να χρησιμοποιηθούν για συμπίεση και αφαιρέθηκαν. Η συμπίεση απαιτεί απευθείας πρόσβαση στον εσωτερικό χώρο αποθήκευσης.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Τουλάχιστον %d ημέρες παλιό</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Εκτιμώμενη ~%d%% εξοικονόμηση για αρχεία JPEG</string>
-    <string name="squeezer_onboarding_got_it">Το κατάλαβα</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Το Squeezer συμπιέζει εκ νέου τις φωτογραφίες και τα βίντεό σας ώστε να καταλαμβάνουν λιγότερο χώρο. Ανταλλάσσετε λίγη ποιότητα με τον χώρο που ανακτάτε. Κάθε στοιχείο εμφανίζει την εκτιμώμενη εξοικονόμησή του, ώστε να μπορείτε να αποφασίσετε τι αξίζει.</string>
     <string name="tour_squeezer_compress_body">Συμπιέστε τα πάντα ταυτόχρονα εδώ ή πατήστε ένα μόνο στοιχείο για να συμπιέσετε μόνο αυτό. Πατήστε παρατεταμένα για να επιλέξετε πολλά. Θα δείτε πάντα μια προεπισκόπηση πριν αλλάξει κάτι.</string>

--- a/app-tool-squeezer/src/main/res/values-es-rAR/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-es-rAR/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Antigüedad mínima del archivo</string>
     <string name="squeezer_min_age_description">Solo incluir archivos más antiguos que esta edad.</string>
     <string name="squeezer_compression_settings_label">General</string>
-    <string name="squeezer_quality_label">Calidad</string>
-    <string name="squeezer_quality_title">Calidad de compresión</string>
     <string name="squeezer_quality_description">Una calidad más baja significa un tamaño de archivo menor pero una calidad visual reducida.</string>
-    <string name="squeezer_quality_example_format">Ejemplo: imagen %1$s → ahorra ~%2$s al %3$d%% de calidad</string>
-    <string name="squeezer_quality_warning_low">Las calidades más bajas pueden causar artefactos visibles.</string>
-    <string name="squeezer_quality_warning_high">La calidad muy alta proporciona un ahorro mínimo de espacio.</string>
     <string name="squeezer_types_category_label">Configuración de imágenes</string>
     <string name="squeezer_video_settings_category_label">Configuración de video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Confirmar compresión</string>
     <string name="squeezer_preview_total_size">Tamaño total</string>
     <string name="squeezer_preview_estimated_savings">Ahorro estimado</string>
-    <string name="squeezer_compress_confirmation_title">¿Comprimir los elementos seleccionados?</string>
-    <string name="squeezer_compress_confirmation_message">Esto reemplazará los archivos originales con versiones comprimidas. Esta acción no se puede deshacer.</string>
     <string name="squeezer_history_title">Historial de compresión</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%d imagen comprimida previamente</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Sin historial de compresión</string>
     <string name="squeezer_history_clear_title">Borrar historial de compresión</string>
     <string name="squeezer_history_clear_message">Esto permitirá que los archivos previamente comprimidos vuelvan a comprimirse. Los archivos en sí no se ven afectados.</string>
-    <string name="squeezer_onboarding_title">Acerca de la compresión de imágenes</string>
-    <string name="squeezer_onboarding_message">La compresión de imágenes reduce el tamaño del archivo eliminando detalles visuales. Este proceso es irreversible - la calidad original no se puede restaurar.\n\nAcá tenés una vista previa de cómo se verán tus imágenes:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Después de la compresión</string>
     <string name="squeezer_onboarding_video_original_label">Fotograma de video</string>
     <string name="squeezer_onboarding_video_compressed_label">Vista previa (aproximada)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">La calidad real del video puede variar</string>
-    <string name="squeezer_onboarding_quality_label">Calidad: %d%%</string>
     <string name="squeezer_compare_action">Ver comparación</string>
     <string name="squeezer_no_example_found">No se encontraron imágenes en las rutas seleccionadas.</string>
     <string name="squeezer_result_empty_message">No se encontraron medios comprimibles.</string>
-    <string name="squeezer_setup_warning">La compresión reduce permanentemente la calidad para ahorrar espacio de almacenamiento. Esto no se puede deshacer. Revise su configuración cuidadosamente antes de comenzar.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d ubicación no se puede usar para compresión y fue eliminada. La compresión requiere acceso directo al almacenamiento interno.</item>
         <item quantity="other">%d ubicaciones no se pueden usar para compresión y fueron eliminadas. La compresión requiere acceso directo al almacenamiento interno.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Al menos %d días de antigüedad</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Ahorros estimados ~%d%% para archivos JPEG</string>
-    <string name="squeezer_onboarding_got_it">Entendido</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer recomprime tus fotos y videos para que ocupen menos espacio. Sacrificás un poco de calidad a cambio del espacio que recuperás. Cada elemento muestra el ahorro estimado, así que podés decidir qué vale la pena.</string>
     <string name="tour_squeezer_compress_body">Comprimí todo aquí de una vez, o tocá un único elemento para reducir solo ese. Presioná prolongadamente para elegir varios. Siempre verás una vista previa antes de cualquier cambio.</string>

--- a/app-tool-squeezer/src/main/res/values-es-rMX/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-es-rMX/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Antigüedad mínima del archivo</string>
     <string name="squeezer_min_age_description">Incluir solo archivos con más antigüedad que esta.</string>
     <string name="squeezer_compression_settings_label">General</string>
-    <string name="squeezer_quality_label">Calidad</string>
-    <string name="squeezer_quality_title">Calidad de compresión</string>
     <string name="squeezer_quality_description">Una calidad más baja significa un tamaño de archivo menor, pero con menor calidad visual.</string>
-    <string name="squeezer_quality_example_format">Ejemplo: imagen %1$s → ahorra ~%2$s al %3$d%% de calidad</string>
-    <string name="squeezer_quality_warning_low">Calidades más bajas pueden causar artefactos visibles.</string>
-    <string name="squeezer_quality_warning_high">Calidad muy alta proporciona un ahorro de espacio mínimo.</string>
     <string name="squeezer_types_category_label">Configuración de imágenes</string>
     <string name="squeezer_video_settings_category_label">Configuración de video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Confirmar compresión</string>
     <string name="squeezer_preview_total_size">Tamaño total</string>
     <string name="squeezer_preview_estimated_savings">Ahorro estimado</string>
-    <string name="squeezer_compress_confirmation_title">¿Comprimir elementos seleccionados?</string>
-    <string name="squeezer_compress_confirmation_message">Esto reemplazará los archivos originales con versiones comprimidas. Esta acción no se puede deshacer.</string>
     <string name="squeezer_history_title">Historial de compresión</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elemento (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Sin historial de compresión</string>
     <string name="squeezer_history_clear_title">Borrar historial de compresión</string>
     <string name="squeezer_history_clear_message">Esto permitirá que los archivos comprimidos anteriormente puedan comprimirse nuevamente. Los archivos en sí no se ven afectados.</string>
-    <string name="squeezer_onboarding_title">Acerca de la Compresión de Imágenes</string>
-    <string name="squeezer_onboarding_message">La compresión de imágenes reduce el tamaño del archivo eliminando detalles visuales. Este proceso es irreversible - la calidad original no se puede restaurar.\n\nAquí tienes una vista previa de cómo se verán tus imágenes:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Después de la compresión</string>
     <string name="squeezer_onboarding_video_original_label">Fotograma de video</string>
     <string name="squeezer_onboarding_video_compressed_label">Vista previa (aproximada)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">La calidad real del video puede variar</string>
-    <string name="squeezer_onboarding_quality_label">Calidad: %d%%</string>
     <string name="squeezer_compare_action">Ver comparación</string>
     <string name="squeezer_no_example_found">No se encontraron imágenes en las rutas seleccionadas.</string>
     <string name="squeezer_result_empty_message">No se encontraron medios comprimibles.</string>
-    <string name="squeezer_setup_warning">La compresión reduce permanentemente la calidad para ahorrar espacio de almacenamiento. Esto no se puede deshacer. Revisa tu configuración cuidadosamente antes de comenzar.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d ubicación no se puede usar para la compresión y fue eliminada. La compresión requiere acceso directo al almacenamiento interno.</item>
         <item quantity="other">%d ubicaciones no se pueden usar para la compresión y fueron eliminadas. La compresión requiere acceso directo al almacenamiento interno.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Al menos %d días de antigüedad</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Ahorro estimado de ~%d%% para archivos JPEG</string>
-    <string name="squeezer_onboarding_got_it">Entendido</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer recomprime tus fotos y videos para que ocupen menos espacio. Cambias un poco de calidad por el espacio que recuperas. Cada elemento muestra el ahorro estimado, para que decidas qué vale la pena.</string>
     <string name="tour_squeezer_compress_body">Comprime todo de una vez aquí, o toca un elemento para reducir solo ese. Mantén presionado para elegir varios. Siempre verás una vista previa antes de que algo cambie.</string>

--- a/app-tool-squeezer/src/main/res/values-es/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-es/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Antigüedad mínima del archivo</string>
     <string name="squeezer_min_age_description">Incluir solo archivos más antiguos que esta edad.</string>
     <string name="squeezer_compression_settings_label">General</string>
-    <string name="squeezer_quality_label">Calidad</string>
-    <string name="squeezer_quality_title">Calidad de compresión</string>
     <string name="squeezer_quality_description">Una calidad menor significa un tamaño de archivo más pequeño pero una calidad visual reducida.</string>
-    <string name="squeezer_quality_example_format">Ejemplo: imagen %1$s → ahorra ~%2$s al %3$d%% de calidad</string>
-    <string name="squeezer_quality_warning_low">Calidades más bajas pueden causar artefactos visibles.</string>
-    <string name="squeezer_quality_warning_high">Calidad muy alta proporciona ahorros mínimos de espacio.</string>
     <string name="squeezer_types_category_label">Configuración de imágenes</string>
     <string name="squeezer_video_settings_category_label">Configuración de vídeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Confirmar compresión</string>
     <string name="squeezer_preview_total_size">Tamaño total</string>
     <string name="squeezer_preview_estimated_savings">Ahorro estimado</string>
-    <string name="squeezer_compress_confirmation_title">¿Comprimir los elementos seleccionados?</string>
-    <string name="squeezer_compress_confirmation_message">Esto reemplazará los archivos originales con versiones comprimidas. Esta acción no se puede deshacer.</string>
     <string name="squeezer_history_title">Historial de compresión</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elemento (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Sin historial de compresión</string>
     <string name="squeezer_history_clear_title">Borrar historial de compresión</string>
     <string name="squeezer_history_clear_message">Esto permitirá que los archivos previamente comprimidos se compriman de nuevo. Los archivos en sí no se ven afectados.</string>
-    <string name="squeezer_onboarding_title">Acerca de la compresión de imágenes</string>
-    <string name="squeezer_onboarding_message">La compresión de imágenes reduce el tamaño del archivo eliminando detalle visual. Este proceso es irreversible: la calidad original no puede restaurarse.\n\nAquí tienes una vista previa de cómo se verán tus imágenes:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Después de la compresión</string>
     <string name="squeezer_onboarding_video_original_label">Fotograma de vídeo</string>
     <string name="squeezer_onboarding_video_compressed_label">Vista previa (aproximada)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">La calidad real del vídeo puede variar</string>
-    <string name="squeezer_onboarding_quality_label">Calidad: %d%%</string>
     <string name="squeezer_compare_action">Ver comparación</string>
     <string name="squeezer_no_example_found">No se encontraron imágenes en las rutas seleccionadas.</string>
     <string name="squeezer_result_empty_message">No se encontraron archivos multimedia comprimibles.</string>
-    <string name="squeezer_setup_warning">La compresión reduce permanentemente la calidad para ahorrar espacio de almacenamiento. Esta acción no se puede deshacer. Revisa tu configuración detenidamente antes de comenzar.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d ubicación no se puede usar para la compresión y fue eliminada. La compresión requiere acceso directo al almacenamiento interno.</item>
         <item quantity="other">%d ubicaciones no se pueden usar para la compresión y fueron eliminadas. La compresión requiere acceso directo al almacenamiento interno.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Al menos %d días de antigüedad</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Ahorro estimado de ~%d%% en archivos JPEG</string>
-    <string name="squeezer_onboarding_got_it">Entiendo</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer recomprime tus fotos y vídeos para que ocupen menos espacio. Sacrificas un poco de calidad por el espacio que recuperas. Cada elemento muestra su ahorro estimado, así puedes decidir qué merece la pena.</string>
     <string name="tour_squeezer_compress_body">Comprime todo de una vez aquí, o toca un elemento para reducir solo ese. Mantén presionado para elegir varios. Siempre verás una vista previa antes de que nada cambie.</string>

--- a/app-tool-squeezer/src/main/res/values-et-rEE/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-et-rEE/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Faili noorim vanus</string>
     <string name="squeezer_min_age_description">Kaasa ainult sellest east vanemad failid.</string>
     <string name="squeezer_compression_settings_label">Üldine</string>
-    <string name="squeezer_quality_label">Kvaliteet</string>
-    <string name="squeezer_quality_title">Kokkupakkimise kvaliteet</string>
     <string name="squeezer_quality_description">Madal kvaliteet tähendab väiksemat faili mahtu, ent kehvemat visuaalset kvaliteeti.</string>
-    <string name="squeezer_quality_example_format">Näiteks: %1$s pilt → säästab ~%2$s %3$d%% kvaliteedi puhul</string>
-    <string name="squeezer_quality_warning_low">Kehvem kvaliteet võib põhjustada nähtavaid segajaid.</string>
-    <string name="squeezer_quality_warning_high">Väga kõrge kvaliteet ei paku eriti mälu säästmist.</string>
     <string name="squeezer_types_category_label">Pildi seaded</string>
     <string name="squeezer_video_settings_category_label">Video seaded</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Kinnita kokkupakkimine</string>
     <string name="squeezer_preview_total_size">Kogumaht</string>
     <string name="squeezer_preview_estimated_savings">Hinnanguline sääst</string>
-    <string name="squeezer_compress_confirmation_title">Pakkida valitud üksused kokku?</string>
-    <string name="squeezer_compress_confirmation_message">See asendab originaalfailid kokkupakitud versioonidega. Seda toimingut ei saa tagasi võtta.</string>
     <string name="squeezer_history_title">Kokkupakkimise ajalugu</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d kirje (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Kokkupakkimise ajalugu puudub</string>
     <string name="squeezer_history_clear_title">Tühjenda kokkupakkimise ajalugu</string>
     <string name="squeezer_history_clear_message">See võimaldab eelnevalt kokkupakitud faile uuesti kokku pakkida. Failid ise ei muutu.</string>
-    <string name="squeezer_onboarding_title">Piltide kokkupakkimisest</string>
-    <string name="squeezer_onboarding_message">Pildi kokkupakkimine vähendab faili mahtu, eemaldades nähtavad osad. Toiming on lõplik ehk algkvaliteeti pole võimalik taastada.\n\nPildid muutuvad sellisteks:</string>
     <string name="squeezer_onboarding_original_label">Algne</string>
     <string name="squeezer_onboarding_compressed_label">Pärast kokkupakkimist</string>
     <string name="squeezer_onboarding_video_original_label">Videokaader</string>
     <string name="squeezer_onboarding_video_compressed_label">Eelvaade (ligikaudne)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Tegelik videokvaliteet võib erineda</string>
-    <string name="squeezer_onboarding_quality_label">Kvaliteet: %d%%</string>
     <string name="squeezer_compare_action">Vaata võrdlust</string>
     <string name="squeezer_no_example_found">Valitud asukohtadest ei leitud ühtki pilti.</string>
     <string name="squeezer_result_empty_message">Kokkupakitavat meediat ei leitud.</string>
-    <string name="squeezer_setup_warning">Tihendamine vähendab kvaliteeti jäädavalt, et säästa salvestusruumi. Seda ei saa tagasi võtta. Vaata seaded enne alustamist hoolikalt üle.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d asukohta ei saa tihendamiseks kasutada ja eemaldati. Tihendamine nõuab otsest juurdepääsu sisemälule.</item>
         <item quantity="other">%d asukohta ei saa tihendamiseks kasutada ja eemaldati. Tihendamine nõuab otsest juurdepääsu sisemälule.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Vähemalt %d päeva vana</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Umbes %d%% sääst JPEG failide puhul</string>
-    <string name="squeezer_onboarding_got_it">Selge!</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Tihendaja tihendab pildid ja videod uuesti, et need võtaksid vähem ruumi. Vahetate veidi kvaliteeti ruumi vastu. Iga faili juures on näha selle hinnangulist kokkuhoidu, nii et saate otsustada, kas see on väärt tihendamist.</string>
     <string name="tour_squeezer_compress_body">Tihenda kõik korraga siin või puuduta üksikut elementi, et see kahaneks. Pikk vajutus mitme valimiseks. Enne muutusi näed alati eelvaadet.</string>

--- a/app-tool-squeezer/src/main/res/values-eu-rES/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-eu-rES/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Fitxategiaren gutxieneko adina</string>
     <string name="squeezer_min_age_description">Adina hau baino zaharragoak diren fitxategiak soilik sartu.</string>
     <string name="squeezer_compression_settings_label">Orokorra</string>
-    <string name="squeezer_quality_label">Kalitatea</string>
-    <string name="squeezer_quality_title">Konpresio-kalitatea</string>
     <string name="squeezer_quality_description">Kalitate txikiagoak fitxategi-tamaina txikiagoa esan nahi du, baina ikusmen-kalitatea murrizten du.</string>
-    <string name="squeezer_quality_example_format">Adibidea: %1$s irudia → ~%2$s aurrezten du %3$d%% kalitatean</string>
-    <string name="squeezer_quality_warning_low">Kalitate baxuagoek ikusgai dauden artifaktuak sor ditzakete.</string>
-    <string name="squeezer_quality_warning_high">Kalitate oso altuak leku-aurrezpen minimoa ematen du.</string>
     <string name="squeezer_types_category_label">Irudien ezarpenak</string>
     <string name="squeezer_video_settings_category_label">Bideoen ezarpenak</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Berretsi konpresioa</string>
     <string name="squeezer_preview_total_size">Tamaina osoa</string>
     <string name="squeezer_preview_estimated_savings">Aurreikusitako aurrezpena</string>
-    <string name="squeezer_compress_confirmation_title">Hautatutako elementuak konprimatu?</string>
-    <string name="squeezer_compress_confirmation_message">Honek jatorrizko fitxategiak bertsio konprimatuekin ordezkatuko ditu. Ekintza hau ezin da desegin.</string>
     <string name="squeezer_history_title">Konpresio-historia</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elementu (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Ez dago konpresio-historiarik</string>
     <string name="squeezer_history_clear_title">Garbitu konpresio-historia</string>
     <string name="squeezer_history_clear_message">Honek aurretik konprimatutako fitxategiak berriro konprimatzea ahalbidetuko du. Fitxategiek beraiek ez dute eraginik jasaten.</string>
-    <string name="squeezer_onboarding_title">Irudi-konpresioa buruz</string>
-    <string name="squeezer_onboarding_message">Irudi-konpresioak fitxategi-tamaina murrizten du xehetasun bisuala kenduz. Prozesu hau itzulezina da - jatorrizko kalitatea ezin da berreskuratu.\n\nHona hemen zure irudiak nola ikusiko diren aurrebista:</string>
     <string name="squeezer_onboarding_original_label">Jatorrizkoa</string>
     <string name="squeezer_onboarding_compressed_label">Konpresio ondoren</string>
     <string name="squeezer_onboarding_video_original_label">Bideo-fotograma</string>
     <string name="squeezer_onboarding_video_compressed_label">Aurrebista (gutxi gorabeherakoa)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Benetako bideo-kalitatea alda daiteke</string>
-    <string name="squeezer_onboarding_quality_label">Kalitatea: %d%%</string>
     <string name="squeezer_compare_action">Ikusi konparazioa</string>
     <string name="squeezer_no_example_found">Ez da irudirik aurkitu hautatutako bideetan.</string>
     <string name="squeezer_result_empty_message">Ez da konprimatu daitekeen multimedia aurkitu.</string>
-    <string name="squeezer_setup_warning">Konprimatzeak kalitatea betirako murrizten du biltegiratze-espazioa aurrezteko. Hau ezin da desegin. Berrikusi zure ezarpenak arretaz hasi aurretik.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d kokapen ezin da konprimatzeko erabili eta ezabatu da. Konprimatzeak barne-biltegiratze zuzeneko sarbidea behar du.</item>
         <item quantity="other">%d kokapen ezin dira konprimatzeko erabili eta ezabatu dira. Konprimatzeak barne-biltegiratze zuzeneko sarbidea behar du.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Gutxienez %d egun zaharrak</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Gutxi gorabehera ~%d%% aurrezkia JPEG fitxategientzat</string>
-    <string name="squeezer_onboarding_got_it">Ulertuta</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer zure argazkiak eta bideoak berriro konprimitzen ditu, gutxiago tokia hartzen dute. Kalitate txiki bat trukatzen duzu bueltatzen dizun espazioarekin. Elementu bakoitzak aurreztia erakusten du, harik eta zuk erabaki dezan zer balio duen.</string>
     <string name="tour_squeezer_compress_body">Konprimitu dena hemen aldi berean, edo kolpatu elementu bakarrean soilik bera txikitzeko. Luze sakatu batzuk aukeratzeko. Aurrebista ikusiko duzu beti, ezer aldatzen den aurretik.</string>

--- a/app-tool-squeezer/src/main/res/values-fa/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-fa/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">حداقل سن فایل</string>
     <string name="squeezer_min_age_description">فقط فایل‌هایی که قدیمی‌تر از این سن هستند را شامل شوید.</string>
     <string name="squeezer_compression_settings_label">عمومی</string>
-    <string name="squeezer_quality_label">کیفیت</string>
-    <string name="squeezer_quality_title">کیفیت فشرده‌سازی</string>
     <string name="squeezer_quality_description">کیفیت پایین‌تر به معنای حجم فایل کمتر اما کیفیت بصری کاهش‌یافته است.</string>
-    <string name="squeezer_quality_example_format">مثال: تصویر %1$s → صرفه‌جویی ~%2$s در کیفیت %3$d%%</string>
-    <string name="squeezer_quality_warning_low">کیفیت‌های پایین‌تر ممکن است آثار قابل مشاهده‌ای ایجاد کنند.</string>
-    <string name="squeezer_quality_warning_high">کیفیت بسیار بالا صرفه‌جویی حداقلی در فضا ارائه می‌دهد.</string>
     <string name="squeezer_types_category_label">تنظیمات تصویر</string>
     <string name="squeezer_video_settings_category_label">تنظیمات ویدیو</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">تأیید فشرده‌سازی</string>
     <string name="squeezer_preview_total_size">اندازه کل</string>
     <string name="squeezer_preview_estimated_savings">صرفه‌جویی تخمینی</string>
-    <string name="squeezer_compress_confirmation_title">موارد انتخاب‌شده فشرده شوند؟</string>
-    <string name="squeezer_compress_confirmation_message">این کار فایل‌های اصلی را با نسخه‌های فشرده‌شده جایگزین می‌کند. این عمل قابل بازگشت نیست.</string>
     <string name="squeezer_history_title">تاریخچه فشرده‌سازی</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d مورد (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">تاریخچه فشرده‌سازی خالی است</string>
     <string name="squeezer_history_clear_title">پاک کردن تاریخچه فشرده‌سازی</string>
     <string name="squeezer_history_clear_message">این کار اجازه می‌دهد فایل‌هایی که قبلاً فشرده شده‌اند دوباره فشرده شوند. خود فایل‌ها تحت تأثیر قرار نمی‌گیرند.</string>
-    <string name="squeezer_onboarding_title">درباره فشرده‌سازی تصاویر</string>
-    <string name="squeezer_onboarding_message">فشرده‌سازی تصاویر اندازه فایل را با حذف جزئیات بصری کاهش می‌دهد. این فرآیند غیرقابل بازگشت است - کیفیت اصلی قابل بازیابی نیست.\n\nدر اینجا پیش‌نمایشی از ظاهر تصاویر شما آمده است:</string>
     <string name="squeezer_onboarding_original_label">اصلی</string>
     <string name="squeezer_onboarding_compressed_label">پس از فشرده‌سازی</string>
     <string name="squeezer_onboarding_video_original_label">فریم ویدیو</string>
     <string name="squeezer_onboarding_video_compressed_label">پیش‌نمایش (تقریبی)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">کیفیت واقعی ویدیو ممکن است متفاوت باشد</string>
-    <string name="squeezer_onboarding_quality_label">کیفیت: %d%%</string>
     <string name="squeezer_compare_action">مشاهده مقایسه</string>
     <string name="squeezer_no_example_found">تصویری در مسیرهای انتخابی یافت نشد.</string>
     <string name="squeezer_result_empty_message">هیچ رسانه‌ای قابل فشرده‌سازی پیدا نشد.</string>
-    <string name="squeezer_setup_warning">فشرده‌سازی کیفیت را به‌طور دائمی کاهش می‌دهد تا فضای ذخیره‌سازی آزاد شود. این عمل قابل بازگشت نیست. قبل از شروع، تنظیمات خود را با دقت بررسی کنید.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d مکان قابل استفاده برای فشرده‌سازی نیست و حذف شد. فشرده‌سازی نیاز به دسترسی مستقیم به حافظه داخلی دارد.</item>
         <item quantity="other">%d مکان قابل استفاده برای فشرده‌سازی نیستند و حذف شدند. فشرده‌سازی نیاز به دسترسی مستقیم به حافظه داخلی دارد.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">حداقل %d روزه</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">پس‌انداز برآوردی ~%d%% برای فایل‌های JPEG</string>
-    <string name="squeezer_onboarding_got_it">فهمیدم</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer عکس‌ها و ویدیوهای شما را دوباره فشرده می‌کند تا فضای کمتری مصرف کنند. شما کمی از کیفیت را برای فضایی که بدست می‌آورید قربانی می‌کنید. هر مورد صرفه‌جویی تخمینی خود را نشان می‌دهد، بنابراین می‌توانید تصمیم بگیرید کدام‌یک ارزشش را دارد.</string>
     <string name="tour_squeezer_compress_body">همه‌چیز را یکجا اینجا فشرده کنید یا روی یک مورد ضربه بزنید تا فقط همان یکی کوچک شود. برای انتخاب چندین، فشار طولانی بدهید. همیشه قبل از هر تغییری یک پیش‌نمایش خواهید دید.</string>

--- a/app-tool-squeezer/src/main/res/values-fi/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-fi/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Tiedoston vähimmäisikä</string>
     <string name="squeezer_min_age_description">Sisällytä vain tätä ikää vanhemmat tiedostot.</string>
     <string name="squeezer_compression_settings_label">Yleiset</string>
-    <string name="squeezer_quality_label">Laatu</string>
-    <string name="squeezer_quality_title">Pakkauksen laatu</string>
     <string name="squeezer_quality_description">Alempi laatu tarkoittaa pienempiä tiedostokokoja, mutta heikentynytä kuvanlaatua.</string>
-    <string name="squeezer_quality_example_format">Esimerkki: %1$s kuva → säästä ~%2$s laadulla %3$d%%</string>
-    <string name="squeezer_quality_warning_low">Matalampi laatu voi aiheuttaa näkyviä artefakteja.</string>
-    <string name="squeezer_quality_warning_high">Erittäin korkea laatu tarjoaa minimaalisia tilansäästöjä.</string>
     <string name="squeezer_types_category_label">Kuva-asetukset</string>
     <string name="squeezer_video_settings_category_label">Videoasetukset</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Vahvista pakkaus</string>
     <string name="squeezer_preview_total_size">Kokonaiskoko</string>
     <string name="squeezer_preview_estimated_savings">Arvioitu säästö</string>
-    <string name="squeezer_compress_confirmation_title">Pakataan valitut kohteet?</string>
-    <string name="squeezer_compress_confirmation_message">Tämä korvaa alkuperäiset tiedostot pakatuilla versioilla. Tätä toimintoa ei voi kumota.</string>
     <string name="squeezer_history_title">Pakkaushistoria</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d kohde (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Ei pakkaushistoriaa</string>
     <string name="squeezer_history_clear_title">Tyhjennä pakkaushistoria</string>
     <string name="squeezer_history_clear_message">Tämä sallii aiemmin pakattujen tiedostojen pakkaamisen uudelleen. Tiedostoihin itseensä ei vaikuteta.</string>
-    <string name="squeezer_onboarding_title">Tietoa kuvien pakkaamisesta</string>
-    <string name="squeezer_onboarding_message">Kuvien pakkaaminen pienentää tiedostokokoa poistamalla visuaalisia yksityiskohtia. Prosessi on peruuttamaton - alkuperäistä laatua ei voi palauttaa.\n\nTässä esikatselu miltä kuvasi näyttävät:</string>
     <string name="squeezer_onboarding_original_label">Alkuperäinen</string>
     <string name="squeezer_onboarding_compressed_label">Pakkauksen jälkeen</string>
     <string name="squeezer_onboarding_video_original_label">Videokuva</string>
     <string name="squeezer_onboarding_video_compressed_label">Esikatselu (likimääräinen)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Todellinen videokuvanlaatu voi poiketa</string>
-    <string name="squeezer_onboarding_quality_label">Laatu: %d%%</string>
     <string name="squeezer_compare_action">Näytä vertailu</string>
     <string name="squeezer_no_example_found">Kuvia ei löytynyt valituista poluista.</string>
     <string name="squeezer_result_empty_message">Pakattavaa mediaa ei löydetty.</string>
-    <string name="squeezer_setup_warning">Pakkaus heikentää pysyvästi laatua tallennustilan säästämiseksi. Tätä ei voi kumota. Tarkista asetukset huolellisesti ennen aloittamista.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d sijaintia ei voi käyttää pakkaamiseen ja se poistettiin. Pakkaaminen vaatii suoran pääsyn sisäiseen tallennustilaan.</item>
         <item quantity="other">%d sijaintia ei voi käyttää pakkaamiseen ja ne poistettiin. Pakkaaminen vaatii suoran pääsyn sisäiseen tallennustilaan.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Vähintään %d päivää vanha</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Arvioidut ~%d%% säästöt JPEG-tiedostoissa</string>
-    <string name="squeezer_onboarding_got_it">Selvä</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer pakkaa kuvia ja videoita uudelleen, jotta ne vievät vähemmän tilaa. Vaihdat hieman laatua säästyvään tilaan. Jokainen kohde näyttää arvioidun säästön, joten voit päättää, mikä kannattaa.</string>
     <string name="tour_squeezer_compress_body">Pakkaa kaikki kerralla tässä tai napauta yksittäistä kohdetta pakataksesi vain sitä. Pidä pitkään painettuna valitaksesi useita. Näet aina esikatselun ennen kuin mitään muuttuu.</string>

--- a/app-tool-squeezer/src/main/res/values-fil/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-fil/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Pinakamababang edad ng file</string>
     <string name="squeezer_min_age_description">Isama lamang ang mga file na mas matanda kaysa sa edad na ito.</string>
     <string name="squeezer_compression_settings_label">Pangkalahatan</string>
-    <string name="squeezer_quality_label">Kalidad</string>
-    <string name="squeezer_quality_title">Kalidad ng compression</string>
     <string name="squeezer_quality_description">Ang mas mababang kalidad ay nangangahulugang mas maliit na laki ng file ngunit nabawasan ang visual na kalidad.</string>
-    <string name="squeezer_quality_example_format">Halimbawa: %1$s na larawan → ~%2$s na matitipid sa %3$d%% na kalidad</string>
-    <string name="squeezer_quality_warning_low">Ang mas mababang kalidad ay maaaring magdulot ng nakikitang artifact.</string>
-    <string name="squeezer_quality_warning_high">Ang napakataas na kalidad ay nagbibigay ng kaunting matitipid na espasyo.</string>
     <string name="squeezer_types_category_label">Mga setting ng larawan</string>
     <string name="squeezer_video_settings_category_label">Mga setting ng video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Kumpirmahin ang compression</string>
     <string name="squeezer_preview_total_size">Kabuuang sukat</string>
     <string name="squeezer_preview_estimated_savings">Tinatayang matitipid</string>
-    <string name="squeezer_compress_confirmation_title">I-compress ang mga napiling item?</string>
-    <string name="squeezer_compress_confirmation_message">Papalitan nito ang mga orihinal na file ng mga compressed na bersyon. Hindi maaaring i-undo ang aksyong ito.</string>
     <string name="squeezer_history_title">History ng compression</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d item (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Walang history ng compression</string>
     <string name="squeezer_history_clear_title">I-clear ang history ng compression</string>
     <string name="squeezer_history_clear_message">Papayagan nito na ma-compress muli ang mga dating na-compress na file. Ang mga file mismo ay hindi apektado.</string>
-    <string name="squeezer_onboarding_title">Tungkol sa Image Compression</string>
-    <string name="squeezer_onboarding_message">Binabawasan ng image compression ang sukat ng file sa pamamagitan ng pag-alis ng visual detail. Ang prosesong ito ay hindi na maaaring ibalik - hindi na maibabalik ang orihinal na kalidad.\n\nNarito ang preview kung paano magiging hitsura ng iyong mga larawan:</string>
     <string name="squeezer_onboarding_original_label">Orihinal</string>
     <string name="squeezer_onboarding_compressed_label">Pagkatapos ng compression</string>
     <string name="squeezer_onboarding_video_original_label">Frame ng video</string>
     <string name="squeezer_onboarding_video_compressed_label">Preview (tinatayang)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Maaaring mag-iba ang aktwal na kalidad ng video</string>
-    <string name="squeezer_onboarding_quality_label">Kalidad: %d%%</string>
     <string name="squeezer_compare_action">Tingnan ang paghahambing</string>
     <string name="squeezer_no_example_found">Walang nahanap na larawan sa mga napiling path.</string>
     <string name="squeezer_result_empty_message">Walang nahanap na compressible na media.</string>
-    <string name="squeezer_setup_warning">Ang compression ay permanenteng nagbabawas ng kalidad upang makatipid ng espasyo sa storage. Hindi ito maaaring i-undo. Suriin nang maingat ang iyong mga setting bago magsimula.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d lokasyon ay hindi magagamit para sa compression at inalis. Ang compression ay nangangailangan ng direktang access sa panloob na storage.</item>
         <item quantity="other">%d mga lokasyon ay hindi magagamit para sa compression at inalis. Ang compression ay nangangailangan ng direktang access sa panloob na storage.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Hindi bababa sa %d araw na edad</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Inaasahang ~%d%% na matitipid para sa JPEG files</string>
-    <string name="squeezer_onboarding_got_it">Kuha ko</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Ang Squeezer ay muling nag-compress ng iyong mga larawan at video upang mabawasan ang espasyo na ginagamit. Ikaw ay nagsasakripisyo ng kaunting kalidad upang makakuha ng mas maraming espasyo. Bawat item ay nagpapakita ng inaasahang pagtitipid, kaya maaari mong magpasya kung alin ang sulit.</string>
     <string name="tour_squeezer_compress_body">I-compress ang lahat nang sabay-sabay dito, o i-tap ang isang item upang bawasan lamang ang iyon. Mahabang-press upang pumili ng marami. Lagi mong makikita ang preview bago magbago ang kahit ano.</string>

--- a/app-tool-squeezer/src/main/res/values-fr/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-fr/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Âge minimal des fichiers</string>
     <string name="squeezer_min_age_description">N\'inclure que les fichiers plus anciens que cet âge.</string>
     <string name="squeezer_compression_settings_label">Général</string>
-    <string name="squeezer_quality_label">Qualité</string>
-    <string name="squeezer_quality_title">Qualité de la compression</string>
     <string name="squeezer_quality_description">Une qualité inférieure implique une taille de fichier plus petite, mais une qualité visuelle moindre.</string>
-    <string name="squeezer_quality_example_format">Exemple : %1$s image → économise ~%2$s avec une qualité de %3$d %%</string>
-    <string name="squeezer_quality_warning_low">Les qualités inférieures peuvent entraîner des distortions visuelles.</string>
-    <string name="squeezer_quality_warning_high">Une qualité très élevée réduit peu la taille du fichier.</string>
     <string name="squeezer_types_category_label">Paramètres d\'image</string>
     <string name="squeezer_video_settings_category_label">Paramètres vidéo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Confirmer la compression</string>
     <string name="squeezer_preview_total_size">Taille totale</string>
     <string name="squeezer_preview_estimated_savings">Économies probables</string>
-    <string name="squeezer_compress_confirmation_title">Compresser les éléments choisis ?</string>
-    <string name="squeezer_compress_confirmation_message">Les fichiers originaux seront remplacés par les versions compressées. Cette action est irréversible.</string>
     <string name="squeezer_history_title">Historique de compression</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d élément (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Aucun historique de compression</string>
     <string name="squeezer_history_clear_title">Effacer l’historique de compression</string>
     <string name="squeezer_history_clear_message">Les fichiers déjà compressés pourront être compressés de nouveau. Les fichiers eux-mêmes ne sont pas affectés.</string>
-    <string name="squeezer_onboarding_title">À propos de la compression des images</string>
-    <string name="squeezer_onboarding_message">La compression des images réduit la taille des fichiers en supprimant certains détails visuels. Ce processus est irréversible ; la qualité originale ne peut pas être restaurée.\n\nVoici un aperçu du rendu final de vos images :</string>
     <string name="squeezer_onboarding_original_label">Originale</string>
     <string name="squeezer_onboarding_compressed_label">Après compression</string>
     <string name="squeezer_onboarding_video_original_label">Image de la vidéo</string>
     <string name="squeezer_onboarding_video_compressed_label">Aperçu (approximatif)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">La qualité réelle de la vidéo peut différer</string>
-    <string name="squeezer_onboarding_quality_label">Qualité : %d %%</string>
     <string name="squeezer_compare_action">Afficher la comparaison</string>
     <string name="squeezer_no_example_found">Aucune image n’a été trouvée dans les chemins définis.</string>
     <string name="squeezer_result_empty_message">Aucun média compressible n’a été trouvé.</string>
-    <string name="squeezer_setup_warning">La compression réduit irrémédiablement la qualité pour économiser l’espace de stockage. Cette opération est irréversible. Confirmez vos paramètres avant de commencer.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d emplacement ne peut pas être utilisé pour la compression et a été supprimé. La compression nécessite un accès direct à la mémoire interne.</item>
         <item quantity="other">%d emplacements ne peuvent pas être utilisés pour la compression et ont été supprimés. La compression nécessite un accès direct à la mémoire interne.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Au moins %d jours</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Économie probable de %d %% pour les fichiers JPEG</string>
-    <string name="squeezer_onboarding_got_it">J’ai compris</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer re-compresse vos photos et vidéos pour qu’elles prennent moins de place. Vous échangez un peu de qualité contre l’espace que vous gagnez. Chaque élément affiche ses économies estimées, vous pouvez donc décider ce qui en vaut la peine.</string>
     <string name="tour_squeezer_compress_body">Compressez tout d’un coup ici, ou appuyez sur un élément unique pour ne réduire que celui-ci. Appui long pour en sélectionner plusieurs. Vous verrez toujours un aperçu avant que quelque chose change.</string>

--- a/app-tool-squeezer/src/main/res/values-gl-rES/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-gl-rES/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Antigüidade mínima do ficheiro</string>
     <string name="squeezer_min_age_description">Incluír só ficheiros máis antigos que esta antigüidade.</string>
     <string name="squeezer_compression_settings_label">Xeral</string>
-    <string name="squeezer_quality_label">Calidade</string>
-    <string name="squeezer_quality_title">Calidade de compresión</string>
     <string name="squeezer_quality_description">Unha calidade inferior significa un tamaño de ficheiro menor pero unha calidade visual reducida.</string>
-    <string name="squeezer_quality_example_format">Exemplo: imaxe de %1$s → aforra ~%2$s ao %3$d%% de calidade</string>
-    <string name="squeezer_quality_warning_low">Calidades máis baixas poden causar artefactos visibles.</string>
-    <string name="squeezer_quality_warning_high">Calidade moi alta proporciona un aforro mínimo de espazo.</string>
     <string name="squeezer_types_category_label">Configuración de imaxes</string>
     <string name="squeezer_video_settings_category_label">Configuración de vídeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Confirmar compresión</string>
     <string name="squeezer_preview_total_size">Tamaño total</string>
     <string name="squeezer_preview_estimated_savings">Aforro estimado</string>
-    <string name="squeezer_compress_confirmation_title">Comprimir os elementos seleccionados?</string>
-    <string name="squeezer_compress_confirmation_message">Isto substituírá os ficheiros orixinais por versións comprimidas. Esta acción non se pode desfacer.</string>
     <string name="squeezer_history_title">Historial de compresión</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elemento (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Sen historial de compresión</string>
     <string name="squeezer_history_clear_title">Borrar historial de compresión</string>
     <string name="squeezer_history_clear_message">Isto permitirá que os ficheiros comprimidos anteriormente poñan comprimirse de novo. Os propios ficheiros non se ven afectados.</string>
-    <string name="squeezer_onboarding_title">Sobre a compresión de imaxes</string>
-    <string name="squeezer_onboarding_message">A compresión de imaxes reduce o tamaño do ficheiro eliminando detalle visual. Este proceso é irreversible - a calidade orixinal non se pode restaurar.\n\nAquí tes unha vista previa de como se verán as túas imaxes:</string>
     <string name="squeezer_onboarding_original_label">Orixinal</string>
     <string name="squeezer_onboarding_compressed_label">Despois da compresión</string>
     <string name="squeezer_onboarding_video_original_label">Fotograma de vídeo</string>
     <string name="squeezer_onboarding_video_compressed_label">Vista previa (aproximada)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">A calidade real do vídeo pode variar</string>
-    <string name="squeezer_onboarding_quality_label">Calidade: %d%%</string>
     <string name="squeezer_compare_action">Ver comparación</string>
     <string name="squeezer_no_example_found">Non se atoparon imaxes nas rutas seleccionadas.</string>
     <string name="squeezer_result_empty_message">Non se atoparon medios comprimibles.</string>
-    <string name="squeezer_setup_warning">A compresión reduce permanentemente a calidade para aforrar espazo de almacenamento. Isto non se pode desfacer. Revisa a túa configuración coidadosamente antes de comezar.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d localización non se pode usar para a compresión e foi eliminada. A compresión require acceso directo ao almacenamento interno.</item>
         <item quantity="other">%d localizacións non se poden usar para a compresión e foron eliminadas. A compresión require acceso directo ao almacenamento interno.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Polo menos %d días de antigüidade</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Estimado ~%d%% de aforro para ficheiros JPEG</string>
-    <string name="squeezer_onboarding_got_it">Entendido</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer recomprime as túas fotos e vídeos para que ocupen menos espazo. Cambia un pouco de calidade polo espazo que recuperas. Cada elemento mostra o aforro estimado, para que poidas decidir o que merece a pena.</string>
     <string name="tour_squeezer_compress_body">Comprime todo dunha vez aquí, ou toca un único elemento para reducir só ese. Antén premido para escoller varios. Sempre verás unha vista previa antes de que algo cambie.</string>

--- a/app-tool-squeezer/src/main/res/values-hi-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-hi-rIN/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">न्यूनतम फ़ाइल आयु</string>
     <string name="squeezer_min_age_description">केवल इस आयु से पुरानी फ़ाइलें शामिल करें।</string>
     <string name="squeezer_compression_settings_label">सामान्य</string>
-    <string name="squeezer_quality_label">गुणवत्ता</string>
-    <string name="squeezer_quality_title">संपीड़न गुणवत्ता</string>
     <string name="squeezer_quality_description">कम गुणवत्ता का अर्थ है छोटा फ़ाइल आकार लेकिन दृश्य गुणवत्ता कम होगी।</string>
-    <string name="squeezer_quality_example_format">उदाहरण: %1$s छवि → %3$d%% गुणवत्ता पर ~%2$s बचाता है</string>
-    <string name="squeezer_quality_warning_low">कम गुणवत्ता में दृश्य आर्टिफ़ैक्ट हो सकते हैं।</string>
-    <string name="squeezer_quality_warning_high">बहुत उच्च गुणवत्ता से स्थान की बचत न्यूनतम होती है।</string>
     <string name="squeezer_types_category_label">छवि सेटिंग</string>
     <string name="squeezer_video_settings_category_label">वीडियो सेटिंग</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">संपीड़न की पुष्टि करें</string>
     <string name="squeezer_preview_total_size">कुल आकार</string>
     <string name="squeezer_preview_estimated_savings">अनुमानित बचत</string>
-    <string name="squeezer_compress_confirmation_title">चयनित आइटम संपीड़ित करें?</string>
-    <string name="squeezer_compress_confirmation_message">यह मूल फ़ाइलों को संपीड़ित संस्करणों से बदल देगा। यह क्रिया पूर्ववत नहीं की जा सकती।</string>
     <string name="squeezer_history_title">संपीड़न इतिहास</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d आइटम (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">कोई संपीड़न इतिहास नहीं</string>
     <string name="squeezer_history_clear_title">संपीड़न इतिहास साफ़ करें</string>
     <string name="squeezer_history_clear_message">यह पहले से संपीड़ित फ़ाइलों को दोबारा संपीड़ित करने की अनुमति देगा। फ़ाइलें स्वयं प्रभावित नहीं होती हैं।</string>
-    <string name="squeezer_onboarding_title">छवि संपीड़न के बारे में</string>
-    <string name="squeezer_onboarding_message">छवि संपीड़न दृश्य विवरण हटाकर फ़ाइल आकार कम करता है। यह प्रक्रिया अपरिवर्तनीय है - मूल गुणवत्ता पुनर्स्थापित नहीं की जा सकती।\n\nयहां आपकी छवियों का पूर्वावलोकन है:</string>
     <string name="squeezer_onboarding_original_label">मूल</string>
     <string name="squeezer_onboarding_compressed_label">संपीड़न के बाद</string>
     <string name="squeezer_onboarding_video_original_label">वीडियो फ्रेम</string>
     <string name="squeezer_onboarding_video_compressed_label">पूर्वावलोकन (अनुमानित)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">वास्तविक वीडियो गुणवत्ता भिन्न हो सकती है</string>
-    <string name="squeezer_onboarding_quality_label">गुणवत्ता: %d%%</string>
     <string name="squeezer_compare_action">तुलना देखें</string>
     <string name="squeezer_no_example_found">चयनित पथों में कोई छवि नहीं मिली।</string>
     <string name="squeezer_result_empty_message">कोई संपीड़न योग्य मीडिया नहीं मिला।</string>
-    <string name="squeezer_setup_warning">संपीड़न स्थायी रूप से स्टोरेज स्पेस बचाने के लिए गुणवत्ता कम करता है। यह पूर्ववत नहीं किया जा सकता। शुरू करने से पहले अपनी सेटिंग ध्यानपूर्वक देखें।</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d स्थान संपीड़न के लिए उपयोग नहीं किया जा सकता और हटा दिया गया। संपीड़न के लिए आंतरिक संग्रहण तक सीधी पहुँच आवश्यक है।</item>
         <item quantity="other">%d स्थान संपीड़न के लिए उपयोग नहीं किए जा सकते और हटा दिए गए। संपीड़न के लिए आंतरिक संग्रहण तक सीधी पहुँच आवश्यक है।</item>
@@ -109,7 +98,6 @@
         <item quantity="other">कम से कम %d दिन पुरानी</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG फ़ाइलों के लिए अनुमानित ~%d%% बचत</string>
-    <string name="squeezer_onboarding_got_it">समझ गया</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer आपकी तस्वीरों और वीडियो को फिर से कंप्रेस करता है ताकि वे कम जगह लें। आप गुणवत्ता में थोड़ी कमी के बदले मिली जगह पाते हैं। हर आइटम अनुमानित बचत दिखाता है, इसलिए आप तय कर सकते हैं कि यह लायक है या नहीं।</string>
     <string name="tour_squeezer_compress_body">यहाँ सब कुछ एक साथ संपीड़ित करें, या केवल किसी एक को छोटा करने के लिए उस पर टैप करें। कई को चुनने के लिए लंबे समय तक दबाएँ। कुछ भी बदलने से पहले आप हमेशा एक पूर्वावलोकन देखेंगे।</string>

--- a/app-tool-squeezer/src/main/res/values-hr/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-hr/strings.xml
@@ -46,12 +46,7 @@
     <string name="squeezer_min_age_title">Minimalna starost datoteke</string>
     <string name="squeezer_min_age_description">Uključi samo datoteke starije od ove dobi.</string>
     <string name="squeezer_compression_settings_label">Općenito</string>
-    <string name="squeezer_quality_label">Kvaliteta</string>
-    <string name="squeezer_quality_title">Kvaliteta kompresije</string>
     <string name="squeezer_quality_description">Niža kvaliteta znači manju veličinu datoteke, ali smanjenu vizualnu kvalitetu.</string>
-    <string name="squeezer_quality_example_format">Primjer: %1$s slika → ušteda ~%2$s pri %3$d%% kvalitete</string>
-    <string name="squeezer_quality_warning_low">Niže kvalitete mogu uzrokovati vidljive artefakte.</string>
-    <string name="squeezer_quality_warning_high">Vrlo visoka kvaliteta pruža minimalnu uštedu prostora.</string>
     <string name="squeezer_types_category_label">Postavke slika</string>
     <string name="squeezer_video_settings_category_label">Postavke videozapisa</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -76,8 +71,6 @@
     <string name="squeezer_preview_dialog_title">Potvrdi kompresiju</string>
     <string name="squeezer_preview_total_size">Ukupna veličina</string>
     <string name="squeezer_preview_estimated_savings">Procijenjena ušteda</string>
-    <string name="squeezer_compress_confirmation_title">Komprimirati odabrane stavke?</string>
-    <string name="squeezer_compress_confirmation_message">Ovo će zamijeniti originalne datoteke komprimiranim verzijama. Ova radnja se ne može poništiti.</string>
     <string name="squeezer_history_title">Povijest kompresije</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d stavka (%2$s)</item>
@@ -87,18 +80,14 @@
     <string name="squeezer_history_empty">Nema povijesti kompresije</string>
     <string name="squeezer_history_clear_title">Obriši povijest kompresije</string>
     <string name="squeezer_history_clear_message">Ovo će omogućiti ponovnu kompresiju prethodno komprimiranih datoteka. Same datoteke neće biti pogođene.</string>
-    <string name="squeezer_onboarding_title">O kompresiji slika</string>
-    <string name="squeezer_onboarding_message">Kompresija slika smanjuje veličinu datoteke uklanjanjem vizualnih detalja. Ovaj proces je nepovratan - originalna kvaliteta se ne može vratiti.\n\nEvo pregleda kako će vaše slike izgledati:</string>
     <string name="squeezer_onboarding_original_label">Originalno</string>
     <string name="squeezer_onboarding_compressed_label">Nakon kompresije</string>
     <string name="squeezer_onboarding_video_original_label">Videosličica</string>
     <string name="squeezer_onboarding_video_compressed_label">Pregled (približan)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Stvarna kvaliteta videozapisa može se razlikovati</string>
-    <string name="squeezer_onboarding_quality_label">Kvaliteta: %d%%</string>
     <string name="squeezer_compare_action">Pogledaj usporedbu</string>
     <string name="squeezer_no_example_found">Nema slika u odabranim putanjama.</string>
     <string name="squeezer_result_empty_message">Nije pronađen medij koji se može komprimirati.</string>
-    <string name="squeezer_setup_warning">Kompresija trajno smanjuje kvalitetu kako bi uštedjela prostor za pohranu. Ovo se ne može poništiti. Pažljivo pregledajte postavke prije pokretanja.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d lokacija ne može se koristiti za kompresiju i uklonjena je. Kompresija zahtijeva izravan pristup internoj pohrani.</item>
         <item quantity="few">%d lokacije ne mogu se koristiti za kompresiju i uklonjene su. Kompresija zahtijeva izravan pristup internoj pohrani.</item>
@@ -120,7 +109,6 @@
         <item quantity="other">Najmanje %d dana stara</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Procijenjeno ~%d%% uštede za JPEG datoteke</string>
-    <string name="squeezer_onboarding_got_it">U redu</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer ponovno sažima vaše fotografije i videozapise kako bi zauzimali manje prostora. Žrtvujete malo kvalitete za prostor koji dobivate natrag. Svaka stavka prikazuje procijenjenu uštedu, tako da možete odlučiti isplati li se.</string>
     <string name="tour_squeezer_compress_body">Komprimiraj sve odjednom ovdje ili dodirni jednu stavku da smanjiš samo tu. Dugim pritiskom odaberi više stavki. Uvijek ćeš vidjeti pretpregled prije nego što se bilo što promijeni.</string>

--- a/app-tool-squeezer/src/main/res/values-hu/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-hu/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Minimális fájlkor</string>
     <string name="squeezer_min_age_description">Csak az ennél régebbi fájlok szerepeljenek.</string>
     <string name="squeezer_compression_settings_label">Általános</string>
-    <string name="squeezer_quality_label">Minőség</string>
-    <string name="squeezer_quality_title">Tömörítési minőség</string>
     <string name="squeezer_quality_description">Az alacsonyabb minőség kisebb fájlméretet jelent, de csökkentett vizuális minőséggel.</string>
-    <string name="squeezer_quality_example_format">Példa: %1$s kép → ~%2$s megtakarítás %3$d%% minőségnél</string>
-    <string name="squeezer_quality_warning_low">Alacsonyabb minőségnél látható műtermékek jelenhetnek meg.</string>
-    <string name="squeezer_quality_warning_high">Nagyon magas minőség minimális helytakarékosságot biztosít.</string>
     <string name="squeezer_types_category_label">Képbeállítások</string>
     <string name="squeezer_video_settings_category_label">Videóbeállítások</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Tömörítés megerősítése</string>
     <string name="squeezer_preview_total_size">Teljes méret</string>
     <string name="squeezer_preview_estimated_savings">Becsült megtakarítás</string>
-    <string name="squeezer_compress_confirmation_title">Tömöríti a kiválasztott elemeket?</string>
-    <string name="squeezer_compress_confirmation_message">Ez lecseréli az eredeti fájlokat tömörített verziókra. Ez a művelet nem vonható vissza.</string>
     <string name="squeezer_history_title">Tömörítési előzmények</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elem (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Nincs tömörítési előzmény</string>
     <string name="squeezer_history_clear_title">Tömörítési előzmények törlése</string>
     <string name="squeezer_history_clear_message">Ez lehetővé teszi, hogy a korábban tömörített fájlokat újra tömörítessük. Magukat a fájlokat ez nem érinti.</string>
-    <string name="squeezer_onboarding_title">A képtömörítésről</string>
-    <string name="squeezer_onboarding_message">A képtömörítés csökkenti a fájlméretet a vizuális részletek eltávolításával. Ez a folyamat visszafordíthatatlan - az eredeti minőség nem állítható vissza.\n\nÍgy fognak kinézni a képeid:</string>
     <string name="squeezer_onboarding_original_label">Eredeti</string>
     <string name="squeezer_onboarding_compressed_label">Tömörítés után</string>
     <string name="squeezer_onboarding_video_original_label">Videókeret</string>
     <string name="squeezer_onboarding_video_compressed_label">Előnézet (hozzávetőleges)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">A tényleges videóminőség eltérhet</string>
-    <string name="squeezer_onboarding_quality_label">Minőség: %d%%</string>
     <string name="squeezer_compare_action">Összehasonlítás megtekintése</string>
     <string name="squeezer_no_example_found">Nem található kép a kiválasztott útvonalakon.</string>
     <string name="squeezer_result_empty_message">Nem található tömöríthető média.</string>
-    <string name="squeezer_setup_warning">A tömörítés véglegesen csökkenti a minőséget a tárhely felszabadítása érdekében. Ez nem vonható vissza. Gondosan ellenőrizd a beállításokat indítás előtt.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d helyszín nem használható tömörítésre és eltávolítottuk. A tömörítéshez közvetlen hozzáférés szükséges a belső tárhelyre.</item>
         <item quantity="other">%d helyszín nem használható tömörítésre és eltávolítottuk. A tömörítéshez közvetlen hozzáférés szükséges a belső tárhelyre.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Legalább %d napos</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Becsült ~%d%% megtakarítás a JPEG fájlokhoz</string>
-    <string name="squeezer_onboarding_got_it">Megvan</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">A Squeezer újratömöríti a fényképeidet és videóidat, hogy kevesebb helyet foglaljanak. Egy kis minőséget adsz fel a visszanyert helyért cserébe. Minden elem megmutatja a becsült megtakarítást, hogy eldönthesd, mi éri meg.</string>
     <string name="tour_squeezer_compress_body">Tömörítse az összes fájlt egyszerre, vagy érintsen meg egy elemet, hogy csak azt tömörítse. Nyomja hosszan meg több elemet választásához. Ön mindig lát egy előnézetet, mielőtt bármi megváltozna.</string>

--- a/app-tool-squeezer/src/main/res/values-in/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-in/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">Umur file minimum</string>
     <string name="squeezer_min_age_description">Hanya sertakan file yang lebih lama dari usia ini.</string>
     <string name="squeezer_compression_settings_label">Umum</string>
-    <string name="squeezer_quality_label">Kualitas</string>
-    <string name="squeezer_quality_title">Kualitas kompresi</string>
     <string name="squeezer_quality_description">Kualitas lebih rendah berarti ukuran file lebih kecil tetapi kualitas visual berkurang.</string>
-    <string name="squeezer_quality_example_format">Contoh: gambar %1$s → menghemat ~%2$s pada kualitas %3$d%%</string>
-    <string name="squeezer_quality_warning_low">Kualitas yang lebih rendah dapat menyebabkan artefak yang terlihat.</string>
-    <string name="squeezer_quality_warning_high">Kualitas yang sangat tinggi memberikan penghematan ruang yang minimal.</string>
     <string name="squeezer_types_category_label">Pengaturan gambar</string>
     <string name="squeezer_video_settings_category_label">Pengaturan video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">Konfirmasi kompresi</string>
     <string name="squeezer_preview_total_size">Ukuran total</string>
     <string name="squeezer_preview_estimated_savings">Perkiraan penghematan</string>
-    <string name="squeezer_compress_confirmation_title">Kompres item yang dipilih?</string>
-    <string name="squeezer_compress_confirmation_message">Ini akan menggantikan file asli dengan versi yang dikompresi. Tindakan ini tidak dapat dibatalkan.</string>
     <string name="squeezer_history_title">Riwayat kompresi</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d item (%2$s)</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">Tidak ada riwayat kompresi</string>
     <string name="squeezer_history_clear_title">Hapus riwayat kompresi</string>
     <string name="squeezer_history_clear_message">Ini akan memungkinkan file yang sebelumnya dikompresi untuk dikompresi kembali. File itu sendiri tidak terpengaruh.</string>
-    <string name="squeezer_onboarding_title">Tentang Kompresi Gambar</string>
-    <string name="squeezer_onboarding_message">Kompresi gambar mengurangi ukuran file dengan menghapus detail visual. Proses ini tidak dapat dibalik - kualitas asli tidak dapat dipulihkan.\n\nBerikut pratinjau tampilan gambar Anda:</string>
     <string name="squeezer_onboarding_original_label">Asli</string>
     <string name="squeezer_onboarding_compressed_label">Setelah kompresi</string>
     <string name="squeezer_onboarding_video_original_label">Bingkai video</string>
     <string name="squeezer_onboarding_video_compressed_label">Pratinjau (perkiraan)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Kualitas video aktual mungkin berbeda</string>
-    <string name="squeezer_onboarding_quality_label">Kualitas: %d%%</string>
     <string name="squeezer_compare_action">Lihat perbandingan</string>
     <string name="squeezer_no_example_found">Tidak ada gambar ditemukan di jalur yang dipilih.</string>
     <string name="squeezer_result_empty_message">Tidak ada media yang dapat dikompresi ditemukan.</string>
-    <string name="squeezer_setup_warning">Kompresi secara permanen mengurangi kualitas untuk menghemat ruang penyimpanan. Ini tidak dapat dibatalkan. Tinjau pengaturan Anda dengan cermat sebelum memulai.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">%d lokasi tidak dapat digunakan untuk kompresi dan telah dihapus. Kompresi memerlukan akses langsung ke penyimpanan internal.</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">Minimal %d hari</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Perkiraan hemat ~%d%% untuk file JPEG</string>
-    <string name="squeezer_onboarding_got_it">Mengerti</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer mengompresi ulang foto dan video Anda sehingga memakan lebih sedikit ruang. Anda mengorbankan sedikit kualitas demi ruang yang didapat kembali. Setiap item menampilkan perkiraan penghematannya, sehingga Anda dapat memutuskan mana yang sepadan.</string>
     <string name="tour_squeezer_compress_body">Kompres semuanya sekaligus di sini, atau ketuk satu item untuk mengecilkan hanya yang itu. Tekan lama untuk memilih beberapa. Anda akan selalu melihat pratinjau sebelum apa pun berubah.</string>

--- a/app-tool-squeezer/src/main/res/values-is/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-is/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Lágmarksaldur skráar</string>
     <string name="squeezer_min_age_description">Taka aðeins með skrár sem eru eldri en þssi aldur.</string>
     <string name="squeezer_compression_settings_label">Almennt</string>
-    <string name="squeezer_quality_label">Gæði</string>
-    <string name="squeezer_quality_title">Þjöppunargæði</string>
     <string name="squeezer_quality_description">Lægri gæði þyðir minni skráarstæð en lakari sjónræn gæði.</string>
-    <string name="squeezer_quality_example_format">Dæmi: %1$s mynd → sparar ~%2$s við %3$d%% gæði</string>
-    <string name="squeezer_quality_warning_low">Lægri gæði gætu valdið sjáanlegum göllum.</string>
-    <string name="squeezer_quality_warning_high">Mjög há gæði veita lágmarks plásssparnað.</string>
     <string name="squeezer_types_category_label">Myndastillingar</string>
     <string name="squeezer_video_settings_category_label">Myndbandasstillingar</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Staðfesta þjöppun</string>
     <string name="squeezer_preview_total_size">Heildarstærð</string>
     <string name="squeezer_preview_estimated_savings">Áætlaður sparnaður</string>
-    <string name="squeezer_compress_confirmation_title">Þjappa völdum atriðum?</string>
-    <string name="squeezer_compress_confirmation_message">Þtta mun skipta upprunalegum skrám út fyrir þjappaðar útgáfur. Ekki er hægt að afturkalla þessa aðgerð.</string>
     <string name="squeezer_history_title">Þjöppunarsaga</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d hlutur (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Engin þjöppunarsaga</string>
     <string name="squeezer_history_clear_title">Hreinsa þjöppunarsögu</string>
     <string name="squeezer_history_clear_message">Þtta mun leyfa skrám sem þgar hafa verið þjappaðar að verða þjappaðar aftur. Skrárnar sjálfar verða ekki fyrir áhrifum.</string>
-    <string name="squeezer_onboarding_title">Um myndaþjöppun</string>
-    <string name="squeezer_onboarding_message">Myndaþjöppun minnkar skráarstærð með því að fjarlægja sjónræn smáatriði. Þetta ferli er óafturkræft - upprunaleg gæði er ekki hægt að endurheimta.\n\nHér er forskoðun á hvernig myndirnar þínar munu líta út:</string>
     <string name="squeezer_onboarding_original_label">Upprunalegt</string>
     <string name="squeezer_onboarding_compressed_label">Eftir þjöppun</string>
     <string name="squeezer_onboarding_video_original_label">Myndbandsrðammi</string>
     <string name="squeezer_onboarding_video_compressed_label">Forskoðun (áætluð)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Raunveruleg myndbandsgaæði geta verið frábruggin</string>
-    <string name="squeezer_onboarding_quality_label">Gæði: %d%%</string>
     <string name="squeezer_compare_action">Skoða samanburð</string>
     <string name="squeezer_no_example_found">Engar myndir fundust á völdum slóðum.</string>
     <string name="squeezer_result_empty_message">Ekkert þjáppanlegt efni fannst.</string>
-    <string name="squeezer_setup_warning">Þjöppun minnkar gæði varanlega til að spara geymslupláss. Ekki er hægt að afturkalla þtta. Farðu vandlega yfir stillingar þinar áður en þú byrjar.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d staðsetning er ekki hægt að nota til þjöppunar og var fjarlægð. Þjöppun krefst beinnar aðgangis að innri geymslu.</item>
         <item quantity="other">%d staðsetningar eru ekki hægt að nota til þjöppunar og voru fjarlægðar. Þjöppun krefst beinnar aðgangis að innri geymslu.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">A.m.k. %d daga gamalt</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Um ~%d%% sparnaður fyrir JPEG skrár</string>
-    <string name="squeezer_onboarding_got_it">Ég skil</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer endurþjappar myndir og myndbönd þín svo þau taki minna pláss. Þú gefur eftir gæðum til að fá pláss til baka. Hver atriði sýnir áætlaðan sparnað, svo þú getur ákveðið hvað borgar sig.</string>
     <string name="tour_squeezer_compress_body">Þjappaðu allt í einu hér, eða þttu á einn hlut til að minnka bara hann. Haltu lengi niðri til að velja marga. Þú munt alltaf sjá forskoðun áður en eitthvað breytist.</string>

--- a/app-tool-squeezer/src/main/res/values-it/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-it/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Età minima del file</string>
     <string name="squeezer_min_age_description">Includi solo i file più vecchi di questa età.</string>
     <string name="squeezer_compression_settings_label">Generale</string>
-    <string name="squeezer_quality_label">Qualità</string>
-    <string name="squeezer_quality_title">Qualità di compressione</string>
     <string name="squeezer_quality_description">Una qualità inferiore significa file di dimensioni minori ma qualità visiva ridotta.</string>
-    <string name="squeezer_quality_example_format">Esempio: immagine %1$s → risparmio ~%2$s al %3$d%% di qualità</string>
-    <string name="squeezer_quality_warning_low">Qualità inferiori possono causare artefatti visibili.</string>
-    <string name="squeezer_quality_warning_high">Una qualità molto alta fornisce risparmi minimi di spazio.</string>
     <string name="squeezer_types_category_label">Impostazioni immagini</string>
     <string name="squeezer_video_settings_category_label">Impostazioni video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Conferma compressione</string>
     <string name="squeezer_preview_total_size">Dimensione totale</string>
     <string name="squeezer_preview_estimated_savings">Risparmio stimato</string>
-    <string name="squeezer_compress_confirmation_title">Comprimi gli elementi selezionati?</string>
-    <string name="squeezer_compress_confirmation_message">Questo sostituirà i file originali con versioni compresse. Questa azione non può essere annullata.</string>
     <string name="squeezer_history_title">Cronologia compressione</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elemento (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Nessuna cronologia di compressione</string>
     <string name="squeezer_history_clear_title">Cancella cronologia compressione</string>
     <string name="squeezer_history_clear_message">Questo permetterà ai file precedentemente compressi di essere compressi di nuovo. I file stessi non vengono modificati.</string>
-    <string name="squeezer_onboarding_title">Informazioni sulla compressione immagini</string>
-    <string name="squeezer_onboarding_message">La compressione riduce la dimensione dei file rimuovendo dettagli visivi. Questo processo è irreversibile - la qualità originale non può essere ripristinata.\n\nEcco un\'anteprima di come appariranno le tue immagini:</string>
     <string name="squeezer_onboarding_original_label">Originale</string>
     <string name="squeezer_onboarding_compressed_label">Dopo la compressione</string>
     <string name="squeezer_onboarding_video_original_label">Fotogramma video</string>
     <string name="squeezer_onboarding_video_compressed_label">Anteprima (approssimativa)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">La qualità video effettiva potrebbe variare</string>
-    <string name="squeezer_onboarding_quality_label">Qualità: %d%%</string>
     <string name="squeezer_compare_action">Visualizza confronto</string>
     <string name="squeezer_no_example_found">Nessuna immagine trovata nei percorsi selezionati.</string>
     <string name="squeezer_result_empty_message">Nessun file multimediale comprimibile trovato.</string>
-    <string name="squeezer_setup_warning">La compressione riduce permanentemente la qualità per risparmiare spazio di archiviazione. Questa operazione non può essere annullata. Rivedi attentamente le impostazioni prima di iniziare.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d posizione non può essere utilizzata per la compressione ed è stata rimossa. La compressione richiede accesso diretto all\'archivio interno.</item>
         <item quantity="other">%d posizioni non possono essere utilizzate per la compressione e sono state rimosse. La compressione richiede accesso diretto all\'archivio interno.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Almeno %d giorni</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Risparmio stimato ~%d%% per file JPEG</string>
-    <string name="squeezer_onboarding_got_it">Fatto</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer ricomprime le tue foto e i tuoi video in modo che occupino meno spazio. Sacrifichi un po’ di qualità in cambio dello spazio recuperato. Ogni elemento mostra il risparmio stimato, così puoi decidere cosa vale la pena.</string>
     <string name="tour_squeezer_compress_body">Comprimi tutto in una volta qui, o tocca un singolo elemento per ridurre solo quello. Pressione lunga per selezionare più elementi. Vedrai sempre un’anteprima prima che qualcosa cambi.</string>

--- a/app-tool-squeezer/src/main/res/values-iw/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-iw/strings.xml
@@ -54,12 +54,7 @@
     <string name="squeezer_min_age_title">גיל קובץ מינימלי</string>
     <string name="squeezer_min_age_description">כלול רק קבצים ישנים יותר מגיל זה.</string>
     <string name="squeezer_compression_settings_label">כללי</string>
-    <string name="squeezer_quality_label">איכות</string>
-    <string name="squeezer_quality_title">איכות דחיסה</string>
     <string name="squeezer_quality_description">איכות נמוכה יותר פירושה גודל קובץ קטן יותר אך איכות ויזואלית מופחתת.</string>
-    <string name="squeezer_quality_example_format">דוגמה: תמונת %1$s → חוסך ~%2$s באיכות %3$d%%</string>
-    <string name="squeezer_quality_warning_low">איכות נמוכה עלולה לגרום לעיוותים נראים.</string>
-    <string name="squeezer_quality_warning_high">איכות גבוהה מאוד מספקת חיסכון מינימלי במקום.</string>
     <string name="squeezer_types_category_label">הגדרות תמונה</string>
     <string name="squeezer_video_settings_category_label">הגדרות וידאו</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -84,8 +79,6 @@
     <string name="squeezer_preview_dialog_title">אשר דחיסה</string>
     <string name="squeezer_preview_total_size">גודל כולל</string>
     <string name="squeezer_preview_estimated_savings">חיסכון משוער</string>
-    <string name="squeezer_compress_confirmation_title">לדחוס את הפריטים הנבחרים?</string>
-    <string name="squeezer_compress_confirmation_message">פעולה זו תחליף את הקבצים המקוריים בגרסאות דחוסות. לא ניתן לבטל פעולה זו.</string>
     <string name="squeezer_history_title">היסטוריית דחיסה</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">פריט %1$d (%2$s)</item>
@@ -96,18 +89,14 @@
     <string name="squeezer_history_empty">אין היסטוריית דחיסה</string>
     <string name="squeezer_history_clear_title">נקה היסטוריית דחיסה</string>
     <string name="squeezer_history_clear_message">פעולה זו תאפשר לדחוס מחדש קבצים שדוחסו בעבר. הקבצים עצמם אינם מושפעים.</string>
-    <string name="squeezer_onboarding_title">אודות דחיסת תמונות</string>
-    <string name="squeezer_onboarding_message">דחיסת תמונות מקטינה את גודל הקובץ על ידי הסרת פרטים חזותיים. תהליך זה בלתי הפיך - לא ניתן לשחזר את האיכות המקורית.\n\nהנה תצוגה מקדימה של איך התמונות שלך ייראו:</string>
     <string name="squeezer_onboarding_original_label">מקור</string>
     <string name="squeezer_onboarding_compressed_label">לאחר דחיסה</string>
     <string name="squeezer_onboarding_video_original_label">פריים וידאו</string>
     <string name="squeezer_onboarding_video_compressed_label">תצוגה מקדימית (משוערת)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">איכות הווידאו בפועל עשויה להיות שונה</string>
-    <string name="squeezer_onboarding_quality_label">איכות: %d%%</string>
     <string name="squeezer_compare_action">הצג השוואה</string>
     <string name="squeezer_no_example_found">לא נמצאו תמונות בנתיבים הנבחרים.</string>
     <string name="squeezer_result_empty_message">לא נמצאו מדיה ניתנים לדחיסה.</string>
-    <string name="squeezer_setup_warning">הדחיסה מפחיתה את האיכות לצמיתות כדי לחסוך שטח אחסון. לא ניתן לבטל פעולה זו. בדוק את ההגדרות בקפידה לפני ההתחלה.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">לא ניתן להשתמש ב-%d מיקום לדחיסה והוא הוסר. דחיסה דורשת גישה ישירה לאחסון פנימי.</item>
         <item quantity="two">לא ניתן להשתמש ב-%d מיקומים לדחיסה והם הוסרו. דחיסה דורשת גישה ישירה לאחסון פנימי.</item>
@@ -131,7 +120,6 @@
         <item quantity="other">לפחות %d ימים</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">חסכון משוער של ~%d%% לקבצי JPEG</string>
-    <string name="squeezer_onboarding_got_it">הבנתי</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer דוחס מחדש את התמונות וסרטוני הווידאו שלך כדי שיתפסו פחות מקום. אתה מוותר על קצת איכות בתמורה למקום שאתה מחזיר. כל פריט מציג את החיסכון המשוער שלו, כך שתוכל להחליט מה שווה זאת.</string>
     <string name="tour_squeezer_compress_body">דחוס הכל בבת אחת כאן, או הקש על פריט יחיד כדי להקטין רק אותו. הקש הקשה ארוכה כדי לבחור כמה פריטים. תמיד תראה תצוגה מקדימה לפני כל שינוי.</string>

--- a/app-tool-squeezer/src/main/res/values-ja/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ja/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">最小ファイル年齢</string>
     <string name="squeezer_min_age_description">この経過時間より古いファイルのみ対象にします。</string>
     <string name="squeezer_compression_settings_label">一般</string>
-    <string name="squeezer_quality_label">品質</string>
-    <string name="squeezer_quality_title">圧縮品質</string>
     <string name="squeezer_quality_description">品質を下げるとファイルサイズは小さくなりますが、画質が低下します。</string>
-    <string name="squeezer_quality_example_format">例：%1$s 画像 → %3$d%% 品質で約 %2$s 節約</string>
-    <string name="squeezer_quality_warning_low">品質が低いと目に見えるアーティファクトが発生する場合があります。</string>
-    <string name="squeezer_quality_warning_high">非常に高い品質では容量の節約がごくわずかです。</string>
     <string name="squeezer_types_category_label">画像設定</string>
     <string name="squeezer_video_settings_category_label">動画設定</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">圧縮の確認</string>
     <string name="squeezer_preview_total_size">合計サイズ</string>
     <string name="squeezer_preview_estimated_savings">推定節約量</string>
-    <string name="squeezer_compress_confirmation_title">選択したアイテムを圧縮しますか？</string>
-    <string name="squeezer_compress_confirmation_message">元のファイルを圧縮バージョンに置き換えます。この操作は元に戻せません。</string>
     <string name="squeezer_history_title">圧縮履歴</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d 項目（%2$s）</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">圧縮履歴がありません</string>
     <string name="squeezer_history_clear_title">圧縮履歴をクリア</string>
     <string name="squeezer_history_clear_message">以前に圧縮されたファイルを再度圧縮できるようになります。ファイル自体には影響しません。</string>
-    <string name="squeezer_onboarding_title">画像圧縮について</string>
-    <string name="squeezer_onboarding_message">画像圧縮は視覚的な詳細を削除してファイルサイズを縮小します。このプロセスは元に戻せません。元の品質は復元できません。\n\n圧縮後の画像のプレビューはこちらです：</string>
     <string name="squeezer_onboarding_original_label">オリジナル</string>
     <string name="squeezer_onboarding_compressed_label">圧縮後</string>
     <string name="squeezer_onboarding_video_original_label">動画フレーム</string>
     <string name="squeezer_onboarding_video_compressed_label">プレビュー（目安）</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">実際の動画品質は異なる場合があります</string>
-    <string name="squeezer_onboarding_quality_label">品質：%d%%</string>
     <string name="squeezer_compare_action">比較を表示</string>
     <string name="squeezer_no_example_found">選択したパスに画像が見つかりません。</string>
     <string name="squeezer_result_empty_message">圧縮可能なメディアが見つかりません。</string>
-    <string name="squeezer_setup_warning">圧縮すると品質が恒久的に低下してストレージ容量を節約します。この操作は元に戻せません。開始前に設定を慎重に確認してください。</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">%d件の場所は圧縮に使用できないため削除されました。圧縮には内部ストレージへの直接アクセスが必要です。</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">少なくとも %d 日以上</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEGファイルの推定 ~%d%% の節約</string>
-    <string name="squeezer_onboarding_got_it">わかりました。</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezerは写真や動画を再圧縮して、必要なスペースを小さくします。若干の画質と引き換えに、スペースを取り戻せます。各アイテムには推定の節約量が表示されるので、何が値するかを判断できます。</string>
     <string name="tour_squeezer_compress_body">ここですべてを一度に圧縮するか、1つの項目をタップしてそれだけを縮小できます。長押しで複数を選択できます。変更前には常にプレビューが表示されます。</string>

--- a/app-tool-squeezer/src/main/res/values-ka-rGE/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ka-rGE/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">ფაილის მინიმალური ასაკი</string>
     <string name="squeezer_min_age_description">შეიტანე მხოლოდ ამ ასაკზე ძველი ფაილები.</string>
     <string name="squeezer_compression_settings_label">ზოგადი</string>
-    <string name="squeezer_quality_label">ხარისხი</string>
-    <string name="squeezer_quality_title">შეკუმშვის ხარისხი</string>
     <string name="squeezer_quality_description">დაბალი ხარისხი ნიშნავს პატარა ფაილის ზომას, მაგრამ მცირდება ვიზუალური ხარისხი.</string>
-    <string name="squeezer_quality_example_format">მაგალითი: %1$s სურათი → %3$d%% ხარისხით ~%2$s დაზოგვა</string>
-    <string name="squeezer_quality_warning_low">დაბალმა ხარისხმა შეიძლება ხილული არტეფაქტები გამოიწვიოს.</string>
-    <string name="squeezer_quality_warning_high">ძალიან მაღალი ხარისხი მინიმალურ დაზოგვას უზრუნველყოფს.</string>
     <string name="squeezer_types_category_label">სურათის პარამეტრები</string>
     <string name="squeezer_video_settings_category_label">ვიდეოს პარამეტრები</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">შეკუმშვის დადასტურება</string>
     <string name="squeezer_preview_total_size">საერთო ზომა</string>
     <string name="squeezer_preview_estimated_savings">სავარაუდო დაზოგვა</string>
-    <string name="squeezer_compress_confirmation_title">შეკუმშოთ არჩეული ელემენტები?</string>
-    <string name="squeezer_compress_confirmation_message">ეს შეცვლის ორიგინალ ფაილებს შეკუმშული ვერსიებით. ეს მოქმედება ვერ გაუქმდება.</string>
     <string name="squeezer_history_title">შეკუმშვის ისტორია</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ელემენტი (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">შეკუმშვის ისტორია არ არის</string>
     <string name="squeezer_history_clear_title">შეკუმშვის ისტორიის გასუფთავება</string>
     <string name="squeezer_history_clear_message">ეს საშუალებას მისცემს ადრე შეკუმშულ ფაილებს კვლავ შეიკუმშოს. თავად ფაილები არ შეიცვლება.</string>
-    <string name="squeezer_onboarding_title">სურათის შეკუმშვის შესახებ</string>
-    <string name="squeezer_onboarding_message">სურათის შეკუმშვა ამცირებს ფაილის ზომას ვიზუალური დეტალების წაშლით. ეს პროცესი შეუქცევადია - ორიგინალი ხარისხის აღდგენა შეუძლებელია.\n\nაი, როგორ გამოიყურება თქვენი სურათები:</string>
     <string name="squeezer_onboarding_original_label">ორიგინალი</string>
     <string name="squeezer_onboarding_compressed_label">შეკუმშვის შემდეგ</string>
     <string name="squeezer_onboarding_video_original_label">ვიდეო კადრი</string>
     <string name="squeezer_onboarding_video_compressed_label">გადახედვა (სავარაუდო)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">ვიდეოს რეალური ხარისხი შეიძლება განსხვავდებოდეს</string>
-    <string name="squeezer_onboarding_quality_label">ხარისხი: %d%%</string>
     <string name="squeezer_compare_action">შედარების ნახვა</string>
     <string name="squeezer_no_example_found">არჩეულ გზებში სურათები ვერ მოიძებნა.</string>
     <string name="squeezer_result_empty_message">შეკუმშვადი მედია ვერ მოიძებნა.</string>
-    <string name="squeezer_setup_warning">შეკუმშვა მუდმივად ამცირებს ხარისხს საცავის სივრცის დაზოგვის მიზნით. ეს ვერ გაუქმდება. ყურადღებით გადახედე პარამეტრებს დაწყებამდე.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d ლოკაცია ვერ გამოიყენება შეკუმშვისთვის და ამოღებულიყო. შეკუმშვა მოითხოვს პირდაპირ წვდომას შიდა საცავზე.</item>
         <item quantity="other">%d ლოკაცია ვერ გამოიყენება შეკუმშვისთვის და ამოღებულიყო. შეკუმშვა მოითხოვს პირდაპირ წვდომას შიდა საცავზე.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">სულ მცირე %d დღის</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">სავარაუდო ~%d%% დაზოგვა JPEG ფაილებისთვის</string>
-    <string name="squeezer_onboarding_got_it">Გავიგე</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer თავიდან იკუმშავს თქვენს ფოტოებს და ვიდეოებს, რათა ისინი ნაკლებ ადგილს დაკავოს. თქვენ ხარისხის ნაწილს სანაცვლად დაბრუნებული ადგილის მოსაპოვებლად. თითოეული ელემენტი აჭვენებს მის სავარაუდო დაზოგვას, ასე რომ თქვენ შეგიძლიათ გადაწყვიტოთ რა არის ღირებული.</string>
     <string name="tour_squeezer_compress_body">შეკუმშეთ ყველაფერი ერთდროულად აქ, ან დააჭირეთ ერთ ელემენტს მხოლოდ მისი შესამცირებლად. გრძელი დაჭერა რამდენიმეს შესარჩევად. ყოველთვის დაინახავთ წინასწარ ხედს ნებისმიერი ცვლილებამდე.</string>

--- a/app-tool-squeezer/src/main/res/values-kaa/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-kaa/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Minimum fayl jasılıǵı</string>
     <string name="squeezer_min_age_description">Tek bul jasdan úlken fayllardy qosiw.</string>
     <string name="squeezer_compression_settings_label">Ulıwmalıq</string>
-    <string name="squeezer_quality_label">Sapa</string>
-    <string name="squeezer_quality_title">Sıǵıstırıw sapası</string>
     <string name="squeezer_quality_description">Tómen sapa — fayldıń kishi ólshemin bildiredi, biraq kóriw sapasın azaytadı.</string>
-    <string name="squeezer_quality_example_format">Mısal: %1$s su\'wret → %3$d%% sapada ~%2$s u\'nemlew</string>
-    <string name="squeezer_quality_warning_low">To\'men sapalarda ko\'rinetug\'ın artefaktlar payda bolıwı mu\'mkin.</string>
-    <string name="squeezer_quality_warning_high">Juqarı sapa az orın u\'nemleydi.</string>
     <string name="squeezer_types_category_label">Súwret sazlamaları</string>
     <string name="squeezer_video_settings_category_label">Video sazlamaları</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Sıǵıstırıwdı tastıyıqlaw</string>
     <string name="squeezer_preview_total_size">Ulıwma o\'lshem</string>
     <string name="squeezer_preview_estimated_savings">Boljamalı u\'nemlew</string>
-    <string name="squeezer_compress_confirmation_title">Tańlap alınǵan elementlerdı sıqıw?</string>
-    <string name="squeezer_compress_confirmation_message">Bul túpnusqa fayllardı sıqılǵan versiyaları menen almaştıradı. Bul ámeldi qaytarıp bolmaydı.</string>
     <string name="squeezer_history_title">Sıǵıstırıw tariyxı</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Sıǵıstırıw tariyxı joq</string>
     <string name="squeezer_history_clear_title">Sıǵıstırıw tariyxın tazalaw</string>
     <string name="squeezer_history_clear_message">Bul burın sıqılǵan fayllardy qaytadan sıqıwǵa múmkinshilik beredi. Fayllardıń ózine tásir etpeydi.</string>
-    <string name="squeezer_onboarding_title">Su\'wret sıǵıstırıw haqqında</string>
-    <string name="squeezer_onboarding_message">Su\'wret sıǵıstırıw ko\'riniw detallarin alıp taslaw arqalı fayl o\'lshemin kemeyterdi. Bul protsess qaytarılmas - original sapa qayta tikleniwi mu\'mkin emes.\n\nSu\'wretleriniz qalay ko\'rinetuǵının aldın alıw:</string>
     <string name="squeezer_onboarding_original_label">Asliyet</string>
     <string name="squeezer_onboarding_compressed_label">Sıǵıstırılǵannan keyin</string>
     <string name="squeezer_onboarding_video_original_label">Video kadr</string>
     <string name="squeezer_onboarding_video_compressed_label">Aldın ala kóriw (taxminiy)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Haqıyqıy video sapası ózgeshe bolıwı múmkin</string>
-    <string name="squeezer_onboarding_quality_label">Sapa: %d%%</string>
     <string name="squeezer_compare_action">Salıstırıwdı ko\'riw</string>
     <string name="squeezer_no_example_found">Tańlanǵan jollarda su\'wretler tabılmadı.</string>
     <string name="squeezer_result_empty_message">Sıqıwǵa jaramlı media tabılmadı.</string>
-    <string name="squeezer_setup_warning">Sıqıw sapanı birotola azaytadı hám saqlaw orınına tejeydi. Bul ámeldi qaytarıp bolmaydı. Baslamastan burın sazlamalardı dıqqat penen qarap shıǵıń.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d orın sıqıw ushın qollanılmaydı hám óshirildi. Sıqıw ishki saqlaw orınına tikkeley qoljetimdi talap etedi.</item>
         <item quantity="other">%d orın sıqıw ushın qollanılmaydı hám óshirildi. Sıqıw ishki saqlaw orınına tikkeley qoljetimdi talap etedi.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Keminde %d ku\'n eski</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG fayllar ushın shama menen ~%d%% tejew kútiledi</string>
-    <string name="squeezer_onboarding_got_it">Túsinikli</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer sizdiń fotolar va videolárıńyzní qayta sıqíp berídí, alar áz joy tutsa bolúdi. Sız ázshe sápat salqín beríp, qaytarilgan joydan fáyde kóreseńíz. Her bir sahada tejemesi kórsetíldí, soño qalájı qímmatı jayinda ekenligín bilip bolasız.</string>
     <string name="tour_squeezer_compress_body">Bunda hámmesin bir waqıtta sıǵıń, yamasa tek sonı kishireytiw ushın bir elementke basıń. Birneshesin tańlaw ushın uzaq basıp turıń. Hesh nárse ózgermesten aldın hámishe aldın kóriwdi kóresiz.</string>

--- a/app-tool-squeezer/src/main/res/values-km-rKH/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-km-rKH/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">អាយុឯកសារតែចិត្ត</string>
     <string name="squeezer_min_age_description">រួមបញ្ចូលតើឯកសារចាសជាងអាយុនេ។</string>
     <string name="squeezer_compression_settings_label">ជាទូទៅ</string>
-    <string name="squeezer_quality_label">គុណភាព</string>
-    <string name="squeezer_quality_title">គុណភាពការចុច</string>
     <string name="squeezer_quality_description">គុណភាពតាបមានន័យថាទំហំឯកសារតូចជាងប៉ុន្តើគុណភាពមើលខើញថយចុ។</string>
-    <string name="squeezer_quality_example_format">ត័វរាង %1$s រូប → សញ្ញ ~%2$s នៅគុណភាព %3$d%%</string>
-    <string name="squeezer_quality_warning_low">គុណភាពតែចិត្តអាចនាឣទាក់ខុស្សនៅរូបបាន។</string>
-    <string name="squeezer_quality_warning_high">គុណភាព័កច្រើនពីក្រោមនិងការសញ្ញតែចិត្តទំហំផ័ឡកតូច។</string>
     <string name="squeezer_types_category_label">ការកំណត់រូបភាព</string>
     <string name="squeezer_video_settings_category_label">ការកំណត់វីដេអូ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">បញ្ជាក់ការចុច</string>
     <string name="squeezer_preview_total_size">ទំហំសរុប</string>
     <string name="squeezer_preview_estimated_savings">ការសញ្ញដែលប័តិម្ឡួត់</string>
-    <string name="squeezer_compress_confirmation_title">បង្រួមធាតុដែលបានជ្រើររើស?</string>
-    <string name="squeezer_compress_confirmation_message">វានឹងជំនួសឯកសារដើមដោយកំណែដែលបានបង្រួម។ សកម្មភាពនេ័ហមិនអាចត្រល្បវឹញបានតើ។</string>
     <string name="squeezer_history_title">ប្រវត្តការចុច</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d ឯកថន្ទ់ (%2$s)</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">មិនមានប្រវត្តការចុច</string>
     <string name="squeezer_history_clear_title">លុបប្រវត្តការចុច</string>
     <string name="squeezer_history_clear_message">វានឹងអនុញ្ញាតអោយឯកសារដែលបានបង្រួមមុននេ័ត្រូវបានបង្រួមម្តងតឹត។ ឯកសារខ្លួនឯងមិនរងផលប៉ែពាលើយ។</string>
-    <string name="squeezer_onboarding_title">អានស័ម្ព័ន្ធការចុចរូប</string>
-    <string name="squeezer_onboarding_message">ការចុចរូបកំណត់ទំហំឯកសារដោយការលុបសម្ឆាល់វិសួយ។ ដ្វងនេឣមិនអាចដក្កើតវិញបាន–គុណភាពដើម្បីមិនអាចផ័ត់វិញបាន។\n\nនេឣជាការមើលឹករបស់អ្នកនៅក្រើ៖</string>
     <string name="squeezer_onboarding_original_label">ត់បញ់ដើម</string>
     <string name="squeezer_onboarding_compressed_label">ប័កការចុច</string>
     <string name="squeezer_onboarding_video_original_label">ស្រតាប់វីដេអូ</string>
     <string name="squeezer_onboarding_video_compressed_label">មើលជាមុន (ប្រហាក់ប្រហែល)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">គុណភាពវីដេអូជាក់ស័ត្តែអាចខុសគ្នា</string>
-    <string name="squeezer_onboarding_quality_label">គុណភាព៖ %d%%</string>
     <string name="squeezer_compare_action">មើលការបរន័យប័កគ្នា</string>
     <string name="squeezer_no_example_found">មិនន័ឯកសាររូបនៅផ្លូវដែលបានជ្រើស។</string>
     <string name="squeezer_result_empty_message">រកមិនឃើញមេដីអដែលអាចបង្រួមបាន។</string>
-    <string name="squeezer_setup_warning">ការបង្រួមកាត់បន្ថយគុណភាពជាអចិន្ត្រ័យ៍ ដើម្បីសន្សំទំហំផ្ទុក។ វាមិនអាចត្រល្បវឹញបានតើ។ ពិនិតការកំណត់របស់អ្នកដោយប្រុងប្រយ័ត្តនមុននឹងចាបផ័តើម។</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">%d តីតំហងមិនអាចប្រើសសម្រាប់ការបង្រួម ហើយត្រូវបានដកចើញ។ ការបង្រួមតម្រួវអោយចូលដំណើរការផ្តល់ទឹលកន្លងផ្ទុកខាងក្នុង។</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">អាយុយឹងតិ %d ថ្ង័ឡក្នៅមក</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">ការសន្សំប្រហាក់ប្រហែល ~%d%% សម្រាប់ឯកសារ JPEG</string>
-    <string name="squeezer_onboarding_got_it">យល់ហើយ</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer ធ្វើឱ្យលុតសងខ្លឹមសាររូបថត និងវីដេអូរបស់អ្នក ដូច្នេះវាកាន់កាប់ទំហំតូចជាង។ អ្នកផ្លាស់ប្តូរគុណភាពបន្តិចបន្ថែមសម្រាប់ទំហំដែលអ្នកទទួលបាន។ វត្ថុនីមួយៗបង្ហាញការសន្សំប៉ាន់ស្មាននៃវា ដូច្នេះអ្នកអាចសម្រេចចិត្តថាវាមានតម្លៃប៉ុណ្ណា។</string>
     <string name="tour_squeezer_compress_body">បង្ហាប់អ្វីៗក្នុងពេលតែមួយនៅទីនេះ ឬចុចធាតុតែមួយដើម្បីកាត់បន្ថយតែវា។ ចុចរយៈពេលវែងដើម្បីជ្រើសរើសច្រើន។ អ្នកនឹងបានឃើញការមើលមុនជានិច្ចមុននឹងមានការផ្លាស់ប្តូរអ្វី។</string>

--- a/app-tool-squeezer/src/main/res/values-ko/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ko/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">최소 파일 기간</string>
     <string name="squeezer_min_age_description">이 기간보다 오래된 파일만 포함합니다.</string>
     <string name="squeezer_compression_settings_label">일반</string>
-    <string name="squeezer_quality_label">품질</string>
-    <string name="squeezer_quality_title">압축 품질</string>
     <string name="squeezer_quality_description">낮은 품질은 파일 크기를 줄이지만 시각적 품질도 낮아집니다.</string>
-    <string name="squeezer_quality_example_format">예시: %1$s 이미지 → %3$d%% 품질에서 ~%2$s 절약</string>
-    <string name="squeezer_quality_warning_low">낮은 품질은 눈에 보이는 아티팩트를 유발할 수 있습니다.</string>
-    <string name="squeezer_quality_warning_high">매우 높은 품질은 공간 절약이 거의 없습니다.</string>
     <string name="squeezer_types_category_label">이미지 설정</string>
     <string name="squeezer_video_settings_category_label">동영상 설정</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">압축 확인</string>
     <string name="squeezer_preview_total_size">총 크기</string>
     <string name="squeezer_preview_estimated_savings">예상 절약량</string>
-    <string name="squeezer_compress_confirmation_title">선택된 항목을 압축하시겠습니까?</string>
-    <string name="squeezer_compress_confirmation_message">원본 파일이 압축 버전으로 교체됩니다. 이 작업은 취소할 수 없습니다.</string>
     <string name="squeezer_history_title">압축 기록</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d개 항목 (%2$s)</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">압축 기록 없음</string>
     <string name="squeezer_history_clear_title">압축 기록 삭제</string>
     <string name="squeezer_history_clear_message">이전에 압축된 파일을 다시 압축할 수 있게 됩니다. 파일 자체에는 영향이 없습니다.</string>
-    <string name="squeezer_onboarding_title">이미지 압축 소개</string>
-    <string name="squeezer_onboarding_message">이미지 압축은 시각적 세부 사항을 제거하여 파일 크기를 줄입니다. 이 과정은 되돌릴 수 없습니다 - 원래 품질을 복원할 수 없습니다.\n\n이미지가 어떻게 보일지 미리보기:</string>
     <string name="squeezer_onboarding_original_label">원본</string>
     <string name="squeezer_onboarding_compressed_label">압축 후</string>
     <string name="squeezer_onboarding_video_original_label">동영상 프레임</string>
     <string name="squeezer_onboarding_video_compressed_label">미리보기 (근사치)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">실제 동영상 품질은 다를 수 있습니다</string>
-    <string name="squeezer_onboarding_quality_label">품질: %d%%</string>
     <string name="squeezer_compare_action">비교 보기</string>
     <string name="squeezer_no_example_found">선택한 경로에서 이미지를 찾을 수 없습니다.</string>
     <string name="squeezer_result_empty_message">압축 가능한 미디어를 찾을 수 없습니다.</string>
-    <string name="squeezer_setup_warning">압축은 저장 공간 절약을 위해 품질을 영구적으로 낙십니다. 이 작업은 취소할 수 없습니다. 시작하기 전에 설정을 주의 깊게 검토하세요.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">%d개의 위치는 압축에 사용할 수 없어 제거되었습니다. 압축을 위해서는 내부 저장소에 직접 접근이 필요합니다.</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">최소 %d일 경과</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG 파일의 예상 ~%d%% 절감</string>
-    <string name="squeezer_onboarding_got_it">확인</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer는 사진과 동영상을 다시 압축하여 저장 공간을 절약합니다. 약간의 화질 손실로 더 많은 공간을 확보합니다. 각 항목은 예상 절약량을 표시하므로 가치 있는 항목을 선택할 수 있습니다.</string>
     <string name="tour_squeezer_compress_body">여기서 모든 항목을 한 번에 압축하거나 단일 항목을 탭하여 해당 항목만 줄입니다. 여러 항목을 선택하려면 길게 누르세요. 변경되기 전에 항상 미리보기를 볼 수 있습니다.</string>

--- a/app-tool-squeezer/src/main/res/values-lo-rLA/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-lo-rLA/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">ອາຍຸໄຟລ໌ຂັ້ນຕໃ఼່ຕ່ໍາ</string>
     <string name="squeezer_min_age_description">ລວມສະເພາະໄຟລ໌ທີ່ເກົ່າກວ່າອາຍຸນີ້ເທົ່ານັ້ນ.</string>
     <string name="squeezer_compression_settings_label">ທົ່ວໄປ</string>
-    <string name="squeezer_quality_label">ຄຸນນາພ</string>
-    <string name="squeezer_quality_title">ຄຸນນາພການບີບອັດ</string>
     <string name="squeezer_quality_description">ຄຸນນະພາບຕ່ຳໝາຍຄວາມວ່າຂະໜາດໄຟລ໌ນ້ອຍລົງ ແຕ່ຄຸນນະພາບຮູບທີ່ຫຼຸດລົງ.</string>
-    <string name="squeezer_quality_example_format">ຕົວອຍ່າງ: ຣູບ %1$s → ປະຫຍັດ ~%2$s ທີ່ຄຸນນາພ %3$d%%</string>
-    <string name="squeezer_quality_warning_low">ຄຸນນາພຕໃ່າອາດທຳໃຫ້ເຫັນສິ່ງຜິດປົກກະຕິ.</string>
-    <string name="squeezer_quality_warning_high">ຄຸນນາພສູງມາກເກັບພື້ນທີ່ດ້ວຍນ້ອຍນິດ.</string>
     <string name="squeezer_types_category_label">ການຕັ້ງຄ່າຮູບພາບ</string>
     <string name="squeezer_video_settings_category_label">ການຕັ້ງຄ່າວິດີໂອ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">ຍືນຍັນການບີບອັດ</string>
     <string name="squeezer_preview_total_size">ຂນາດທັງຫມດ</string>
     <string name="squeezer_preview_estimated_savings">ການປະຫຍັດທີ່ຄາດເດົາ</string>
-    <string name="squeezer_compress_confirmation_title">ບີບອັດລາຍການທີ່ເລືອກ?</string>
-    <string name="squeezer_compress_confirmation_message">ນີ້ຈະແທນທີ່ໄຟລ໌ຕົ້ນສະບັບດ້ວຍສະບັບທີ່ຖືກບີບອັດ. ການກະທຳນີ້ບໍ່ສາມາດຍ້ອນກັບໄດ້.</string>
     <string name="squeezer_history_title">ປະຫວັດການບີບອັດ</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d ລາຍການ (%2$s)</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">ໄມ່ມີປະຫວັດການບີບອັດ</string>
     <string name="squeezer_history_clear_title">ລົບປະຫວັດການບີບອັດ</string>
     <string name="squeezer_history_clear_message">ນີ້ຈະອະນຸຍາດໃຫ້ໄຟລ໌ທີ່ຖືກບີບອັດກ່ອນໜ້ານີ້ຖືກບີບອັດອີກຄັ້ງ. ໄຟລ໌ເຫຼົ່ານັ້ນເອງບໍ່ໄດ້ຮັບຜົນກະທົບ.</string>
-    <string name="squeezer_onboarding_title">ກ່ນການບີບອັດຣູບ</string>
-    <string name="squeezer_onboarding_message">ການບີບອັດຣູບລດຂນາດໄຟລ໌ດ້ວຍການລົບລາຍລະເອີຊດ້ານພາບ. ການກະທຳນີ້ໄມ່ສາມາຖກັບຄືນໄດ້ - ຄຸນນາພຕ້ນພົ້ນໄມ່ສາມາຖຖືກຄືນ.\n\nนଵ່ໂປຣຮ້ວຂອງວິຘີທີ່ຣູບຂອງທ່ານຈະປະກົດ:</string>
     <string name="squeezer_onboarding_original_label">ຕ້ນພົ້ນ</string>
     <string name="squeezer_onboarding_compressed_label">ຫລັງການບີບອັດ</string>
     <string name="squeezer_onboarding_video_original_label">ເຟຣມວິດີໂອ</string>
     <string name="squeezer_onboarding_video_compressed_label">ຕົວຢ່າງ (ໂດຍປະມານ)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">ຄຸນນະພາບວິດີໂອທີ່ແທ້ຈິງອາດຕ່າງກັນ</string>
-    <string name="squeezer_onboarding_quality_label">ຄຸນນາພ: %d%%</string>
     <string name="squeezer_compare_action">ດູການເປົນເທີຍບ</string>
     <string name="squeezer_no_example_found">ໄມ່ພົບຣູບໃນເສ້ນທາງທີ່ເລືອກ.</string>
     <string name="squeezer_result_empty_message">ບໍ່ພົບສື່ທີ່ສາມາດບີບອັດໄດ້.</string>
-    <string name="squeezer_setup_warning">ການບີບອັດຫຼຸດຄຸນນະພາບຢ່າງຖາວອນເພື່ອປະຢັດພື້ນທີ່ເກັບຂໍ້ມູນ. ນີ້ບໍ່ສາມາດຍ້ອນກັບໄດ້. ກວດສອບການຕັ້ງຄ່າຂອງທ່ານຢ່າງລະມັດລະວັງກ່ອນເລີ່ມ.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">%d ສະຖານທີ່ບໍ່ສາມາດໃຊ້ສຳລັບການບີບອັດ ແລະ ຖືກລຶບອອກ. ການບີບອັດຕ້ອງການການເຂົ້າເຖິງໂດຍກົງຕໍ່ບ່ອນເກັບຂໍ້ມູນພາຍໃນ.</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">ອາຍຸອຍ່າງນ້ອຍ %d ວັນ</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">ປະມານ ~%d%% ປະຍັດສຳລັບໄຟລ໌ JPEG</string>
-    <string name="squeezer_onboarding_got_it">ເຂົ້າໃຈແລ້ວ</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer ບີບອັດຄືນຮູບຖ່າຍ ແລະ ວິດີໂອຂອງທ່ານເພື່ອໃຫ້ພວກມັນໃຊ້ພື້ນທີ່ນ້ອຍລົງ. ທ່ານແລກປ່ຈງຄຸນນະພາບເລັກນ້ອຍເພື່ອຕອບແທນກັບພື້ນທີ່ທີ່ທ່ານໄດ້ກັບຄືນ. ແຕ່ລະລາຍການສະແດງບໍລິມາທີ່ປະເມີນໄວ້ ດັ່ງນັ້ນທ່ານສາມາດຕັດສິນໃຈວ່າມັນຄຸ້ມຄ່າຫຼືບໍ່.</string>
     <string name="tour_squeezer_compress_body">ບີບອັດທັງໝົດຍູ່ນີ້ພາຍໃນເວລາດຽວ ຫຼືແຕະໄຟລ໌ໝນຶ່ງເພື່ອໜຸດຂະໝາດພຽງແຕ່ໄຟລ໌ອັນນັ້ນ. ກົດຄ້າງໄວ້ເພື່ອເລືອກຫາຍອັນ. ທ່ານຈະສະເຫມີເໝັນຕົວຍ່າງກໍ່ນທີ່ຈະມີການປຽນແປງໃດໆ.</string>

--- a/app-tool-squeezer/src/main/res/values-lt/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-lt/strings.xml
@@ -54,12 +54,7 @@
     <string name="squeezer_min_age_title">Minimalus failo amžius</string>
     <string name="squeezer_min_age_description">Įtraukti tik failus, senesnius už šį amžių.</string>
     <string name="squeezer_compression_settings_label">Bendrieji</string>
-    <string name="squeezer_quality_label">Kokybė</string>
-    <string name="squeezer_quality_title">Suglaudinimo kokybė</string>
     <string name="squeezer_quality_description">Mažesnė kokybė reiškia mažesnį failo dydį, tačiau blogesnę vaizdinę kokybę.</string>
-    <string name="squeezer_quality_example_format">Pavyzdys: %1$s vaizdas → sutaupo ~%2$s prie %3$d%% kokybės</string>
-    <string name="squeezer_quality_warning_low">Maesnė kokybė gali sukelti matomus artefaktus.</string>
-    <string name="squeezer_quality_warning_high">Labai aukšta kokybė suteikia minimalias vietos sutaupymas.</string>
     <string name="squeezer_types_category_label">Vaizdo nustatymai</string>
     <string name="squeezer_video_settings_category_label">Vaizdo įrašų nustatymai</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -84,8 +79,6 @@
     <string name="squeezer_preview_dialog_title">Patvirtinti suglaudinimą</string>
     <string name="squeezer_preview_total_size">Bendras dydis</string>
     <string name="squeezer_preview_estimated_savings">Numatomas sutaupymas</string>
-    <string name="squeezer_compress_confirmation_title">Suglaudinti pasirinktus elementus?</string>
-    <string name="squeezer_compress_confirmation_message">Originalūs failai bus pakeisti suglaudintomis versijomis. Šio veiksmo negalima atšaukti.</string>
     <string name="squeezer_history_title">Suglaudinimo istorija</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elementas (%2$s)</item>
@@ -96,18 +89,14 @@
     <string name="squeezer_history_empty">Nėra suglaudinimo istorijos</string>
     <string name="squeezer_history_clear_title">Išvalyti suglaudinimo istoriją</string>
     <string name="squeezer_history_clear_message">Tai leis anksčiau suglaudintus failus suglaudinti dar kartą. Patys failai nebus paveikti.</string>
-    <string name="squeezer_onboarding_title">Apie vaizdų suglaudinimą</string>
-    <string name="squeezer_onboarding_message">Vaizdų suglaudinimas sumažina failo dydį pašalindamas vizualias detales. Šis procesas yra neatstatomas - originalės kokybės negalima atstatyti.\n\nStai kaip atrodys jūsų vaizdai:</string>
     <string name="squeezer_onboarding_original_label">Originalas</string>
     <string name="squeezer_onboarding_compressed_label">Po suglaudinimo</string>
     <string name="squeezer_onboarding_video_original_label">Vaizdo kadras</string>
     <string name="squeezer_onboarding_video_compressed_label">Peržiūra (apytikslė)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Tikroji vaizdo kokybė gali skirtis</string>
-    <string name="squeezer_onboarding_quality_label">Kokybė: %d%%</string>
     <string name="squeezer_compare_action">Peržiūrėti palyginimą</string>
     <string name="squeezer_no_example_found">Pasirinktuose keliuose vaizdai nerasti.</string>
     <string name="squeezer_result_empty_message">Nesurasta jokių suglaudinamų medijų.</string>
-    <string name="squeezer_setup_warning">Suglaudinimas visam laikui sumažina kokybę, kad atlaisvintų atminties vietą. Šio veiksmo negalima atšaukti. Prieš pradėdami atidžiai peržiūrėkite savo nustatymus.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d vieta negali būti naudojama suglaudinimui ir buvo pašalinta. Suglaudinimui reikalinga tiesioginė prieiga prie vidinės atminties.</item>
         <item quantity="few">%d vietos negali būti naudojamos suglaudinimui ir buvo pašalintos. Suglaudinimui reikalinga tiesioginė prieiga prie vidinės atminties.</item>
@@ -131,7 +120,6 @@
         <item quantity="other">Ne mažiau kaip %d dienų</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Apytiksliai ~%d%% sutaupymų JPEG failams</string>
-    <string name="squeezer_onboarding_got_it">Supratau</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer iš naujo suspaudžia jūsų nuotraukas ir vaizdo įrašus, todėl jie užima mažiau vietą. Jūs mainote šiek tiek kokybės į erdvę, kurią atgaunate. Kiekvienas elementas parodo numatytą sutaupymą, todėl galite nuspręsti, ką verta.</string>
     <string name="tour_squeezer_compress_body">Suglaudinkite viską iš karto čia arba palieskite vieną elementą, norėdami sumažinti tik tą. Ilgai spustelėkite, norėdami pasirinkti kelis. Prieš bet kokius pokyčius visada matysite peržiūrą.</string>

--- a/app-tool-squeezer/src/main/res/values-lv/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-lv/strings.xml
@@ -46,12 +46,7 @@
     <string name="squeezer_min_age_title">Minimālais faila vecums</string>
     <string name="squeezer_min_age_description">Iekļaut tikai failus, kas ir vecāki par šo vecumu.</string>
     <string name="squeezer_compression_settings_label">Vispārīgi</string>
-    <string name="squeezer_quality_label">Kvalitāte</string>
-    <string name="squeezer_quality_title">Kompresijas kvalitāte</string>
     <string name="squeezer_quality_description">Zemāka kvalitāte nozīmē mazāku faila izmēru, bet samazinātu vizuālo kvalitāti.</string>
-    <string name="squeezer_quality_example_format">Piemērs: %1$s attēls → ietaupa ~%2$s pie %3$d%% kvalitātes</string>
-    <string name="squeezer_quality_warning_low">Zemāka kvalitāte var radīt redzamus artefaktus.</string>
-    <string name="squeezer_quality_warning_high">Oti augsta kvalitāte nodrošina minimalu vietas ietaupijumu.</string>
     <string name="squeezer_types_category_label">Attēlu iestatījumi</string>
     <string name="squeezer_video_settings_category_label">Video iestatījumi</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -76,8 +71,6 @@
     <string name="squeezer_preview_dialog_title">Apstiprināt kompresiju</string>
     <string name="squeezer_preview_total_size">Kopējais izmērs</string>
     <string name="squeezer_preview_estimated_savings">Paredzamais ietaupijums</string>
-    <string name="squeezer_compress_confirmation_title">Saspiest atlasītos vienumus?</string>
-    <string name="squeezer_compress_confirmation_message">Tas aizstās oriģinālos failus ar saspiestam versijām. Šo darbību nevar atsaukt.</string>
     <string name="squeezer_history_title">Kompresijas vēsture</string>
     <plurals name="squeezer_history_summary">
         <item quantity="zero">%1$d vienības (%2$s)</item>
@@ -87,18 +80,14 @@
     <string name="squeezer_history_empty">Nav kompresijas vēstures</string>
     <string name="squeezer_history_clear_title">Notīrīt kompresijas vēsturi</string>
     <string name="squeezer_history_clear_message">Tas ļaus iepriekš saspiestus failus saspiest vēlreiz. Paši faili netiek ietekmēti.</string>
-    <string name="squeezer_onboarding_title">Par attēlu kompresiju</string>
-    <string name="squeezer_onboarding_message">Attēlu kompresija samazina faila izmēru, noņemot vizuālas detajas. Šis process ir neatgriezenisks — originālo kvalitāti nav iespējams atjaunot.\n\nLot paskats, kā jūsu attēli izskatiesšies:</string>
     <string name="squeezer_onboarding_original_label">Origināls</string>
     <string name="squeezer_onboarding_compressed_label">Pēc kompresijas</string>
     <string name="squeezer_onboarding_video_original_label">Video rāmis</string>
     <string name="squeezer_onboarding_video_compressed_label">Priekšskatījums (aptuvens)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Faktiskā video kvalitāte var atšķirties</string>
-    <string name="squeezer_onboarding_quality_label">Kvalitāte: %d%%</string>
     <string name="squeezer_compare_action">Skatīt salīdzīnājumu</string>
     <string name="squeezer_no_example_found">Nav atrasts neviens attēls atlasītajās ceļos.</string>
     <string name="squeezer_result_empty_message">Nav atrasts neviens saspiežams multivides fails.</string>
-    <string name="squeezer_setup_warning">Saspiešana neatgriezeniski samazina kvalitāti, lai ietaupītu krātuves vietu. To nevar atsaukt. Pirms sākšanas rūpīgi pārskatiet iestatījumus.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="zero">%d atrašanvietu nevar izmantot saspiešanai un tās tika noņemtas. Saspiešanai nepieciešama tieša piekļuve iekšējai krātuvei.</item>
         <item quantity="one">%d atrašanvietu nevar izmantot saspiešanai un tā tika noņemta. Saspiešanai nepieciešama tieša piekļuve iekšējai krātuvei.</item>
@@ -120,7 +109,6 @@
         <item quantity="other">Vismaz %d dienas vecs</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Aptuvenais ~%d%% ietaupījums JPEG failiem</string>
-    <string name="squeezer_onboarding_got_it">Sapratu</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer pārkompresē jūsu fotogrāfijas un video, lai tie aizņemtu mazāk vietas. Jūs apmaināt nedaudz kvalitātes pret vietu, ko iegūstat atpakaļ. Katrs vienums rāda savu aprēķināto ietaupījumu, tāpēc varat izlemt, kas ir vērts.</string>
     <string name="tour_squeezer_compress_body">Saspiediet visu uzreiz šeit, vai pieskarieties vienam vienumam, lai samazinātu tikai to. Ilgi nospiediet, lai izvēlētos vairākus. Jūs vienmēr redzēsiet priekšskatījumu pirms jebkādām izmaiņām.</string>

--- a/app-tool-squeezer/src/main/res/values-mk-rMK/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-mk-rMK/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Минимална старост на датотека</string>
     <string name="squeezer_min_age_description">Вклучи само датотеки постари од оваа возраст.</string>
     <string name="squeezer_compression_settings_label">Општо</string>
-    <string name="squeezer_quality_label">Квалитет</string>
-    <string name="squeezer_quality_title">Квалитет на компресија</string>
     <string name="squeezer_quality_description">Пониски квалитет значи помала големина на датотеката но намален визуелен квалитет.</string>
-    <string name="squeezer_quality_example_format">Пример: %1$s слика → заштеда ~%2$s при %3$d%% квалитет</string>
-    <string name="squeezer_quality_warning_low">Пониски квалитети може да предизвикаат видливи артефакти.</string>
-    <string name="squeezer_quality_warning_high">Многу висок квалитет дава минимална заштеда на простор.</string>
     <string name="squeezer_types_category_label">Поставки за слики</string>
     <string name="squeezer_video_settings_category_label">Поставки за видео</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Потврди компресија</string>
     <string name="squeezer_preview_total_size">Вкупна големина</string>
     <string name="squeezer_preview_estimated_savings">Проценета заштеда</string>
-    <string name="squeezer_compress_confirmation_title">Да се компресираат избраните ставки?</string>
-    <string name="squeezer_compress_confirmation_message">Ова ќе ги замени оригиналните датотеки со компресирани верзии. Оваа акција не може да се врати.</string>
     <string name="squeezer_history_title">Историја на компресија</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ставка (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Нема историја на компресија</string>
     <string name="squeezer_history_clear_title">Избриши историја на компресија</string>
     <string name="squeezer_history_clear_message">Ова ќе дозволи претходно компресирани датотеки да бидат компресирани повторно. Самите датотеки не се засегнати.</string>
-    <string name="squeezer_onboarding_title">За компресија на слики</string>
-    <string name="squeezer_onboarding_message">Компресијата на слики ја намалува големината на датотеката со отстранување визуелни детали. Овој процес е неповратен - оригиналниот квалитет не може да се врати.\n\nЕве преглед како ќе изгледаат вашите слики:</string>
     <string name="squeezer_onboarding_original_label">Оригинал</string>
     <string name="squeezer_onboarding_compressed_label">По компресија</string>
     <string name="squeezer_onboarding_video_original_label">Видео рамка</string>
     <string name="squeezer_onboarding_video_compressed_label">Преглед (приближно)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Вистинскиот квалитет на видеото може да се разликува</string>
-    <string name="squeezer_onboarding_quality_label">Квалитет: %d%%</string>
     <string name="squeezer_compare_action">Прегледај споредба</string>
     <string name="squeezer_no_example_found">Нема пронајдени слики во избраните патеки.</string>
     <string name="squeezer_result_empty_message">Не е пронајдено компресибилно медиумско содржина.</string>
-    <string name="squeezer_setup_warning">Компресијата трајно го намалува квалитетот за да заштеди простор за складирање. Ова не може да се врати. Внимателно прегледајте ги вашите поставки пред да започнете.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d локација не може да се користи за компресија и беше отстранета. Компресијата бара директен пристап до внатрешниот склад.</item>
         <item quantity="other">%d локации не можат да се користат за компресија и беа отстранети. Компресијата бара директен пристап до внатрешниот склад.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Најмалку %d дена стара</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Проценето ~%d%% заштеда за JPEG датотеки</string>
-    <string name="squeezer_onboarding_got_it">Разбрав</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer повторно ги компресира твоите фотографии и видеа за да заземаат помалку простор. Даваш малку квалитет за просторот што го добиваш назад. Секој предмет го покажува проценетото спасување, за да можеш да одлучиш што вреди.</string>
     <string name="tour_squeezer_compress_body">Компресирајте сè одеднаш овде, или допрете една ставка за да ја намалите само таа. Долго притиснете за да изберете неколку. Секогаш ќе видите преглед пред да се промени нешто.</string>

--- a/app-tool-squeezer/src/main/res/values-ml-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ml-rIN/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">കുറഞ്ഞ ഫയൽ പഴക്കം</string>
     <string name="squeezer_min_age_description">ഈ പഴക്കത്തിൽ കൂടുതൽ പഴയ ഫയലുകൾ മാത്രം ഉൾപ്പെടുത്തുക.</string>
     <string name="squeezer_compression_settings_label">പൊതുവായ</string>
-    <string name="squeezer_quality_label">ഗുണമേൻമ</string>
-    <string name="squeezer_quality_title">കമ്പ്രഷൻ ഗുണമേൻമ</string>
     <string name="squeezer_quality_description">കുറഞ്ഞ ഗുണമേൻമ എന്നാൽ ചെറിയ ഫയൽ വലിപ്പം, പക്ഷേ ദൃശ്യ ഗുണമേൻമ കുറയും.</string>
-    <string name="squeezer_quality_example_format">ഉദാ: %1$s ചിത്രം → %3$d%% ഗുണമേൻമയിൽ ~%2$s ലാഭിക്കും</string>
-    <string name="squeezer_quality_warning_low">കുറഞ്ഞ ഗുണമേൻമ ദൃശ്യമായ തക്രാരുകൾ ഉണ്ടാകാൻ സാധ്യതയുണ്ട്.</string>
-    <string name="squeezer_quality_warning_high">വളരെ ഉച്ച ഗുണമേൻമ കുറഞ്ഞ സ്ഥല ലാഭം നൽകുന്നു.</string>
     <string name="squeezer_types_category_label">ചിത്ര ക്രമീകരണങ്ങൾ</string>
     <string name="squeezer_video_settings_category_label">വീഡിയോ ക്രമീകരണങ്ങൾ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">കമ്പ്രഷൻ സ്ഥിരീകരിക്കുക</string>
     <string name="squeezer_preview_total_size">മൊത്തം വലുപ്പം</string>
     <string name="squeezer_preview_estimated_savings">കണക്കാക്കിയ ലാഭം</string>
-    <string name="squeezer_compress_confirmation_title">തിരഞ്ഞെടുത്ത ഇനങ്ങൾ കംപ്രസ്സ് ചെയ്യണോ?</string>
-    <string name="squeezer_compress_confirmation_message">ഇത് യഥാർത്ഥ ഫയലുകൾ കംപ്രസ്സ് ചെയ്ത പതിപ്പുകൾ ഉപയോഗിച്ച് മാറ്റിസ്ഥാപിക്കും. ഈ പ്രവൃത്തി പഴേ നിലയിലാക്കാൻ കഴിയില്ല.</string>
     <string name="squeezer_history_title">കമ്പ്രഷൻ ചരിത്രം</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ഇനം (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">കമ്പ്രഷൻ ചരിത്രം ഇല്ല</string>
     <string name="squeezer_history_clear_title">കമ്പ്രഷൻ ചരിത്രം മാർജിക്കുക</string>
     <string name="squeezer_history_clear_message">ഇത് മുമ്പ് കംപ്രസ്സ് ചെയ്ത ഫയലുകൾ വീണ്ടും കംപ്രസ്സ് ചെയ്യാൻ അനുവദിക്കും. ഫയലുകൾ തന്നെ ബാധിക്കപ്പെടില്ല.</string>
-    <string name="squeezer_onboarding_title">ഇമേജ് കമ്പ്രഷൻ കുറിച്ച്</string>
-    <string name="squeezer_onboarding_message">ഇമേജ് കമ്പ്രഷൻ ദൃശ്യമാന വിവരങ്ങൾ നീക്കി ഫയൽ വലുപ്പം കുറയ്ക്കുന്നു. ഈ പ്രക്രിയ തിരിച്ചെടുക്കാൻ കഴിയാത്തതാണ് - മൂല ഗുണമേൻമ വില തിരിച്ചെടുക്കാൻ കഴിയില്ല.\n\nനിങ്ങളുടെ ചിത്രങ്ങൾ എപ്പോർ കാണപ്പെടും എന്നതിന്റെ ഒരു മുന്നല്:</string>
     <string name="squeezer_onboarding_original_label">യഥാർത്ഥം</string>
     <string name="squeezer_onboarding_compressed_label">കമ്പ്രഷൻക്കു ശേഷം</string>
     <string name="squeezer_onboarding_video_original_label">വീഡിയോ ഫ്രെയിം</string>
     <string name="squeezer_onboarding_video_compressed_label">പ്രിവ്യൂ (ഏകദേശം)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">യഥാർത്ഥ വീഡിയോ ഗുണമേൻമ വ്യത്യാസപ്പെടാം</string>
-    <string name="squeezer_onboarding_quality_label">ഗുണമേൻമ: %d%%</string>
     <string name="squeezer_compare_action">താരതമ്യം കാണുക</string>
     <string name="squeezer_no_example_found">തിരഞ്ഞെടുത്ത പാതകളിൽ ചിത്രങ്ങൾ കണ്ടെത്തിയില്ല.</string>
     <string name="squeezer_result_empty_message">കംപ്രസ്സ് ചെയ്യാവുന്ന മീഡിയ ഒന്നും കണ്ടെത്തിയില്ല.</string>
-    <string name="squeezer_setup_warning">കംപ്രഷൻ സ്ഥിരമായി ഗുണമേൻമ കുറക്കുന്നു, സ്റ്റോറേജ് സ്പേസ് ലാഭിക്കാൻ. ഇത് പഴേ നിലയിലാക്കാൻ കഴിയില്ല. തുടങ്ങുന്നതിന് മുമ്പ് ക്രമീകരണങ്ങൾ ശ്രദ്ധാപൂർവ്വം പരിശോധിക്കുക.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">കംപ്രഷനായി %d സ്ഥാനം ഉപയോഗിക്കാനാകില്ല, അത് നീക്കം ചെയ്തു. കംപ്രഷന് ആന്തരിക സ്റ്റോറേജിലേക്ക് നേരിട്ടുള്ള ആക്സസ് ആവശ്യമാണ്.</item>
         <item quantity="other">കംപ്രഷനായി %d സ്ഥാനങ്ങൾ ഉപയോഗിക്കാനാകില്ല, അവ നീക്കം ചെയ്തു. കംപ്രഷന് ആന്തരിക സ്റ്റോറേജിലേക്ക് നേരിട്ടുള്ള ആക്സസ് ആവശ്യമാണ്.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">കുറഞ്ഞത് %d ദിവസം പഴക്കമുള്ളത്</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG ഫയലുകൾക്കായി കണക്കാക്കിയ ~%d%% ലാഭം</string>
-    <string name="squeezer_onboarding_got_it">മനസ്സിലായി</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer നിങ്ങളുടെ ഫോട്ടോകളും വീഡിയോകളും വീണ്ടും കംപ്രസ്സ് ചെയ്യുന്നതിനാൽ അവ കുറഞ്ഞ സ്ഥലം ഉപയോഗിക്കുന്നു. നിങ്ങൾക്ക് ലഭിക്കുന്ന സ്ഥലത്തിനായി അൽപ്പ ഗുണനിലവാരം കൈമാറുന്നു. ഓരോ ഇനവും അതിന്റെ കണക്കാക്കിയ ലാഭം കാണിക്കുന്നതിനാൽ, എന്താണ് മൂല്യവത്തെന്ന് നിങ്ങൾക്ക് തീരുമാനിക്കാനാകും.</string>
     <string name="tour_squeezer_compress_body">ഇവിടെ ഒരേസമയം എല്ലാം കംപ്രസ് ചെയ്യുക, അല്ലെങ്കിൽ ഒറ്റ ഇനത്തിൽ ടാപ്പ് ചെയ്ത് അത് മാത്രം ചെറുതാക്കുക. പലതും തിരഞ്ഞെടുക്കാൻ ദീർഘനേരം അമർത്തുക. എന്തെങ്കിലും മാറുന്നതിന് മുൻപ് നിങ്ങൾ എപ്പോഴും ഒരു പ്രിവ്യൂ കാണും.</string>

--- a/app-tool-squeezer/src/main/res/values-mn-rMN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-mn-rMN/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Файлын деэд нас</string>
     <string name="squeezer_min_age_description">Зөвхөн энэ насаас ахмад файлуудыг оруулна.</string>
     <string name="squeezer_compression_settings_label">Ерөнхий</string>
-    <string name="squeezer_quality_label">Чанар</string>
-    <string name="squeezer_quality_title">Шахалтын чанар</string>
     <string name="squeezer_quality_description">Чанар бага байх нь файлын хэмжээ жижиг боловч харагдах чанар буурна.</string>
-    <string name="squeezer_quality_example_format">Жишээ: %1$s зураг → %3$d%% чанарт ойроор ~%2$s хадгалалана</string>
-    <string name="squeezer_quality_warning_low">Дородуу чанар харагдсан алдаа үүсгэх боломжтой.</string>
-    <string name="squeezer_quality_warning_high">Маш өндөр чанар нь зайны олзолт хадгалалт цөөн байна.</string>
     <string name="squeezer_types_category_label">Зургийн тохиргоо</string>
     <string name="squeezer_video_settings_category_label">Видеоны тохиргоо</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Шахалтыг баталгаажуулах</string>
     <string name="squeezer_preview_total_size">Нийт хэмжээ</string>
     <string name="squeezer_preview_estimated_savings">Төсөөлдсөн хадгалалт</string>
-    <string name="squeezer_compress_confirmation_title">Сонгосон зүйлсийг шахах уу?</string>
-    <string name="squeezer_compress_confirmation_message">Энэ нь анхны файлуудыг шахагдсан хувилбараар солих болно. Энэ үйлдлийг буцаах боломжгүй.</string>
     <string name="squeezer_history_title">Шахалтын түүх</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d зүйл (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Шахалтын түүх байхгүй</string>
     <string name="squeezer_history_clear_title">Шахалтын түүхийг арилгах</string>
     <string name="squeezer_history_clear_message">Энэ нь өмнө нь шахагдсан файлуудыг дахин шахах боломжтой болгоно. Файлуудад өөрчлөлт ороогүй.</string>
-    <string name="squeezer_onboarding_title">Зураг шахалтын тухай</string>
-    <string name="squeezer_onboarding_message">Зураг шахалт нь хараахад дэталгыг арилгаснаар файлын хэмжээг багасгана. Энэ ургшийлах боломжгүй явц — эх чанарыг сэргээх боломжгүй.\n\nТаны зурагууд хэрхэн харагдахыг үзүүлэхэд үз:</string>
     <string name="squeezer_onboarding_original_label">Эх</string>
     <string name="squeezer_onboarding_compressed_label">Шахаасны дараа</string>
     <string name="squeezer_onboarding_video_original_label">Видео фрэйм</string>
     <string name="squeezer_onboarding_video_compressed_label">Урьдчилан харах (ойролцоогоор)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Бодит видеоны чанар өөр байж болно</string>
-    <string name="squeezer_onboarding_quality_label">Чанар: %d%%</string>
     <string name="squeezer_compare_action">Харьцуулга үзэх</string>
     <string name="squeezer_no_example_found">Сонгосон замуудаас зураг олдсонгүй.</string>
     <string name="squeezer_result_empty_message">Шахах боломжтой медиа олдсонгүй.</string>
-    <string name="squeezer_setup_warning">Шахалт нь санах ойн зайг хэмнэхийн тулд чанарыг байнгын бууруулна. Үүнийг буцаах боломжгүй. Эхлэхийн өмнө тохиргоогоо сайтар хянана уу.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d байршлыг шахахад ашиглах боломжгүй тул устгагдлаа. Шахалт нь дотоод санах ойд шууд хандахыг шаардадаг.</item>
         <item quantity="other">%d байршлыг шахахад ашиглах боломжгүй тул устгагдлаа. Шахалт нь дотоод санах ойд шууд хандахыг шаардадаг.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Дорроо %d өдөөсийн</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG файлуудын хувьд тооцоолсон ~%d%% хэмнэлт</string>
-    <string name="squeezer_onboarding_got_it">Ойлголоо</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer таны зургууд болон видеоуудыг дахин шахаж, тэдгээр нь бага орон зай эзэлнэ. Та чанарын нэг хэсэгийг буцаан авсан орон зайтай солилцож байна. Зүйл бүр сэргээсэн хэмжээг харуулдаг тул та аль нь үнэтэй гэж шийдэх боломжтой.</string>
     <string name="tour_squeezer_compress_body">Бүгдийг нэг дор энд шахаж, эсвэл нэг зүйлийг дарж зөвхөн түүнийг л жижигрүүлнэ. Олоныг сонгохын тулд удаан дар. Аливаа зүйл өөрчлөгдөхөөс өмнө үргэлж урьдчилсан үзүүлэлтийг харах болно.</string>

--- a/app-tool-squeezer/src/main/res/values-ms/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ms/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">Umur fail minimum</string>
     <string name="squeezer_min_age_description">Hanya sertakan fail yang lebih lama daripada umur ini.</string>
     <string name="squeezer_compression_settings_label">Umum</string>
-    <string name="squeezer_quality_label">Kualiti</string>
-    <string name="squeezer_quality_title">Kualiti mampatan</string>
     <string name="squeezer_quality_description">Kualiti lebih rendah bermaksud saiz fail lebih kecil tetapi kualiti visual berkurangan.</string>
-    <string name="squeezer_quality_example_format">Contoh: %1$s imej → jimat ~%2$s pada kualiti %3$d%%</string>
-    <string name="squeezer_quality_warning_low">Kualiti rendah mungkin menyebabkan artifak yang kelihatan.</string>
-    <string name="squeezer_quality_warning_high">Kualiti sangat tinggi memberikan penjimatan ruang yang minimum.</string>
     <string name="squeezer_types_category_label">Tetapan imej</string>
     <string name="squeezer_video_settings_category_label">Tetapan video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">Sahkan pemampatan</string>
     <string name="squeezer_preview_total_size">Jumlah saiz</string>
     <string name="squeezer_preview_estimated_savings">Anggaran penjimatan</string>
-    <string name="squeezer_compress_confirmation_title">Mampatkan item yang dipilih?</string>
-    <string name="squeezer_compress_confirmation_message">Ini akan menggantikan fail asal dengan versi yang dimampatkan. Tindakan ini tidak boleh dibatalkan.</string>
     <string name="squeezer_history_title">Sejarah pemampatan</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d item (%2$s)</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">Tiada sejarah pemampatan</string>
     <string name="squeezer_history_clear_title">Kosongkan sejarah pemampatan</string>
     <string name="squeezer_history_clear_message">Ini akan membenarkan fail yang telah dimampatkan sebelum ini untuk dimampatkan semula. Fail itu sendiri tidak terjejas.</string>
-    <string name="squeezer_onboarding_title">Tentang Pemampatan Imej</string>
-    <string name="squeezer_onboarding_message">Pemampatan imej mengurangkan saiz fail dengan mengalih keluar butiran visual. Proses ini tidak boleh dibalikkan - kualiti asal tidak boleh dipulihkan.\n\nBerikut ialah pratonton bagaimana imej anda akan kelihatan:</string>
     <string name="squeezer_onboarding_original_label">Asal</string>
     <string name="squeezer_onboarding_compressed_label">Selepas pemampatan</string>
     <string name="squeezer_onboarding_video_original_label">Bingkai video</string>
     <string name="squeezer_onboarding_video_compressed_label">Pratonton (anggaran)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Kualiti video sebenar mungkin berbeza</string>
-    <string name="squeezer_onboarding_quality_label">Kualiti: %d%%</string>
     <string name="squeezer_compare_action">Lihat perbandingan</string>
     <string name="squeezer_no_example_found">Tiada imej dijumpai di laluan yang dipilih.</string>
     <string name="squeezer_result_empty_message">Tiada media yang boleh dimampatkan ditemui.</string>
-    <string name="squeezer_setup_warning">Pemampatan mengurangkan kualiti secara kekal untuk menjimatkan ruang storan. Ini tidak boleh dibatalkan. Semak tetapan anda dengan teliti sebelum memulakan.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">%d lokasi tidak boleh digunakan untuk pemampatan dan telah dikeluarkan. Pemampatan memerlukan akses terus ke storan dalaman.</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">Sekurang-kurangnya %d hari</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Anggaran ~%d%% penjimatan untuk fail JPEG</string>
-    <string name="squeezer_onboarding_got_it">Faham</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer memampatkan semula foto dan video anda supaya ia mengambil ruang yang lebih sedikit. Anda mengorbankan sedikit kualiti untuk ruang yang anda dapat kembali. Setiap item menunjukkan anggaran simpanan, jadi anda boleh memutuskan apa yang berbaloi.</string>
     <string name="tour_squeezer_compress_body">Mampatkan semuanya sekali gus di sini, atau ketuk satu item untuk mengecilkan hanya itu sahaja. Tekan lama untuk memilih beberapa. Anda akan sentiasa melihat pratonton sebelum sesuatu berubah.</string>

--- a/app-tool-squeezer/src/main/res/values-my-rMM/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-my-rMM/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">အနည်းဆုံး ဖိုင်သက်တမ်း</string>
     <string name="squeezer_min_age_description">ဤသက်တမ်းထက် ဟောင်းသောဖိုင်များသာ ထည့်သွင်းပါ။</string>
     <string name="squeezer_compression_settings_label">ယေဘူယျ</string>
-    <string name="squeezer_quality_label">အရည်အသွေး</string>
-    <string name="squeezer_quality_title">ချုံ့မှု အရည်အသွေး</string>
     <string name="squeezer_quality_description">အရည်အသွေး နည်းလေ ဖိုင်အရွယ်အစား သေးလေ သို့သော်လည်း မြင်နိုင်သောအရည်အသွေး ကျဆင်းသွားမည်။</string>
-    <string name="squeezer_quality_example_format">ဥပမာ - %1$s ပုံ → %3$d%% အရည်အသွေးတွင် ~%2$s ချွေတာနိုင်သည်</string>
-    <string name="squeezer_quality_warning_low">အရည်အသွေး နည်းသည့်က မြင်ရနိုင်သော ချို့ပျက်ချက်များ ဖြစ်ပော်နိုင်သည်။</string>
-    <string name="squeezer_quality_warning_high">အလွန် မြင့်မားသော အရည်အသွေးသည် နေရာချွေတာမှု အနည်းဆုံးသာသာ ပေးသည်။</string>
     <string name="squeezer_types_category_label">ပုံဆက်တင်များ</string>
     <string name="squeezer_video_settings_category_label">ဗီဒီယိုဆက်တင်များ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">ချုံ့ခြင်း အတည်ပြုရန်</string>
     <string name="squeezer_preview_total_size">စုစုပေါင်း အရွယ်အစား</string>
     <string name="squeezer_preview_estimated_savings">ခန့်မှန်းသော သက်သာမှု</string>
-    <string name="squeezer_compress_confirmation_title">ရွေးချယ်ထားသောအရာများကို ချုံ့မည်လား?</string>
-    <string name="squeezer_compress_confirmation_message">ဤလုပ်ဆောင်ချက်သည် မူရင်းဖိုင်များကို ချုံ့ထားသောဗားရှင်းများဖြင့် အစားထိုးမည်။ ဤလုပ်ဆောင်ချက်ကို နောက်ကြောင်းပြောင်း၍ မရနိုင်ပါ။</string>
     <string name="squeezer_history_title">ချုံ့ခြင်း မှတ်တမ်း</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d ခု (%2$s)</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">ချုံ့ခြင်း မှတ်တမ်း မရှိပါ</string>
     <string name="squeezer_history_clear_title">ချုံ့ခြင်း မှတ်တမ်း သန့်သင်းရန်</string>
     <string name="squeezer_history_clear_message">ဤလုပ်ဆောင်ချက်သည် ယခင်ချုံ့ပြီးသောဖိုင်များကို ထပ်မံချုံ့နိုင်ရန် ခွင့်ပြုမည်။ ဖိုင်များကိုယ်တိုင် မထိခိုက်ပါ။</string>
-    <string name="squeezer_onboarding_title">ပုံချုံ့ခြင်း အကြောင်း</string>
-    <string name="squeezer_onboarding_message">ပုံချုံ့ခြင်းသည် ဗျင်ပါးချုံ့ခြင်းဖြင့် ပုံဖိုင်အရွယ်အစားကို လျှော့ချသည်။ ဤလုပ်ဆောင်ချက်ကို ပြန်ဆွဲ၍မရ၊ မူရင်းပန်ဆွဲကို ပြန်ယူ၍မရနိုင်ပါ။\n\nသင်လာရပုံများကို မည်သို့မည်သို့:</string>
     <string name="squeezer_onboarding_original_label">မူရင်း</string>
     <string name="squeezer_onboarding_compressed_label">ချုံ့ပြီးသည်နောက်</string>
     <string name="squeezer_onboarding_video_original_label">ဗီဒီယိုဘောင်</string>
     <string name="squeezer_onboarding_video_compressed_label">အစမ်းကြည့်ရှုခြင်း (ခန့်မှန်းချက်)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">တကယ့်ဗီဒီယိုအရည်အသွေး ကွဲပြာရနိုင်သည်</string>
-    <string name="squeezer_onboarding_quality_label">အစနအစား: %d%%</string>
     <string name="squeezer_compare_action">နှိုင်းယှဉ်ချက် ကြည့်ရန်</string>
     <string name="squeezer_no_example_found">ရွေးချယ်ထားသောလမ်းများတွင် ပုံများ မရှိပါ။</string>
     <string name="squeezer_result_empty_message">ချုံ့နိုင်သောမီဒီယို မတွေ့ရှိပါ။</string>
-    <string name="squeezer_setup_warning">ချုံ့ခြင်းသည် သိုလှောင်မှုနေရာကို သက်သာစေရန် အရည်အသွေးကို ဆက်တိုက်လျှော့ချသည်။ ဤလုပ်ဆောင်ချက်ကို နောက်ကြောင်းပြောင်း၍ မရနိုင်ပါ။ စတင်မတိုင်မအစား သင်သောဆက်တင်များကို သေချားသေးသေးသေခြည့်ပါ။</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">%d တည်နေရာ(များ)ကို ချုံ့ရန် အသုံးမပြုသောကြောင် ဖယ်ရှားလိုက်သည်။ ချုံ့ခြင်းသည် အတွင်သိုလှောင်သို့ဆိုသို တိုက်ရိုက်ခွင့်ပြု လိုအပ်သည်။</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">အနည်းဆုံး %d ရက် အနည်းဆုံးသား</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG ဖိုင်များအတွက် အကြမ်းဖြင်း ~%d%% လျှော့ချမှု</string>
-    <string name="squeezer_onboarding_got_it">နား လည်ပါပြီ</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer သည် သင်၏ ဓာတ်ပုံများ နှင့် ဗီဒီယိုများကို ပြန်လည်ချုံ့ပေးသည်။ အရည်အသွေးအနည်းငယ်ကို လဲလှယ်ပြီး နေရာများ ရယူသည်။ ပစ္စည်းတစ်ခုစီသည် ခန့်မှန်းအားဖြင့် သိမ်းဆည်းမည့်အရာ ကိုပြသသည်။ သင်သည် တန်ဖိုးကျသောအရာ ကိုသုံးသပ်နိုင်သည်။</string>
     <string name="tour_squeezer_compress_body">ဤနေရာတွင် အားလုံးကို တစ်ကြိမ်တည်းချုပ်တည်းသည်။ သို့မဟုတ် တစ်ခုတည်းလျှော့ချရန် တစ်ခုကို တို့ခြင်း။ အများအပြားရွေးချယ်ရန်အတွက် ကြာပိုက်နှိပ်ခြင်း။ မည်သည့်အရာမျိုးပြောင်းလဲမည့်တိုင် အစီအစဉ်ကို အမြဲမြင်နိုင်သည်။</string>

--- a/app-tool-squeezer/src/main/res/values-nb/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-nb/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Minste filens alder</string>
     <string name="squeezer_min_age_description">Ta bare med filer som er eldre enn denne alderen.</string>
     <string name="squeezer_compression_settings_label">Generelt</string>
-    <string name="squeezer_quality_label">Kvalitet</string>
-    <string name="squeezer_quality_title">Komprimeringskvalitet</string>
     <string name="squeezer_quality_description">Lavere kvalitet betyr mindre filstørrelse, men redusert visuell kvalitet.</string>
-    <string name="squeezer_quality_example_format">Eksempel: %1$s-bilde → sparer ~%2$s ved %3$d%% kvalitet</string>
-    <string name="squeezer_quality_warning_low">Lavere kvalitet kan forårsake synlige artefakter.</string>
-    <string name="squeezer_quality_warning_high">Svært høy kvalitet gir minimal plassbesparelse.</string>
     <string name="squeezer_types_category_label">Bildeinnstillinger</string>
     <string name="squeezer_video_settings_category_label">Videoinnstillinger</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Bekreft komprimering</string>
     <string name="squeezer_preview_total_size">Total størrelse</string>
     <string name="squeezer_preview_estimated_savings">Estimert besparelse</string>
-    <string name="squeezer_compress_confirmation_title">Komprimer valgte elementer?</string>
-    <string name="squeezer_compress_confirmation_message">Dette vil erstatte originalfiler med komprimerte versjoner. Denne handlingen kan ikke angres.</string>
     <string name="squeezer_history_title">Komprimeringshistorikk</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Ingen komprimeringshistorikk</string>
     <string name="squeezer_history_clear_title">Tøm komprimeringshistorikk</string>
     <string name="squeezer_history_clear_message">Dette vil tillate at tidligere komprimerte filer komprimeres på nytt. Selve filene påvirkes ikke.</string>
-    <string name="squeezer_onboarding_title">Om bildekomprimering</string>
-    <string name="squeezer_onboarding_message">Bildekomprimering reduserer filstørrelsen ved å fjerne visuelle detaljer. Denne prosessen er irreversibel – original kvalitet kan ikke gjenopprettes.\n\nHer er en forhåndsvisning av hvordan bildene dine vil se ut:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Etter komprimering</string>
     <string name="squeezer_onboarding_video_original_label">Videoramme</string>
     <string name="squeezer_onboarding_video_compressed_label">Forhåndsvisning (omtrentlig)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Faktisk videokvalitet kan variere</string>
-    <string name="squeezer_onboarding_quality_label">Kvalitet: %d%%</string>
     <string name="squeezer_compare_action">Vis sammenligning</string>
     <string name="squeezer_no_example_found">Ingen bilder funnet i valgte stier.</string>
     <string name="squeezer_result_empty_message">Ingen komprimerbare medier funnet.</string>
-    <string name="squeezer_setup_warning">Komprimering reduserer kvaliteten permanent for å spare lagringsplass. Dette kan ikke angres. Gå nøye gjennom innstillingene dine før du starter.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d sted kan ikke brukes til komprimering og ble fjernet. Komprimering krever direkte tilgang til intern lagring.</item>
         <item quantity="other">%d steder kan ikke brukes til komprimering og ble fjernet. Komprimering krever direkte tilgang til intern lagring.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Minst %d dager gammel</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Estimert ~%d%% besparelse for JPEG-filer</string>
-    <string name="squeezer_onboarding_got_it">Forstått</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer rekomprimerer bildene og videoene dine slik at de tar opp mindre plass. Du bytter litt kvalitet mot plassen du får tilbake. Hvert element viser sin estimerte besparelse, slik at du kan bestemme hva som er verdt det.</string>
     <string name="tour_squeezer_compress_body">Komprimer alt på en gang her, eller trykk på et enkelt element for å krympe bare det. Lang-trykk for å velge flere. Du vil alltid se en forhåndsvisning før noe endres.</string>

--- a/app-tool-squeezer/src/main/res/values-ne-rNP/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ne-rNP/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">न्यूनतम फाइल उमेर</string>
     <string name="squeezer_min_age_description">यो उमेरभन्दा पुराना फाइलहरू मात्र समावेश गर्नुहोस्।</string>
     <string name="squeezer_compression_settings_label">सामान्य</string>
-    <string name="squeezer_quality_label">गुणस्तर</string>
-    <string name="squeezer_quality_title">संकुचन गुणस्तर</string>
     <string name="squeezer_quality_description">कम गुणस्तरको अर्थ सानो फाइल आकार तर घटेको दृश्य गुणस्तर हो।</string>
-    <string name="squeezer_quality_example_format">उदाहरण: %1$s छवि → %3$d%% गुणस्तरमा ~%2$s बचत गर्छ</string>
-    <string name="squeezer_quality_warning_low">न्यून गुणस्तरले दृश्यमान कलाकृतिहरू निम्त्याउन सक्छ।</string>
-    <string name="squeezer_quality_warning_high">अत्यधिक उच्च गुणस्तरले न्यूनतम स्थान बचत प्रदान गर्छ।</string>
     <string name="squeezer_types_category_label">छवि सेटिङहरू</string>
     <string name="squeezer_video_settings_category_label">भिडियो सेटिङहरू</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">संकुचन पुष्टि गर्नुहोस्</string>
     <string name="squeezer_preview_total_size">कुल आकार</string>
     <string name="squeezer_preview_estimated_savings">अनुमानित बचत</string>
-    <string name="squeezer_compress_confirmation_title">चयन गरिएका वस्तुहरू सम्पीडन गर्ने?</string>
-    <string name="squeezer_compress_confirmation_message">यसले मूल फाइलहरूलाई सम्पीडन गरिएका संस्करणहरूले प्रतिस्थापन गर्नेछ। यो कार्य पूर्ववत् गर्न सकिँदैन।</string>
     <string name="squeezer_history_title">संकुचन इतिहास</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">1 वस्तु (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">कुनै संकुचन इतिहास छैन</string>
     <string name="squeezer_history_clear_title">संकुचन इतिहास सफा गर्नुहोस्</string>
     <string name="squeezer_history_clear_message">यसले पहिले सम्पीडन गरिएका फाइलहरूलाई फेरि सम्पीडन गर्न अनुमति दिनेछ। फाइलहरू आफैंमा प्रभावित हुँदैनन्।</string>
-    <string name="squeezer_onboarding_title">छवि संकुचन बारे</string>
-    <string name="squeezer_onboarding_message">छवि संकुचनले दृश्य विवरण हटाेर फाइल आकार घटाउँछ। यो प्रक्रिया अपरिवर्तनीय छ - मूल गुणस्तर पुनः स्थापन गर्न सकिँदैन।\n\nतपाईंका छविहरू कस्तो देखिनेछन् भन्ने पूर्वावलोकन:</string>
     <string name="squeezer_onboarding_original_label">मूल</string>
     <string name="squeezer_onboarding_compressed_label">संकुचनपछि</string>
     <string name="squeezer_onboarding_video_original_label">भिडियो फ्रेम</string>
     <string name="squeezer_onboarding_video_compressed_label">पूर्वावलोकन (अनुमानित)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">वास्तविक भिडियो गुणस्तर फरक हुन सक्छ</string>
-    <string name="squeezer_onboarding_quality_label">गुणस्तर: %d%%</string>
     <string name="squeezer_compare_action">तुलना हेर्नुहोस्</string>
     <string name="squeezer_no_example_found">चयनित पाथहरूमा कुनै छवि फेला परेन।</string>
     <string name="squeezer_result_empty_message">कुनै सम्पीडन गर्न मिल्ने मिडिया फेला परेन।</string>
-    <string name="squeezer_setup_warning">सम्पीडनले भण्डारण स्थान बचत गर्न गुणस्तर स्थायी रूपमा घटाउँछ। यो पूर्ववत् गर्न सकिँदैन। सुरु गर्नुअघि आफ्नो सेटिङहरू ध्यानपूर्वक समीक्षा गर्नुहोस्।</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d स्थान सम्पीडनका लागि प्रयोग गर्न सकिँदैन र हटाइयो। सम्पीडनका लागि आन्तरिक भण्डारणमा प्रत्यक्ष पहुँच आवश्यक छ।</item>
         <item quantity="other">%d स्थानहरू सम्पीडनका लागि प्रयोग गर्न सकिँदैन र हटाइए। सम्पीडनका लागि आन्तरिक भण्डारणमा प्रत्यक्ष पहुँच आवश्यक छ।</item>
@@ -109,7 +98,6 @@
         <item quantity="other">कम्तिमा %d दिन पुरानो</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG फाइलहरूको लागि अनुमानित ~%d%% बचत</string>
-    <string name="squeezer_onboarding_got_it">ठिक छ</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer तपाईंको फोटो र भिडियोहरूलाई पुनः संकुचित गर्दछ ताकि तिनीहरूले कम स्थान लिनू पर्छ। तपाईंले अलिकति गुणस्तर गुमाएर ठाउँ पाउनु हुन्छ। प्रत्येक वस्तुले यसको अनुमानित बचत देखाउछ, त्यसैले तपाईं निर्णय गर्न सक्नुहुन्छ कि कुन लायक छ।</string>
     <string name="tour_squeezer_compress_body">सबै कुरा एक साथ यहाँ संपीडन गर्नुहोस्, वा एकल वस्तुमा ट्याप गर्नुहोस् केवल त्यसलाई सानो गर्न। बहुविध छनौट गर्न लामो दबाउनुहोस्। तपाईंले सधैं कुनै पनि परिवर्तन हुनु अघि पूर्वावलोकन देख्नुहुनेछ।</string>

--- a/app-tool-squeezer/src/main/res/values-nl/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-nl/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Minimale bestandsleeftijd</string>
     <string name="squeezer_min_age_description">Neem alleen bestanden op die ouder zijn dan deze leeftijd.</string>
     <string name="squeezer_compression_settings_label">Algemeen</string>
-    <string name="squeezer_quality_label">Kwaliteit</string>
-    <string name="squeezer_quality_title">Compressiekwaliteit</string>
     <string name="squeezer_quality_description">Een lagere kwaliteit betekent een kleinere bestandsgrootte, maar een verminderde beeldkwaliteit.</string>
-    <string name="squeezer_quality_example_format">Voorbeeld: %1$s afbeelding → bespaart ~%2$s bij %3$d%% kwaliteit</string>
-    <string name="squeezer_quality_warning_low">Lagere kwaliteiten kunnen zichtbare artefacten veroorzaken.</string>
-    <string name="squeezer_quality_warning_high">Zeer hoge kwaliteit biedt minimale ruimtebesparing.</string>
     <string name="squeezer_types_category_label">Afbeeldingsinstellingen</string>
     <string name="squeezer_video_settings_category_label">Video-instellingen</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Compressie bevestigen</string>
     <string name="squeezer_preview_total_size">Totale grootte</string>
     <string name="squeezer_preview_estimated_savings">Geschatte besparing</string>
-    <string name="squeezer_compress_confirmation_title">Geselecteerde items comprimeren?</string>
-    <string name="squeezer_compress_confirmation_message">Dit vervangt originele bestanden door gecomprimeerde versies. Deze actie kan niet ongedaan worden gemaakt.</string>
     <string name="squeezer_history_title">Compressiegeschiedenis</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d item (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Geen compressiegeschiedenis</string>
     <string name="squeezer_history_clear_title">Compressiegeschiedenis wissen</string>
     <string name="squeezer_history_clear_message">Dit maakt het mogelijk om eerder gecomprimeerde bestanden opnieuw te comprimeren. De bestanden zelf worden niet beïnvloed.</string>
-    <string name="squeezer_onboarding_title">Over beeldcompressie</string>
-    <string name="squeezer_onboarding_message">Beeldcompressie verkleint het bestand door visueel detail te verwijderen. Dit proces is onomkeerbaar - de originele kwaliteit kan niet worden hersteld.\n\nHier is een voorbeeld van hoe je afbeeldingen eruit zullen zien:</string>
     <string name="squeezer_onboarding_original_label">Origineel</string>
     <string name="squeezer_onboarding_compressed_label">Na compressie</string>
     <string name="squeezer_onboarding_video_original_label">Videoframe</string>
     <string name="squeezer_onboarding_video_compressed_label">Voorbeeld (bij benadering)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Werkelijke videokwaliteit kan afwijken</string>
-    <string name="squeezer_onboarding_quality_label">Kwaliteit: %d%%</string>
     <string name="squeezer_compare_action">Bekijk de vergelijking</string>
     <string name="squeezer_no_example_found">Geen afbeeldingen gevonden in geselecteerde paden.</string>
     <string name="squeezer_result_empty_message">Geen comprimeerbare media gevonden.</string>
-    <string name="squeezer_setup_warning">Compressie vermindert de kwaliteit permanent om opslagruimte te besparen. Dit kan niet ongedaan worden gemaakt. Controleer je instellingen zorgvuldig voor je begint.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d locatie kan niet worden gebruikt voor compressie en is verwijderd. Compressie vereist directe toegang tot de interne opslag.</item>
         <item quantity="other">%d locaties kunnen niet worden gebruikt voor compressie en zijn verwijderd. Compressie vereist directe toegang tot de interne opslag.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Minstens %d dagen oud</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Geschatte ~%d%% besparing voor JPEG-bestanden</string>
-    <string name="squeezer_onboarding_got_it">Begrepen</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer comprimeert je foto\'s en video\'s opnieuw zodat ze minder ruimte innemen. Je ruilt een beetje kwaliteit in voor de ruimte die je terugkrijgt. Elk item toont de geschatte besparing, zodat je kunt beslissen wat het waard is.</string>
     <string name="tour_squeezer_compress_body">Comprimeer hier alles tegelijk, of tik op een enkel item om alleen dat item te verkleinen. Lange druk om meerdere items te selecteren. Je ziet altijd een voorbeeld voordat iets verandert.</string>

--- a/app-tool-squeezer/src/main/res/values-or-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-or-rIN/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">ସର୍ବନିମ୍ନ ଫାଇଲ୍ ବୟସ</string>
     <string name="squeezer_min_age_description">କେବଳ ଏହି ବୟସରୁ ପୁରୁଣା ଫାଇଲ ଅନ୍ତର୍ଭୁକ୍ତ କରନ୍ତୁ।</string>
     <string name="squeezer_compression_settings_label">ସାଧାରଣ</string>
-    <string name="squeezer_quality_label">ଗୁଣବତ୍ତା</string>
-    <string name="squeezer_quality_title">ସଙ୍କୋଚନ ଗୁଣବତ୍ତା</string>
     <string name="squeezer_quality_description">କମ ଗୁଣମାନ ମାନେ ଛୋଟ ଫାଇଲ ଆକାର କିନ୍ତୁ ଦୃଶ୍ୟ ଗୁଣମାନ ହ୍ରାସ ପାଏ।</string>
-    <string name="squeezer_quality_example_format">ଉଦାହରଣ: %1$s ଚିତ୍ର → %3$d%% ଗୁଣବତ୍ତାରେ ~%2$s ସଞ୍ଚୟ</string>
-    <string name="squeezer_quality_warning_low">କମ୍ ଗୁଣବତ୍ତା ଦୃଶ୍ୟମାନ ତ୍ରୁଟି ସୃଷ୍ଟି କରିପାରେ।</string>
-    <string name="squeezer_quality_warning_high">ଅତ୍ୟଧିକ ଉଚ୍ଚ ଗୁଣବତ୍ତା ସର୍ବନିମ୍ନ ସ୍ଥାନ ସଞ୍ଚୟ ପ୍ରଦାନ କରେ।</string>
     <string name="squeezer_types_category_label">ଚିତ୍ର ସେଟିଂସ</string>
     <string name="squeezer_video_settings_category_label">ଭିଡ଼ିଓ ସେଟିଂସ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">ସଙ୍କୋଚନ ନିଶ୍ଚିତ କରନ୍ତୁ</string>
     <string name="squeezer_preview_total_size">ମୋଟ ଆକାର</string>
     <string name="squeezer_preview_estimated_savings">ଆନୁମାନିକ ସଞ୍ଚୟ</string>
-    <string name="squeezer_compress_confirmation_title">ମନୋନୀତ ଆଇଟମ ସଙ୍କୁଚିତ କରିବେ?</string>
-    <string name="squeezer_compress_confirmation_message">ଏହା ମିଳ ଫାଇଲ ସ୍ଥାନରେ ସଙ୍କୁଚିତ ସଂସ୍କରଣ ରଖିବ। ଏହି କ୍ରିୟା ପୂର୍ବବତ୍ ହୋଇ ପାରିବ ନାହିଁ।</string>
     <string name="squeezer_history_title">ସଙ୍କୋଚନ ଇତିହାସ</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ଆଇଟମ୍ (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">କୌଣସି ସଙ୍କୋଚନ ଇତିହାସ ନାହିଁ</string>
     <string name="squeezer_history_clear_title">ସଙ୍କୋଚନ ଇତିହାସ ସଫା କରନ୍ତୁ</string>
     <string name="squeezer_history_clear_message">ଏହା ପୂର୍ବରୁ ସଙ୍କୁଚିତ ଫାଇଲ ପୁଣି ସଙ୍କୁଚିତ ହେବାର ସୁୟୋଗ ଦେବ। ଫାଇଲ ନିଜେ ପ୍ରଭାଵିତ ହୁଏ ନାହିଁ।</string>
-    <string name="squeezer_onboarding_title">ଚିତ୍ର ସଙ୍କୋଚନ ବିଷୟରେ</string>
-    <string name="squeezer_onboarding_message">ଚିତ୍ର ସଙ୍କୋଚନ ଦୃଶ୍ୟ ବିବରଣୀ ଅପସାରଣ କରି ଫାଇଲ୍ ଆକାର ହ୍ରାସ କରେ। ଏହି ପ୍ରକ୍ରିୟା ଅପ୍ରତ୍ୟାବର୍ତ୍ତନୀୟ - ମୂଳ ଗୁଣବତ୍ତା ପୁନଃସ୍ଥାପିତ ହୋଇପାରିବ ନାହିଁ।\n\nଆପଣଙ୍କ ଚିତ୍ରଗୁଡିକ କିପରି ଦେଖାଯିବ ତାହାର ଏକ ପୂର୍ବାବଲୋକନ ଏଠାରେ ଅଛି:</string>
     <string name="squeezer_onboarding_original_label">ମୂଳ</string>
     <string name="squeezer_onboarding_compressed_label">ସଙ୍କୋଚନ ପରେ</string>
     <string name="squeezer_onboarding_video_original_label">ଭିଡ଼ିଓ ଫ୍ରେମ</string>
     <string name="squeezer_onboarding_video_compressed_label">ପୂର୍ବାବଲୋକନ (ଆନୁମାନିକ)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">ପ୍ରକୃତ ଭିଡ଼ିଓ ଗୁଣମାନ ଭିନ୍ନ ହୋଇ ପାରେ</string>
-    <string name="squeezer_onboarding_quality_label">ଗୁଣବତ୍ତା: %d%%</string>
     <string name="squeezer_compare_action">ତୁଳନା ଦେଖନ୍ତୁ</string>
     <string name="squeezer_no_example_found">ଚୟନ ହୋଇଥିବା ପଥରେ କୌଣସି ଚିତ୍ର ମିଳିଲା ନାହିଁ।</string>
     <string name="squeezer_result_empty_message">କୌଣସି ସଙ୍କୁଚିତ ଯୋଗ୍ୟ ମିଡ଼ିଆ ମିଳିଲା ନାହିଁ।</string>
-    <string name="squeezer_setup_warning">ସଙ୍କୋଚନ ଷ୍ଟୋରେଜ ସ୍ଥାନ ସଞ୍ଚୟ କରିବାକୁ ଗୁଣମାନ ସ୍ଥାୟୀଭାବେ ହ୍ରାସ କରେ। ଏହା ପୂର୍ବବତ୍ ହୋଇ ପାରିବ ନାହିଁ। ଆରମ୍ଭ କରିବା ପୂର୍ବରୁ ଆପଣଙ୍କ ସେଟିଂସ ୟତ୍ନ ସହ ୟାଞ୍ଚ କରନ୍ତୁ।</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d ଅବସ୍ଥାନ ସଙ୍କୋଚନ ପାଇଁ ବ୍ୟବହାର ହୋଇ ପାରିବ ନାହିଁ ଏବଂ ହଟାଇ ଦିଆଗଲା। ସଙ୍କୋଚନ ପାଇଁ ଆଭ୍ୟନ୍ତରୀଣ ଷ୍ଟୋରେଜରେ ସିଧା ପ୍ରବେଶ ଆବଶ୍ୟକ।</item>
         <item quantity="other">%d ଅବସ୍ଥାନ ସଙ୍କୋଚନ ପାଇଁ ବ୍ୟବହାର ହୋଇ ପାରିବ ନାହିଁ ଏବଂ ହଟାଇ ଦିଆଗଲା। ସଙ୍କୋଚନ ପାଇଁ ଆଭ୍ୟନ୍ତରୀଣ ଷ୍ଟୋରେଜରେ ସିଧା ପ୍ରବେଶ ଆବଶ୍ୟକ।</item>
@@ -109,7 +98,6 @@
         <item quantity="other">ଅତିକମରେ %d ଦିନ ପୁରୁଣା</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG ଫାଇଲଗୁଡ଼ିକ ପାଇଁ ଅନୁମାନିତ ~%d%% ସଞ୍ଚୟ</string>
-    <string name="squeezer_onboarding_got_it">ବୁଝିଗଲି</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer ଆପଣଙ୍କର ଫଟୋ ଏବଂ ଭିଡିଓଗୁଡ଼ିକୁ ପୁନଃ-ସଙ୍କୋଚିତ କରେ ଯାହାଫଳରୁ ସେଗୁଡ଼ିକ କମ ସ୍ଥାନ ନିଏ। ଆପଣ ଯେ ସ୍ଥାନ ଫେରି ପାଆନ୍ତି ସେଥିପାଇଁ ଟିକେ ଗୁଣମାନ ବିନିମୟ କରନ୍ତି। ପ୍ରତ୍ୟେକ ବସ୍ତୁ ଏହାର ଅନୁମାନିତ ସଞ୍ଚୟ ଦେଖାଏ, ତେଣୁ ଆପଣ ଚୟନ କରିପାରିବେ ଏଟି ସାର୍ଥକ ଅଥବା ନୁହେଁ।</string>
     <string name="tour_squeezer_compress_body">ଏଠାରେ ସବୁକିଛୁ ଏକ ସାଥେ ସଙ୍କୋଚନ କରନ୍ତୁ, ବା କେବଳ ସେହି ଏକଟିକୁ ସଙ୍କୋଚନ କରିବାକୁ ଏକ ବସ୍ତୁ ଟ୍ୟାପ କରନ୍ତୁ। ଅନେକଟି ବାଛିବାକୁ ଦୀର୍ଘ-ପ୍ରେସ କରନ୍ତୁ। କୌଣସି ପରିବର୍ତନ ହେବାର ଆଗରୁ ଆପଣ ସର୍ବଦା ପୂର୍ବାବଲୋକନ ଦେଖିବେ।</string>

--- a/app-tool-squeezer/src/main/res/values-pa-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-pa-rIN/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">ਘੱਟੋ-ਘੱਟ ਫਾਈਲ ਉਮਰ</string>
     <string name="squeezer_min_age_description">ਸਿਰਫ਼ ਇਸ ਉਮਰ ਤੋਂ ਪੁਰਾਣੀਆਂ ਫਾਈਲਾਂ ਸ਼ਾਮਲ ਕਰੋ।</string>
     <string name="squeezer_compression_settings_label">ਆਮ</string>
-    <string name="squeezer_quality_label">ਗੁਣਵੱਤਾ</string>
-    <string name="squeezer_quality_title">ਕੰਪ੍ਰੈਸ਼ਨ ਗੁਣਵੱਤਾ</string>
     <string name="squeezer_quality_description">ਘੱਟ ਗੁਣਵੱਤਾ ਦਾ ਮਤਲਬ ਹੈ ਛੋਟਾ ਫਾਈਲ ਆਕਾਰ ਪਰ ਘੱਟ ਵਿਜ਼ੂਅਲ ਗੁਣਵੱਤਾ।</string>
-    <string name="squeezer_quality_example_format">ਉਦਾਹਰਨ: %1$s ਤਸਵੀਰ → %3$d%% ਗੁਣਵੱਤਾ \'ਤੇ ~%2$s ਬਚਤ</string>
-    <string name="squeezer_quality_warning_low">ਘੱਟ ਗੁਣਵੱਤਾ ਦਿਖਾਈ ਦੇਣ ਵਾਲੀਆਂ ਖਾਮੀਆਂ ਪੈਦਾ ਕਰ ਸਕਦੀ ਹੈ।</string>
-    <string name="squeezer_quality_warning_high">ਬਹੁਤ ਉੱਚੀ ਗੁਣਵੱਤਾ ਘੱਟ ਥਾਂ ਬਚਾਉਂਦੀ ਹੈ।</string>
     <string name="squeezer_types_category_label">ਚਿੱਤਰ ਸੈਟਿੰਗਾਂ</string>
     <string name="squeezer_video_settings_category_label">ਵੀਡੀਓ ਸੈਟਿੰਗਾਂ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">ਕੰਪ੍ਰੈਸ਼ਨ ਦੀ ਪੁਸ਼ਟੀ ਕਰੋ</string>
     <string name="squeezer_preview_total_size">ਕੁੱਲ ਆਕਾਰ</string>
     <string name="squeezer_preview_estimated_savings">ਅੰਦਾਜ਼ਨ ਬੱਚਤ</string>
-    <string name="squeezer_compress_confirmation_title">ਚੁਣੀਆਂ ਗਈਆਂ ਆਈਟਮਾਂ ਕੰਪ੍ਰੈੱਸ ਕਰੋ?</string>
-    <string name="squeezer_compress_confirmation_message">ਇਹ ਅਸਲੀ ਫਾਈਲਾਂ ਨੂੰ ਕੰਪ੍ਰੈੱਸ ਕੀਤੇ ਸੰਸਕਰਣਾਂ ਨਾਲ ਬਦਲ ਦੇਵੇਗਾ। ਇਹ ਕਿਰਿਆ ਵਾਪਸ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕਦੀ।</string>
     <string name="squeezer_history_title">ਕੰਪ੍ਰੈਸ਼ਨ ਇਤਿਹਾਸ</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ਆਈਟਮ (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">ਕੋਈ ਕੰਪ੍ਰੈਸ਼ਨ ਇਤਿਹਾਸ ਨਹੀਂ</string>
     <string name="squeezer_history_clear_title">ਕੰਪ੍ਰੈਸ਼ਨ ਇਤਿਹਾਸ ਸਾਫ਼ ਕਰੋ</string>
     <string name="squeezer_history_clear_message">ਇਹ ਪਹਿਲਾਂ ਕੰਪ੍ਰੈੱਸ ਕੀਤੀਆਂ ਫਾਈਲਾਂ ਨੂੰ ਦੁਬਾਰਾ ਕੰਪ੍ਰੈੱਸ ਕਰਨ ਦੇਵੇਗਾ। ਫਾਈਲਾਂ ਆਪ ਪ੍ਰਭਾਵਿਤ ਨਹੀਂ ਹੁੰਦੀਆਂ।</string>
-    <string name="squeezer_onboarding_title">ਤਸਵੀਰ ਕੰਪ੍ਰੈਸ਼ਨ ਬਾਰੇ</string>
-    <string name="squeezer_onboarding_message">ਤਸਵੀਰ ਕੰਪ੍ਰੈਸ਼ਨ ਦ੍ਰਿਸ਼ਟੀਗਤ ਵੇਰਵੇ ਹਟਾ ਕੇ ਫਾਈਲ ਦਾ ਆਕਾਰ ਘਟਾਉਂਦੀ ਹੈ। ਇਹ ਪ੍ਰਕਿਰਿਆ ਉਲਟਾਈ ਨਹੀਂ ਜਾ ਸਕਦੀ - ਅਸਲ ਗੁਣਵੱਤਾ ਬਹਾਲ ਨਹੀਂ ਕੀਤੀ ਜਾ ਸਕਦੀ।\n\nਇੱਥੇ ਝਲਕ ਹੈ ਕਿ ਤੁਹਾਡੀਆਂ ਤਸਵੀਰਾਂ ਕਿਵੇਂ ਦਿਖਣਗੀਆਂ:</string>
     <string name="squeezer_onboarding_original_label">ਅਸਲ</string>
     <string name="squeezer_onboarding_compressed_label">ਕੰਪ੍ਰੈਸ਼ਨ ਤੋਂ ਬਾਅਦ</string>
     <string name="squeezer_onboarding_video_original_label">ਵੀਡੀਓ ਫ੍ਰੇਮ</string>
     <string name="squeezer_onboarding_video_compressed_label">ਝਲਕ (ਅੰਦਾਜ਼ਨ)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">ਅਸਲ ਵੀਡੀਓ ਗੁਣਵੱਤਾ ਵੱਖਰੀ ਹੋ ਸਕਦੀ ਹੈ</string>
-    <string name="squeezer_onboarding_quality_label">ਗੁਣਵੱਤਾ: %d%%</string>
     <string name="squeezer_compare_action">ਤੁਲਨਾ ਦੇਖੋ</string>
     <string name="squeezer_no_example_found">ਚੁਣੇ ਮਾਰਗਾਂ ਵਿੱਚ ਕੋਈ ਤਸਵੀਰਾਂ ਨਹੀਂ ਮਿਲੀਆਂ।</string>
     <string name="squeezer_result_empty_message">ਕੋਈ ਕੰਪ੍ਰੈੱਸ ਕਰਨਯੋਗ ਮੀਡੀਆ ਨਹੀਂ ਮਿਲਿਆ।</string>
-    <string name="squeezer_setup_warning">ਕੰਪ੍ਰੈਸ਼ਨ ਸਟੋਰੇਜ ਸਪੇਸ ਬਚਾਉਣ ਲਈ ਗੁਣਵੱਤਾ ਨੂੰ ਸਥਾਈ ਤੌਰ \'ਤੇ ਘਟਾਉਂਦਾ ਹੈ। ਇਹ ਵਾਪਸ ਨਹੀਂ ਕੀਤਾ ਜਾ ਸਕਦਾ। ਸ਼ੁਰੂ ਕਰਨ ਤੋਂ ਪਹਿਲਾਂ ਆਪਣੀਆਂ ਸੈਟਿੰਗਾਂ ਧਿਆਨ ਨਾਲ ਜਾਂਚੋ।</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d ਟਿਕਾਣਾ ਕੰਪ੍ਰੈਸ਼ਨ ਲਈ ਵਰਤਿਆ ਨਹੀਂ ਜਾ ਸਕਦਾ ਅਤੇ ਹਟਾ ਦਿੱਤਾ ਗਿਆ। ਕੰਪ੍ਰੈਸ਼ਨ ਲਈ ਅੰਦਰੂਨੀ ਸਟੋਰੇਜ ਤੱਕ ਸਿੱਧੀ ਪਹੁੰਚ ਲੋੜੀਂਦੀ ਹੈ।</item>
         <item quantity="other">%d ਟਿਕਾਣੇ ਕੰਪ੍ਰੈਸ਼ਨ ਲਈ ਵਰਤੇ ਨਹੀਂ ਜਾ ਸਕਦੇ ਅਤੇ ਹਟਾ ਦਿੱਤੇ ਗਏ। ਕੰਪ੍ਰੈਸ਼ਨ ਲਈ ਅੰਦਰੂਨੀ ਸਟੋਰੇਜ ਤੱਕ ਸਿੱਧੀ ਪਹੁੰਚ ਲੋੜੀਂਦੀ ਹੈ।</item>
@@ -109,7 +98,6 @@
         <item quantity="other">ਘੱਟੋ-ਘੱਟ %d ਦਿਨ ਪੁਰਾਣੀ</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG ਫਾਈਲਾਂ ਲਈ ਅਨੁਮਾਨਿਤ ~%d%% ਬਚਤ</string>
-    <string name="squeezer_onboarding_got_it">ਸਮਝ ਗਿਆਂ/ ਗਈ</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer ਤੁਹਾਡੀਆਂ ਤਸਵੀਰਾਂ ਅਤੇ ਵੀਡੀਓਜ਼ ਨੂੰ ਦੁਬਾਰਾ ਕੰਪ੍ਰੈਸ ਕਰਦਾ ਹੈ ਤਾਂ ਕਿ ਉਹ ਘੱਟ ਥਾਂ ਲਵੇ। ਤੁਸੀਂ ਥੋੜ੍ਹੀ ਗੁਣਵੱਤਾ ਦੇ ਬਦਲੇ ਥਾਂ ਲੈਂਦੇ ਹੋ। ਹਰੇਕ ਆਈਟਮ ਇਸ ਦੀ ਅਨੁਮਾਨਿਤ ਬਚਤ ਦਿਖਾਉਂਦੀ ਹੈ, ਇਸ ਲਈ ਤੁਸੀਂ ਫ਼ੈਸਲਾ ਕਰ ਸਕਦੇ ਹੋ ਕਿ ਕੀ ਲਾਭਦਾਇਕ ਹੈ।</string>
     <string name="tour_squeezer_compress_body">ਸਭ ਕੁਝ ਇੱਥੇ ਇੱਕ ਵਾਰ ਸੰਕੁਚਿਤ ਕਰੋ, ਜਾਂ ਕੇਵਲ ਉਸ ਇੱਕ ਨੂੰ ਛੋਟਾ ਕਰਨ ਲਈ ਇੱਕ ਆਈਟਮ ਨੂੰ ਟੈਪ ਕਰੋ। ਕਈਆਂ ਨੂੰ ਚੁਣਨ ਲਈ ਲੰਬੀ ਦਬਾਓ ਕਰੋ। ਤੁਸੀਂ ਹਮੇਸ਼ਾ ਕੋਈ ਬਦਲਾਅ ਤੋਂ ਪਹਿਲਾਂ ਪੂਰਵ-ਨਜ਼ਾਰਾ ਦੇਖੋਗੇ।</string>

--- a/app-tool-squeezer/src/main/res/values-pl/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-pl/strings.xml
@@ -54,12 +54,7 @@
     <string name="squeezer_min_age_title">Minimalny wiek pliku</string>
     <string name="squeezer_min_age_description">Uwzględniaj tylko pliki starsze niż ten wiek.</string>
     <string name="squeezer_compression_settings_label">Ogólne</string>
-    <string name="squeezer_quality_label">Jakość</string>
-    <string name="squeezer_quality_title">Kompresja jakości</string>
     <string name="squeezer_quality_description">Niższa jakość oznacza mniejszy rozmiar pliku, ale gorszą jakość wizualną.</string>
-    <string name="squeezer_quality_example_format">Przykład: %1$s obraz → zapisuje ~%2$s przy %3$d%% jakości</string>
-    <string name="squeezer_quality_warning_low">Niższa jakość może powodować widoczne artefakty.</string>
-    <string name="squeezer_quality_warning_high">Bardzo wysoka jakość zapewnia minimalne oszczędności przestrzeni.</string>
     <string name="squeezer_types_category_label">Ustawienia obrazu</string>
     <string name="squeezer_video_settings_category_label">Ustawienia wideo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -84,8 +79,6 @@
     <string name="squeezer_preview_dialog_title">Potwierdź kompresję</string>
     <string name="squeezer_preview_total_size">Całkowity rozmiar</string>
     <string name="squeezer_preview_estimated_savings">Szacowane oszczędności</string>
-    <string name="squeezer_compress_confirmation_title">Skompresować zaznaczone elementy?</string>
-    <string name="squeezer_compress_confirmation_message">Spowoduje to zastąpienie oryginalnych plików wersjami skompresowanymi. Tej czynności nie można cofnąć.</string>
     <string name="squeezer_history_title">Historia kompresji</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -96,18 +89,14 @@
     <string name="squeezer_history_empty">Brak historii kompresji</string>
     <string name="squeezer_history_clear_title">Wyczyść historię kompresji</string>
     <string name="squeezer_history_clear_message">Umożliwi to ponowną kompresję wcześniej skompresowanych plików. Same pliki nie zostaną naruszone.</string>
-    <string name="squeezer_onboarding_title">O kompresji obrazów</string>
-    <string name="squeezer_onboarding_message">Kompresja obrazu zmniejsza rozmiar pliku, usuwając szczegóły wizualne. Ten proces jest nieodwracalny - oryginalna jakość nie może być przywrócona.\n\nOto podgląd jak będą wyglądać twoje obrazy:</string>
     <string name="squeezer_onboarding_original_label">Oryginał</string>
     <string name="squeezer_onboarding_compressed_label">Po kompresji</string>
     <string name="squeezer_onboarding_video_original_label">Klatka wideo</string>
     <string name="squeezer_onboarding_video_compressed_label">Podgląd (przybliżony)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Rzeczywista jakość wideo może się różnić</string>
-    <string name="squeezer_onboarding_quality_label">Jakość: %d%%</string>
     <string name="squeezer_compare_action">Zobacz porównanie</string>
     <string name="squeezer_no_example_found">Nie znaleziono obrazów w wybranych ścieżkach.</string>
     <string name="squeezer_result_empty_message">Nie znaleziono kompresowalnych multimediów.</string>
-    <string name="squeezer_setup_warning">Kompresja trwale obniża jakość, oszczędzając miejsce na dysku. Tej operacji nie można cofnąć. Przed rozpoczęciem dokładnie sprawdź ustawienia.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d lokalizacja nie może zostać użyta do kompresji i została usunięta. Kompresja wymaga bezpośredniego dostępu do pamięci wewnętrznej.</item>
         <item quantity="few">%d lokalizacje nie mogą zostać użyte do kompresji i zostały usunięte. Kompresja wymaga bezpośredniego dostępu do pamięci wewnętrznej.</item>
@@ -131,7 +120,6 @@
         <item quantity="other">Co najmniej %d dni</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Szacowane oszczędności ~%d%% dla plików JPEG</string>
-    <string name="squeezer_onboarding_got_it">Rozumiem</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Kompresja multimediów ponownie kompresuje twoje zdjęcia i filmy, dzięki czemu zajmują mniej miejsca. W zamian za odzyskane miejsce tracisz nieco na jakości. Każdy element pokazuje szacowaną oszczędność, dzięki czemu możesz zdecydować, co jest tego warte.</string>
     <string name="tour_squeezer_compress_body">Kompresuj wszystko na raz tutaj lub naciśnij pojedynczy element, aby zmniejszyć tylko ten jeden. Przytrzymaj, aby wybrać kilka. Zawsze zobaczysz podgląd przed zmianą.</string>

--- a/app-tool-squeezer/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-pt-rBR/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Idade mínima do arquivo</string>
     <string name="squeezer_min_age_description">Incluir apenas arquivos mais antigos que esta idade.</string>
     <string name="squeezer_compression_settings_label">Gerais</string>
-    <string name="squeezer_quality_label">Qualidade</string>
-    <string name="squeezer_quality_title">Qualidade de compressão</string>
     <string name="squeezer_quality_description">Qualidade menor significa tamanho de arquivo menor, mas qualidade visual reduzida.</string>
-    <string name="squeezer_quality_example_format">Exemplo: imagem %1$s → economiza ~%2$s a %3$d%% de qualidade</string>
-    <string name="squeezer_quality_warning_low">Qualidades mais baixas podem causar artefatos visíveis.</string>
-    <string name="squeezer_quality_warning_high">Qualidade muito alta oferece economia mínima de espaço.</string>
     <string name="squeezer_types_category_label">Configurações de imagem</string>
     <string name="squeezer_video_settings_category_label">Configurações de vídeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Confirmar compressão</string>
     <string name="squeezer_preview_total_size">Tamanho total</string>
     <string name="squeezer_preview_estimated_savings">Economia estimada</string>
-    <string name="squeezer_compress_confirmation_title">Comprimir itens selecionados?</string>
-    <string name="squeezer_compress_confirmation_message">Isso substituirá os arquivos originais por versões comprimidas. Esta ação não pode ser desfeita.</string>
     <string name="squeezer_history_title">Histórico de compressão</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d item (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Sem histórico de compressão</string>
     <string name="squeezer_history_clear_title">Limpar histórico de compressão</string>
     <string name="squeezer_history_clear_message">Isso permitirá que arquivos previamente comprimidos sejam comprimidos novamente. Os próprios arquivos não são afetados.</string>
-    <string name="squeezer_onboarding_title">Sobre a Compressão de Imagens</string>
-    <string name="squeezer_onboarding_message">A compressão de imagens reduz o tamanho do arquivo removendo detalhes visuais. Este processo é irreversível - a qualidade original não pode ser restaurada.\n\nVeja como suas imagens ficarão:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Após compressão</string>
     <string name="squeezer_onboarding_video_original_label">Quadro de vídeo</string>
     <string name="squeezer_onboarding_video_compressed_label">Pré-visualização (aproximada)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">A qualidade real do vídeo pode variar</string>
-    <string name="squeezer_onboarding_quality_label">Qualidade: %d%%</string>
     <string name="squeezer_compare_action">Ver comparação</string>
     <string name="squeezer_no_example_found">Nenhuma imagem encontrada nos caminhos selecionados.</string>
     <string name="squeezer_result_empty_message">Nenhuma mídia comprimível encontrada.</string>
-    <string name="squeezer_setup_warning">A compressão reduz permanentemente a qualidade para economizar espaço de armazenamento. Isso não pode ser desfeito. Revise suas configurações cuidadosamente antes de começar.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d local não pode ser usado para compressão e foi removido. A compressão requer acesso direto ao armazenamento interno.</item>
         <item quantity="other">%d locais não podem ser usados para compressão e foram removidos. A compressão requer acesso direto ao armazenamento interno.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Pelo menos %d dias</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Economia estimada de ~%d%% para arquivos JPEG</string>
-    <string name="squeezer_onboarding_got_it">Entendi</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">O Squeezer recompacta suas fotos e vídeos para ocuparem menos espaço. Você troca um pouco de qualidade pelo espaço recuperado. Cada item mostra a economia estimada, para que você possa decidir o que vale a pena.</string>
     <string name="tour_squeezer_compress_body">Comprima tudo de uma vez aqui, ou toque em um único item para comprimir apenas esse. Pressione por tempo prolongado para escolher vários. Você sempre verá uma visualização antes de qualquer alteração.</string>

--- a/app-tool-squeezer/src/main/res/values-pt/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-pt/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Idade mínima do ficheiro</string>
     <string name="squeezer_min_age_description">Incluir apenas ficheiros com idade superior a esta.</string>
     <string name="squeezer_compression_settings_label">Geral</string>
-    <string name="squeezer_quality_label">Qualidade</string>
-    <string name="squeezer_quality_title">Qualidade da compressão</string>
     <string name="squeezer_quality_description">Qualidade inferior significa tamanho de ficheiro menor, mas qualidade visual reduzida.</string>
-    <string name="squeezer_quality_example_format">Exemplo: imagem de %1$s → poupa cerca de %2$s com %3$d%% de qualidade</string>
-    <string name="squeezer_quality_warning_low">Qualidades inferiores podem causar artefactos visíveis.</string>
-    <string name="squeezer_quality_warning_high">Uma qualidade muito elevada permite poupar muito pouco espaço.</string>
     <string name="squeezer_types_category_label">Definições de imagem</string>
     <string name="squeezer_video_settings_category_label">Definições de vídeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Confirmar compressão</string>
     <string name="squeezer_preview_total_size">Tamanho total</string>
     <string name="squeezer_preview_estimated_savings">Poupança estimada</string>
-    <string name="squeezer_compress_confirmation_title">Comprimir os itens selecionados?</string>
-    <string name="squeezer_compress_confirmation_message">Isto irá substituir os ficheiros originais por versões comprimidas. Esta ação não pode ser anulada.</string>
     <string name="squeezer_history_title">Histórico de compressão</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d item (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Sem histórico de compressão</string>
     <string name="squeezer_history_clear_title">Limpar histórico de compressão</string>
     <string name="squeezer_history_clear_message">Isto permitirá que ficheiros previamente comprimidos sejam comprimidos novamente. Os próprios ficheiros não são afetados.</string>
-    <string name="squeezer_onboarding_title">Sobre a compressão de imagens</string>
-    <string name="squeezer_onboarding_message">A compressão de imagens reduz o tamanho dos ficheiros ao remover detalhes visuais. Este processo é irreversível — não é possível restaurar a qualidade original.\n\nEsta pré-visualização mostra como ficarão as imagens:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Após compressão</string>
     <string name="squeezer_onboarding_video_original_label">Fotograma de vídeo</string>
     <string name="squeezer_onboarding_video_compressed_label">Pré-visualização (aproximada)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">A qualidade real do vídeo pode ser diferente</string>
-    <string name="squeezer_onboarding_quality_label">Qualidade: %d%%</string>
     <string name="squeezer_compare_action">Ver comparação</string>
     <string name="squeezer_no_example_found">Nenhuma imagem encontrada nos caminhos selecionados.</string>
     <string name="squeezer_result_empty_message">Não foi encontrado conteúdo multimédia que possa ser comprimido.</string>
-    <string name="squeezer_setup_warning">A compressão reduz permanentemente a qualidade para poupar espaço de armazenamento. Isto não pode ser anulado. Reveja as suas definições com cuidado antes de começar.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d localização não pode ser utilizada para compressão e foi removida. A compressão requer acesso direto ao armazenamento interno.</item>
         <item quantity="other">%d localizações não podem ser utilizadas para compressão e foram removidas. A compressão requer acesso direto ao armazenamento interno.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Pelo menos %d dias de idade</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Poupança estimada de ~%d%% para ficheiros JPEG</string>
-    <string name="squeezer_onboarding_got_it">Entendido</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">O Media Squeeze volta a comprimir as fotografias e os vídeos para ocuparem menos espaço. Perde alguma qualidade em troca do espaço recuperado. Cada item mostra a poupança estimada para poder decidir se vale a pena.</string>
     <string name="tour_squeezer_compress_body">Comprima tudo de uma só vez aqui ou toque num item para comprimir apenas esse. Mantenha premido para selecionar vários. Verá sempre uma pré-visualização antes de qualquer alteração.</string>

--- a/app-tool-squeezer/src/main/res/values-ro/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ro/strings.xml
@@ -46,12 +46,7 @@
     <string name="squeezer_min_age_title">Vârsta minimă a fișierului</string>
     <string name="squeezer_min_age_description">Include doar fișierele mai vechi decât această vârstă.</string>
     <string name="squeezer_compression_settings_label">General</string>
-    <string name="squeezer_quality_label">Calitate</string>
-    <string name="squeezer_quality_title">Calitatea de compresie</string>
     <string name="squeezer_quality_description">Calitate mai scăzută înseamnă dimensiune mai mică a fișierului, dar calitate vizuală redusă.</string>
-    <string name="squeezer_quality_example_format">Exemplu: %1$s imagine→ economisește ~%2$s la %3$d%% calitate</string>
-    <string name="squeezer_quality_warning_low">Calitățile inferioare pot provoca artefacte vizibile.</string>
-    <string name="squeezer_quality_warning_high">Calitatea foarte înaltă oferă economii minime de spațiu.</string>
     <string name="squeezer_types_category_label">Setări imagine</string>
     <string name="squeezer_video_settings_category_label">Setări video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -76,8 +71,6 @@
     <string name="squeezer_preview_dialog_title">Confirmați compresia</string>
     <string name="squeezer_preview_total_size">Dimensiune totală</string>
     <string name="squeezer_preview_estimated_savings">Economii estimate</string>
-    <string name="squeezer_compress_confirmation_title">Comprimați elementele selectate?</string>
-    <string name="squeezer_compress_confirmation_message">Aceasta va înlocui fișierele originale cu versiuni comprimate. Această acțiune nu poate fi anulată.</string>
     <string name="squeezer_history_title">Istoric compresie</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -87,18 +80,14 @@
     <string name="squeezer_history_empty">Fără istoric de compresie</string>
     <string name="squeezer_history_clear_title">Ștergeți istoricul de compresie</string>
     <string name="squeezer_history_clear_message">Aceasta va permite ca fișierele comprimate anterior să fie comprimate din nou. Fișierele în sine nu sunt afectate.</string>
-    <string name="squeezer_onboarding_title">Despre compresia imaginii</string>
-    <string name="squeezer_onboarding_message">Compresia imaginilor reduce dimensiunea fișierului prin eliminarea detaliilor vizuale. Acest proces este ireversibil - calitatea originală nu poate fi restaurată.\n\nIată o previzualizare a modului în care vor arăta imaginile dvs:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Dupa compresie</string>
     <string name="squeezer_onboarding_video_original_label">Cadru video</string>
     <string name="squeezer_onboarding_video_compressed_label">Previzualizare (aproximativă)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Calitatea reală a videoclipului poate diferi</string>
-    <string name="squeezer_onboarding_quality_label">Calitate: %d%%</string>
     <string name="squeezer_compare_action">Vizualizare comparație</string>
     <string name="squeezer_no_example_found">Nu s-au găsit imagini în căile selectate.</string>
     <string name="squeezer_result_empty_message">Nu s-au găsit fișiere media compresibile.</string>
-    <string name="squeezer_setup_warning">Compresia reduce permanent calitatea pentru a economisi spațiu de stocare. Aceasta nu poate fi anulată. Revizuiți setările cu atenție înainte de a începe.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d locație nu poate fi utilizată pentru comprimare și a fost eliminată. Compresia necesită acces direct la memoria internă.</item>
         <item quantity="few">%d locații nu pot fi utilizate pentru comprimare și au fost eliminate. Compresia necesită acces direct la memoria internă.</item>
@@ -120,7 +109,6 @@
         <item quantity="other">Cel puțin %d zile vechime</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Se estimează că ~%d%% economii pentru fișierele JPEG</string>
-    <string name="squeezer_onboarding_got_it">Am înțeles</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer recomprimă fotografiile și videoclipurile dvs. pentru a ocupa mai puțin spațiu. Sacrificați puțin din calitate pentru spațiul pe care îl obțineți înapoi. Fiecare element afișează economiile estimate, așa că puteți decide ce merită.</string>
     <string name="tour_squeezer_compress_body">Comprimă totul dintr-o dată aici, sau atinge un singur element pentru a-l micșora. Apasă lung pentru a alege mai multe. Vei vedea întotdeauna o previzualizare înainte ca ceva să se schimbe.</string>

--- a/app-tool-squeezer/src/main/res/values-ru/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ru/strings.xml
@@ -54,12 +54,7 @@
     <string name="squeezer_min_age_title">Минимальный возраст файла</string>
     <string name="squeezer_min_age_description">Включать только файлы старше этого возраста.</string>
     <string name="squeezer_compression_settings_label">Общее</string>
-    <string name="squeezer_quality_label">Качество</string>
-    <string name="squeezer_quality_title">Качество сжатия</string>
     <string name="squeezer_quality_description">Меньшее качество означает меньший размер файла, но снижение качества изображения.</string>
-    <string name="squeezer_quality_example_format">Пример: %1$s изображение → экономия ~%2$s при качестве %3$d%%</string>
-    <string name="squeezer_quality_warning_low">Низкое качество может вызывать видимые артефакты.</string>
-    <string name="squeezer_quality_warning_high">Очень высокое качество ведет к минимальной экономии места.</string>
     <string name="squeezer_types_category_label">Настройки изображений</string>
     <string name="squeezer_video_settings_category_label">Настройки видео</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -84,8 +79,6 @@
     <string name="squeezer_preview_dialog_title">Подтвердите сжатие</string>
     <string name="squeezer_preview_total_size">Общий размер</string>
     <string name="squeezer_preview_estimated_savings">Предполагаемая экономия</string>
-    <string name="squeezer_compress_confirmation_title">Сжать выбранные элементы?</string>
-    <string name="squeezer_compress_confirmation_message">Оригинальные файлы будут заменены сжатыми версиями. Это действие не может быть отменено.</string>
     <string name="squeezer_history_title">История сжатия</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d элем. (%2$s)</item>
@@ -96,18 +89,14 @@
     <string name="squeezer_history_empty">Нет истории сжатия</string>
     <string name="squeezer_history_clear_title">Очистить историю сжатия</string>
     <string name="squeezer_history_clear_message">Это позволит снова сжимать ранее сжатые файлы. Сами файлы не изменяются.</string>
-    <string name="squeezer_onboarding_title">О сжатии изображений</string>
-    <string name="squeezer_onboarding_message">Сжатие изображений уменьшает размер файла путем удаления деталей. Этот процесс необратим - исходное качество не может быть восстановлено.\n\nВот предпросмотр того, как будут выглядеть Ваши изображения:</string>
     <string name="squeezer_onboarding_original_label">Оригинал</string>
     <string name="squeezer_onboarding_compressed_label">После сжатия</string>
     <string name="squeezer_onboarding_video_original_label">Кадр видео</string>
     <string name="squeezer_onboarding_video_compressed_label">Предпросмотр (приблизительно)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Фактическое качество видео может отличаться</string>
-    <string name="squeezer_onboarding_quality_label">Качество: %d%%</string>
     <string name="squeezer_compare_action">Сравнение</string>
     <string name="squeezer_no_example_found">В выбранных путях изображения не найдены.</string>
     <string name="squeezer_result_empty_message">Сжимаемых медиафайлов не найдено.</string>
-    <string name="squeezer_setup_warning">Сжатие навсегда снижает качество для экономии места. Это невозможно отменить. Внимательно проверьте настройки перед началом.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d местоположение нельзя использовать для сжатия, оно было удалено. Для сжатия необходим прямой доступ к внутреннему хранилищу.</item>
         <item quantity="few">%d местополож. нельзя использовать для сжатия, они были удалены. Для сжатия необходим прямой доступ к внутреннему хранилищу.</item>
@@ -131,7 +120,6 @@
         <item quantity="other">По крайней мере %d дн.</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Приблизительно ~%d%% экономия для JPEG-файлов</string>
-    <string name="squeezer_onboarding_got_it">Понятно</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer повторно сжимает Ваши фотографии и видео, чтобы они занимали меньше места. Вы частично жертвуете качеством, чтобы получить освобождённое пространство. Каждый элемент показывает приблизительную экономию, чтобы Вы могли решить, стоит ли это того.</string>
     <string name="tour_squeezer_compress_body">Сожмите всё сразу здесь, или коснитесь одного элемента, чтобы уменьшить только его. Длительное нажатие выбирает несколько. Вы всегда увидите предпросмотр перед тем, как что-либо изменится.</string>

--- a/app-tool-squeezer/src/main/res/values-sc-rIT/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sc-rIT/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Edade mìnima de s\'archìviu</string>
     <string name="squeezer_min_age_description">Includi ebbia sos archìvios prus bèzios de custa edade.</string>
     <string name="squeezer_compression_settings_label">Generale</string>
-    <string name="squeezer_quality_label">Calidade</string>
-    <string name="squeezer_quality_title">Calidade de cumpressione</string>
     <string name="squeezer_quality_description">Una calidàde prus bàscia significat unu archìviu prus pitchinu ma una calidàde visuale reduida.</string>
-    <string name="squeezer_quality_example_format">Esèmpiu: %1$s immàgine → isparagnos de ~%2$s a %3$d%% calidade</string>
-    <string name="squeezer_quality_warning_low">Calidades prus bascias podent càusare artefatos visìbiles.</string>
-    <string name="squeezer_quality_warning_high">Calidade meda arta dat isparagnos mìnimos de ispàtziu.</string>
     <string name="squeezer_types_category_label">Cunfiguratziones de imàgines</string>
     <string name="squeezer_video_settings_category_label">Cunfiguratziones de vìdeo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Cunfirma sa cumpressione</string>
     <string name="squeezer_preview_total_size">Mannesa totale</string>
     <string name="squeezer_preview_estimated_savings">Isparagnu istimadu</string>
-    <string name="squeezer_compress_confirmation_title">Comprimi sos elementos seletzionados?</string>
-    <string name="squeezer_compress_confirmation_message">Custu ddos remplatzàrà sos archìvios originales cun versiones comprimidas. Custa atzione non podet èssere annullada.</string>
     <string name="squeezer_history_title">Istòria de cumpressione</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d elementu (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Peruna istòria de cumpressione</string>
     <string name="squeezer_history_clear_title">Lìmpia s\'istòria de cumpressione</string>
     <string name="squeezer_history_clear_message">Custu permettet a sos archìvios comprimidos in antis de bènnere comprimidos ancora. Sos archìvios medesimu no ant a èssere afetados.</string>
-    <string name="squeezer_onboarding_title">Informatzione subra sa cumpressione de immàgines</string>
-    <string name="squeezer_onboarding_message">Sa cumpressione de immàgines reduet sa mannesa de s\'archìviu boggende detàllios visivos. Custu protzessu est irreversìbile - sa calidade originale non si podet torrare.\n\nEcco comente ant a apàrrere is immàgines tuas:</string>
     <string name="squeezer_onboarding_original_label">Originale</string>
     <string name="squeezer_onboarding_compressed_label">Pustis de sa cumpressione</string>
     <string name="squeezer_onboarding_video_original_label">Fotogramma de vìdeo</string>
     <string name="squeezer_onboarding_video_compressed_label">Anteprima (aproximada)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Sa calidàde reale de vìdeo podet èssere diferente</string>
-    <string name="squeezer_onboarding_quality_label">Calidade: %d%%</string>
     <string name="squeezer_compare_action">Bide su paragone</string>
     <string name="squeezer_no_example_found">Peruna immàgine agatada in is caminos selecionados.</string>
     <string name="squeezer_result_empty_message">Medios comprimìbiles non sunt istados agatados.</string>
-    <string name="squeezer_setup_warning">Sa compressione reduet in manera permanente sa calidàde pro arrisparmiare ispàtziu de archiviàtzione. Custu non podet èssere annulladu. Revisiona cun cuidadu sas tunadas tuas antes de incomintzare.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d logu non podet èssere utilizadu pro sa compressione ed est istadu eliminadu. Sa compressione rechidet atzessu direttu a s\'archìviu internu.</item>
         <item quantity="other">%d logos non podent èssere utilizados pro sa compressione ed ant a èssere eliminados. Sa compressione rechidet atzessu direttu a s\'archìviu internu.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">A su mancu %d dies de edade</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Istimadu ~%d%% de risparmiu pro ficheros JPEG</string>
-    <string name="squeezer_onboarding_got_it">Apat cumprèndiu</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer ricomprime tue fotus e bideos pro che prendan pocu logu. Cambias un pagu de qualidade pro s\'espaziu chi ti torrat. Cada elementu mostrat s\'economia estimada, pro che ti podes decider cos\'est meritzevu.</string>
     <string name="tour_squeezer_compress_body">Cumprimi totu a una volta chì, o tunga un ìtemu singulu pro diminuiri desso. Premi a longa pro ischeddiri prus. Semper vides una anteprima prima chi mudes calche cosa.</string>

--- a/app-tool-squeezer/src/main/res/values-si-rLK/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-si-rLK/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">අවම ගොනු වයස</string>
     <string name="squeezer_min_age_description">මෙම වයසට වඩා පැරණි ගොනු පමණක් ඇතුළත් කරන්න.</string>
     <string name="squeezer_compression_settings_label">සාමාන්‍ය</string>
-    <string name="squeezer_quality_label">ගුණත්වය</string>
-    <string name="squeezer_quality_title">සංකෝචන ගුණත්වය</string>
     <string name="squeezer_quality_description">අඩු ගුණාත්මකභාවය කුඩා ගොනු ප්‍රමාණය අදහස් කරයි නමුත් දෘශ්‍ය ගුණාත්මකභාවය අඩු වේ.</string>
-    <string name="squeezer_quality_example_format">උදාහරණ: %1$s රූපය → %3$d%% ගුණත්වයේදී ~%2$s ඉතිරි</string>
-    <string name="squeezer_quality_warning_low">අඩු ගුණත්වයන්හි දෘශ්‍ය අවශේෂ ඇති විය හැක.</string>
-    <string name="squeezer_quality_warning_high">ඉතා ඉහළ ගුණත්වය අවම ඉඩ ඉතිරිකිරීම් සපයයි.</string>
     <string name="squeezer_types_category_label">රූප සැකසීම්</string>
     <string name="squeezer_video_settings_category_label">වීඩියෝ සැකසීම්</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">සංකෝචනය තහවුරු කරන්න</string>
     <string name="squeezer_preview_total_size">මුළු ප්‍රමාණය</string>
     <string name="squeezer_preview_estimated_savings">ඇස්තමේන්තු ඉතිරි</string>
-    <string name="squeezer_compress_confirmation_title">තෝරාගත් අයිතම සම්පීඩනය කරන්නද?</string>
-    <string name="squeezer_compress_confirmation_message">මෙය මුල් ගොනු සම්පීඩිත අනුවාද සමඟ ප්‍රතිස්ථාපනය කරනු ඇත. මෙම ක්‍රියාව නිෂ්ප්‍රභ කළ නොහැක.</string>
     <string name="squeezer_history_title">සංකෝචන ඉතිහාසය</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">අයිතම %1$d (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">සංකෝචන ඉතිහාසයක් නැත</string>
     <string name="squeezer_history_clear_title">සංකෝචන ඉතිහාසය මකන්න</string>
     <string name="squeezer_history_clear_message">මෙය කලින් සම්පීඩනය කරන ලද ගොනු නැවත සම්පීඩනය කිරීමට ඉඩ දෙනු ඇත. ගොනු ම කෙරෙහි බලපෑමක් නොමැත.</string>
-    <string name="squeezer_onboarding_title">රූප සංකෝචනය ගැන</string>
-    <string name="squeezer_onboarding_message">රූප සංකෝචනය දෘශ්‍ය විස්තර ඉවත් කිරීමෙන් ගොනු ප්‍රමාණය අඩු කරයි. මෙම ක්‍රියාවලිය ආපසු හැරවිය නොහැක - මුල් ගුණත්වය ප්‍රතිසාධනය කළ නොහැක.\n\nඔබේ රූප කෙසේ පෙනෙනු ඇත්දැයි මෙන්න:</string>
     <string name="squeezer_onboarding_original_label">මුල්</string>
     <string name="squeezer_onboarding_compressed_label">සංකෝචනයෙන් පසුව</string>
     <string name="squeezer_onboarding_video_original_label">වීඩියෝ රාමුව</string>
     <string name="squeezer_onboarding_video_compressed_label">පූර්වදර්ශනය (ආසන්න)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">සත්‍ය වීඩියෝ ගුණාත්මකභාවය වෙනස් විය හැක</string>
-    <string name="squeezer_onboarding_quality_label">ගුණත්වය: %d%%</string>
     <string name="squeezer_compare_action">සැසඳීම බලන්න</string>
     <string name="squeezer_no_example_found">තෝරාගත් මාර්ගවල රූප හමු නොවීය.</string>
     <string name="squeezer_result_empty_message">සම්පීඩනය කළ හැකි මාධ්‍ය හමු නොවීය.</string>
-    <string name="squeezer_setup_warning">සම්පීඩනය ගබඩා ඉඩ ඉතිරි කිරීමට ගුණාත්මකභාවය ස්ථිරවශයෙන් අඩු කරයි. මෙය නිෂ්ප්‍රභ කළ නොහැක. ආරම්භ කිරීමට පෙර ඔබගේ සැකසීම් ප්‍රවේශමෙන් සමාලෝචනය කරන්න.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d ස්ථානයක් සම්පීඩනය සඳහා භාවිතා කළ නොහැකි අතර ඉවත් කරන ලදි. සම්පීඩනයට අභ්‍යන්තර ගබඩාවට සෘජු ප්‍රවේශය අවශ්‍ය වේ.</item>
         <item quantity="other">%d ස්ථාන සම්පීඩනය සඳහා භාවිතා කළ නොහැකි අතර ඉවත් කරන ලදි. සම්පීඩනයට අභ්‍යන්තර ගබඩාවට සෘජු ප්‍රවේශය අවශ්‍ය වේ.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">අවම දින %d ක් පැරණි</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG ගොනු සඳහා ඇස්තමේන්තුගත ඉතිරිය ~%d%%</string>
-    <string name="squeezer_onboarding_got_it">තේරුණා</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer ඔබගේ ඡායාරූප සහ වීඩියෝ නැවත සම්පීඩනය කරයි එවිට ඒවා අඩු ඉඩ ගතා කරයි. ඔබ ටිකක් ගුණාත්මක බාවට වෙනුවෙන් ඔබ ආපසු ගන්නා ඉඩ ලබා ගනු ඇත. සෑම අයිතමයෙන්ම එහි ඇස්තමේන්තුගත සිතෙටුම් පෙන්වයි එවිට ඔබට එය වටින ද යන්න තීරණය කළ හැකිය.</string>
     <string name="tour_squeezer_compress_body">මෙහිදී සියල්ල එකවර සම්පීඩනය කරන්න, හෝ තනි අයිතමයක් කුඩා කිරීමට එය ටැප් කරන්න. කිහිපයක් තෝරා ගැනීමට දිගු වෙලාවක් ඔබා. කිසිවක් වෙනස් වීමට පෙර ඔබට සැම විටටම පෙරදසුනක් පෙනෙනු ඇත.</string>

--- a/app-tool-squeezer/src/main/res/values-sk/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sk/strings.xml
@@ -54,12 +54,7 @@
     <string name="squeezer_min_age_title">Minimálny vek súboru</string>
     <string name="squeezer_min_age_description">Zahrnúť iba súbory staršie ako tento vek.</string>
     <string name="squeezer_compression_settings_label">Všeobecné</string>
-    <string name="squeezer_quality_label">Kvalita</string>
-    <string name="squeezer_quality_title">Kvalita kompresie</string>
     <string name="squeezer_quality_description">Nižšia kvalita znamená menšiu veľkosť súboru, ale zníſenú vizuálnu kvalitu.</string>
-    <string name="squeezer_quality_example_format">Príklad: %1$s obrázok → úspora ~%2$s pri %3$d%% kvalite</string>
-    <string name="squeezer_quality_warning_low">Nižšie kvality môžu spôsobiť viditeľné artefakty.</string>
-    <string name="squeezer_quality_warning_high">Veľmi vysoká kvalita poskytuje minimálnu úsporu miesta.</string>
     <string name="squeezer_types_category_label">Nastavenia obrázkov</string>
     <string name="squeezer_video_settings_category_label">Nastavenia videa</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -84,8 +79,6 @@
     <string name="squeezer_preview_dialog_title">Potvrdiť kompresiu</string>
     <string name="squeezer_preview_total_size">Celková veľkosť</string>
     <string name="squeezer_preview_estimated_savings">Odhadovaná úspora</string>
-    <string name="squeezer_compress_confirmation_title">Komprimovať vybrané položky?</string>
-    <string name="squeezer_compress_confirmation_message">Tým sa pôvodné súbory nahradia skomprimovanými verziami. Túto akciu nie je možné vrátiť späť.</string>
     <string name="squeezer_history_title">História kompresie</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d položka (%2$s)</item>
@@ -96,18 +89,14 @@
     <string name="squeezer_history_empty">Žiadna história kompresie</string>
     <string name="squeezer_history_clear_title">Vymazať históriu kompresie</string>
     <string name="squeezer_history_clear_message">Tým sa umožní, aby prípadne skomprimované súbory boli skomprimované znova. Samé súbory nie sú ovplyvnené.</string>
-    <string name="squeezer_onboarding_title">O kompresii obrázkov</string>
-    <string name="squeezer_onboarding_message">Kompresia obrázkov zmenšuje veľkosť súboru odstránením vizuálnych detailov. Tento proces je nezvratný — pôvodnú kvalitu nie je možné obnoviť.\n\nTu je ukážka, ako budú vaše obrázky vyzerať:</string>
     <string name="squeezer_onboarding_original_label">Originál</string>
     <string name="squeezer_onboarding_compressed_label">Po kompresii</string>
     <string name="squeezer_onboarding_video_original_label">Snímka videa</string>
     <string name="squeezer_onboarding_video_compressed_label">Náhľad (približný)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Skutočná kvalita videa sa môže líšiť</string>
-    <string name="squeezer_onboarding_quality_label">Kvalita: %d%%</string>
     <string name="squeezer_compare_action">Zobraziť porovnanie</string>
     <string name="squeezer_no_example_found">V zvolených cestách sa nenašli žiadne obrázky.</string>
     <string name="squeezer_result_empty_message">Nebol nájdený žiadny komprimovateľný mediálny obsáh.</string>
-    <string name="squeezer_setup_warning">Kompresia trvalo znižuje kvalitu, aby ušetrila úložný priestor. Túto akciu nie je možné vrátiť späť. Pred spustením si pozorne prezrite nastavenia.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d miesto nemôže byť použité na kompresiu a bolo odstránené. Kompresia vyžaduje priamy prístup k internému úložisku.</item>
         <item quantity="few">%d miesta nemôžu byť použité na kompresiu a boli odstránené. Kompresia vyžaduje priamy prístup k internému úložisku.</item>
@@ -131,7 +120,6 @@
         <item quantity="other">Aspoň %d dní starých</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Odhadovaná úspora ~%d%% pre súbory JPEG</string>
-    <string name="squeezer_onboarding_got_it">Rozumiem</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer znovu komprimuje vaše fotografie a videá, aby zaberali menej miesta. Obetujete trochu kvality za miesto, ktoré získate späť. Každá položka zobrazuje odhadované úspory, takže si môžete rozhodnúť, čo sa oplatí.</string>
     <string name="tour_squeezer_compress_body">Tu môžete komprimovať všetko naraz, alebo klepnite na jednu položku, aby ste ju zmenšili. Dlhým stlačením vyberte niekoľko. Vždy uvidíte náhľad pred akokoľvek zmenou.</string>

--- a/app-tool-squeezer/src/main/res/values-sl/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sl/strings.xml
@@ -54,12 +54,7 @@
     <string name="squeezer_min_age_title">Najmanjša starost datoteke</string>
     <string name="squeezer_min_age_description">Vključi samo datoteke, starejše od te starosti.</string>
     <string name="squeezer_compression_settings_label">Splošno</string>
-    <string name="squeezer_quality_label">Kakovost</string>
-    <string name="squeezer_quality_title">Kakovost stiskanja</string>
     <string name="squeezer_quality_description">Nižja kakovost pomeni manjšo velikost datoteke, vendar slabšo vizualno kakovost.</string>
-    <string name="squeezer_quality_example_format">Primer: slika %1$s → prihranite ~%2$s pri %3$d%% kakovosti.</string>
-    <string name="squeezer_quality_warning_low">Nižje kakovosti lahko povzročijo vidna popačenja.</string>
-    <string name="squeezer_quality_warning_high">Zelo visoka kakovost omogoča le majhen prihranek prostora.</string>
     <string name="squeezer_types_category_label">Nastavitve slik</string>
     <string name="squeezer_video_settings_category_label">Nastavitve videoposnetkov</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -84,8 +79,6 @@
     <string name="squeezer_preview_dialog_title">Potrdi stiskanje</string>
     <string name="squeezer_preview_total_size">Skupna velikost</string>
     <string name="squeezer_preview_estimated_savings">Predviden prihranek</string>
-    <string name="squeezer_compress_confirmation_title">Stisni izbrane predmete?</string>
-    <string name="squeezer_compress_confirmation_message">To bo nadomestilo izvirne datoteke s stisnjenimi različicami. Tega dejanja ni mogoče razveljaviti.</string>
     <string name="squeezer_history_title">Zgodovina stiskanja</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d predmet (%2$s)</item>
@@ -96,18 +89,14 @@
     <string name="squeezer_history_empty">Ni zgodovine stiskanja.</string>
     <string name="squeezer_history_clear_title">Počisti zgodovino stiskanja</string>
     <string name="squeezer_history_clear_message">To bo omogočilo, da se predhodno stisnjene datoteke stisnejo znova. Same datoteke ne bodo prizadete.</string>
-    <string name="squeezer_onboarding_title">O stiskanju slik</string>
-    <string name="squeezer_onboarding_message">Stiskanje slik zmanjša velikost datoteke z odstranitvijo vizualnih podrobnosti.  Ta postopek je nepovraten – izvirne kakovosti ni mogoče obnoviti.\n\nTu je predogled, kako bodo izgledale vaše slike:</string>
     <string name="squeezer_onboarding_original_label">Izvirnik</string>
     <string name="squeezer_onboarding_compressed_label">Po stiskanju</string>
     <string name="squeezer_onboarding_video_original_label">Sličica videa</string>
     <string name="squeezer_onboarding_video_compressed_label">Predogled (približno)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Dejanska kakovost videa se lahko razlikuje</string>
-    <string name="squeezer_onboarding_quality_label">Kakovost: %d%%</string>
     <string name="squeezer_compare_action">Pokaži primerjavo</string>
     <string name="squeezer_no_example_found">Na izbranih poteh ni bilo mogoče najti slik.</string>
     <string name="squeezer_result_empty_message">Ni stisljive predstavnostne vsebine.</string>
-    <string name="squeezer_setup_warning">Stiskanje trajno zmanjša kakovost za prihranek prostora. Tega ni mogoče razveljaviti. Pred začetkom skrbno preglejte nastavitve.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d lokacije ni mogoče uporabiti za stiskanje in je bila odstranjena. Stiskanje zahteva neposreden dostop do notranjega pomnilnika.</item>
         <item quantity="two">%d lokaciji ni mogoče uporabiti za stiskanje in sta bili odstranjeni. Stiskanje zahteva neposreden dostop do notranjega pomnilnika.</item>
@@ -131,7 +120,6 @@
         <item quantity="other">Vsaj %d dni</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Ocenjeno ~%d%% prihrankov za datoteke JPEG</string>
-    <string name="squeezer_onboarding_got_it">Razumem!</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer ponovno stisne vaše fotografije in video posnetke, da zavzamejo manj prostora. Malo kakovosti zamenjate za prostor, ki ga pridobite. Vsaka postavka prikazuje ocenjeno varčevanje, da se lahko odločite, kaj se splača.</string>
     <string name="tour_squeezer_compress_body">Stisnite vse naenkrat tukaj ali pritisnite en predmet, da ga zmanjšate. Dolgo pritisnite, da izberete več. Pred kakršnimi koli spremembami vedno vidite predogled.</string>

--- a/app-tool-squeezer/src/main/res/values-sq-rAL/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sq-rAL/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Mosha minimale e skedarit</string>
     <string name="squeezer_min_age_description">Përfshi vetëm skedarët më të vjetër se kjo moshë.</string>
     <string name="squeezer_compression_settings_label">Gjenerik</string>
-    <string name="squeezer_quality_label">Cilësia</string>
-    <string name="squeezer_quality_title">Cilësia e kompresimit</string>
     <string name="squeezer_quality_description">Cilësia më e ulët nënkupton madhësi më të vogël të skedarit, por cilësi vizuale të reduktuar.</string>
-    <string name="squeezer_quality_example_format">Shembull: imazh %1$s → kursen ~%2$s në cilësinë %3$d%%</string>
-    <string name="squeezer_quality_warning_low">Cilësi më e ulët mund të shkaktojë artefakte të dukshme.</string>
-    <string name="squeezer_quality_warning_high">Cilësia shumë e lartë ofron kursime minimale të hapësirës.</string>
     <string name="squeezer_types_category_label">Cilësimet e imazhit</string>
     <string name="squeezer_video_settings_category_label">Cilësimet e videos</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Konfirmo kompresimin</string>
     <string name="squeezer_preview_total_size">Madhësia totale</string>
     <string name="squeezer_preview_estimated_savings">Kursime të vlerësuara</string>
-    <string name="squeezer_compress_confirmation_title">Kompreso artikujt e zgjedhur?</string>
-    <string name="squeezer_compress_confirmation_message">Kjo do t\'i zëvendësojë skedarët origjinalë me versione të kompresuar. Ky veprim nuk mund të zhbëhet.</string>
     <string name="squeezer_history_title">Historia e kompresimit</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d artikull (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Asnjë histori kompresimi</string>
     <string name="squeezer_history_clear_title">Pastro historinë e kompresimit</string>
     <string name="squeezer_history_clear_message">Kjo do të lejojë skedarët e kompresuar më parë të kompresohen përsëri. Vetë skedarët nuk preken.</string>
-    <string name="squeezer_onboarding_title">Rreth kompresimit të imazheve</string>
-    <string name="squeezer_onboarding_message">Kompresimi i imazheve zvogëlon madhësinë e skedarit duke hequr detajet vizuale. Ky proces është i pakthyeshëm - cilësia origjinale nuk mund të rikthehet.\n\nJa një pamje paraprake se si do të duken imazhet tuaja:</string>
     <string name="squeezer_onboarding_original_label">Origjinale</string>
     <string name="squeezer_onboarding_compressed_label">Pas kompresimit</string>
     <string name="squeezer_onboarding_video_original_label">Kornizë video</string>
     <string name="squeezer_onboarding_video_compressed_label">Shikimi paraprak (afërsisht)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Cilësia aktuale e videos mund të ndryshojë</string>
-    <string name="squeezer_onboarding_quality_label">Cilësia: %d%%</string>
     <string name="squeezer_compare_action">Shiko krahasimin</string>
     <string name="squeezer_no_example_found">Nuk u gjetën imazhe në shtegjet e zgjedhura.</string>
     <string name="squeezer_result_empty_message">Nuk u gjet asnjë media e kompresueshme.</string>
-    <string name="squeezer_setup_warning">Kompresimi zvogëlon cilësinë përgjithmonë për të kursyer hapësirë ruajtjeje. Kjo nuk mund të zhbëhet. Rishikoni cilësimet tuaja me kujdes para se të filloni.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d vend nuk mund të përdoret për kompresim dhe u hoq. Kompresimi kërkon qasje të drejtëpërdrejtë në memorien e brendshme.</item>
         <item quantity="other">%d vende nuk mund të përdoren për kompresim dhe u hoqën. Kompresimi kërkon qasje të drejtëpërdrejtë në memorien e brendshme.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Të paktën %d ditë të vjetra</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Vlerësohet ~%d%% kursim për skedarët JPEG</string>
-    <string name="squeezer_onboarding_got_it">E kuptova</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer ripunon fotografitë dhe videot tuaja në mënyrë që të zënë më pak vend. Ju sakrifikoni pak cilësi për hapësirën që fitoni. Çdo artikull tregon kursimet e vlerësuara, kështu që mund të vendosni se çfarë vlen.</string>
     <string name="tour_squeezer_compress_body">Kompresi gjithçka në të njëjtën kohë këtu, ose trokit një element për ta zvogëluar atë. Shtypja e gjatë për të zgjedhur disa. Gjithmonë do të shikoni një pamje përpara se të ndryshojë ndonjë gjë.</string>

--- a/app-tool-squeezer/src/main/res/values-sr/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sr/strings.xml
@@ -46,12 +46,7 @@
     <string name="squeezer_min_age_title">Минимална старост датотеке</string>
     <string name="squeezer_min_age_description">Укључи само датотеке старије од ове старости.</string>
     <string name="squeezer_compression_settings_label">Опште</string>
-    <string name="squeezer_quality_label">Квалитет</string>
-    <string name="squeezer_quality_title">Квалитет компресије</string>
     <string name="squeezer_quality_description">Нижи квалитет значи мању величину датотеке, али смањен визуелни квалитет.</string>
-    <string name="squeezer_quality_example_format">Пример: %1$s слика → штеди ~%2$s при %3$d%% квалитету</string>
-    <string name="squeezer_quality_warning_low">Нижи квалитети могу изазвати видљиве артефакте.</string>
-    <string name="squeezer_quality_warning_high">Веома висок квалитет пружа минималну уштеду простора.</string>
     <string name="squeezer_types_category_label">Подешавања слике</string>
     <string name="squeezer_video_settings_category_label">Подешавања видеа</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -76,8 +71,6 @@
     <string name="squeezer_preview_dialog_title">Потврди компресију</string>
     <string name="squeezer_preview_total_size">Укупна величина</string>
     <string name="squeezer_preview_estimated_savings">Процењена уштеда</string>
-    <string name="squeezer_compress_confirmation_title">Компримовати изабране ставке?</string>
-    <string name="squeezer_compress_confirmation_message">Ово ће заменити оригиналне датотеке компримованим верзијама. Ова радња не може да се опозове.</string>
     <string name="squeezer_history_title">Историја компресије</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d ставка (%2$s)</item>
@@ -87,18 +80,14 @@
     <string name="squeezer_history_empty">Нема историје компресије</string>
     <string name="squeezer_history_clear_title">Обриши историју компресије</string>
     <string name="squeezer_history_clear_message">Ово ће омогућити да претходно компримоване датотеке буду поново компримоване. Саме датотеке нису погођене.</string>
-    <string name="squeezer_onboarding_title">О компресији слика</string>
-    <string name="squeezer_onboarding_message">Компресија слика смањује величину датотеке уклањањем визуелних детаља. Овај процес је неповратан - оригинални квалитет се не може вратити.\n\nЕво прегледа како ће ваше слике изгледати:</string>
     <string name="squeezer_onboarding_original_label">Оригинал</string>
     <string name="squeezer_onboarding_compressed_label">После компресије</string>
     <string name="squeezer_onboarding_video_original_label">Кадар видеа</string>
     <string name="squeezer_onboarding_video_compressed_label">Преглед (приближно)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Стварни квалитет видеа може да се разликује</string>
-    <string name="squeezer_onboarding_quality_label">Квалитет: %d%%</string>
     <string name="squeezer_compare_action">Прегледај поређење</string>
     <string name="squeezer_no_example_found">Нису пронађене слике на изабраним путањама.</string>
     <string name="squeezer_result_empty_message">Нема медија погодних за компресију.</string>
-    <string name="squeezer_setup_warning">Компресија трајно смањује квалитет да би се уштедео простор за складиштење. Ово не може да се опозове. Пажљиво прегледај подешавања пре него што почнеш.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d локација не може да се користи за компресију и уклоњена је. Компресија захтева директан приступ интерној меморији.</item>
         <item quantity="few">%d локације не могу да се користе за компресију и уклоњене су. Компресија захтева директан приступ интерној меморији.</item>
@@ -120,7 +109,6 @@
         <item quantity="other">Најмање %d дана старо</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Процењена ~%d%% уштеда за JPEG датотеке</string>
-    <string name="squeezer_onboarding_got_it">Разумем</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer поново компресује ваше фотографије и видео снимке како би заузимали мање простора. Жртвујете мало квалитета за простор који добијате назад. Свака ставка показује процењену уштеду, тако да можете одлучити шта је вредно.</string>
     <string name="tour_squeezer_compress_body">Компресујте све одједном овде, или додирните једну ставку да смањите само ту. Дугим притиском одаберите више. Увек ћете видети преглед пре него што се нешто промени.</string>

--- a/app-tool-squeezer/src/main/res/values-sv/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sv/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Lägsta filålder</string>
     <string name="squeezer_min_age_description">Inkludera bara filer som är äldre än den här åldern.</string>
     <string name="squeezer_compression_settings_label">Allmänt</string>
-    <string name="squeezer_quality_label">Kvalitet</string>
-    <string name="squeezer_quality_title">Komprimeringskvalitet</string>
     <string name="squeezer_quality_description">Lägre kvalitet innebär mindre filstorlek men sämre visuell kvalitet.</string>
-    <string name="squeezer_quality_example_format">Exempel: %1$s-bild → sparar ~%2$s vid %3$d%% kvalitet</string>
-    <string name="squeezer_quality_warning_low">Lägre kvalitet kan orsaka synliga artefakter.</string>
-    <string name="squeezer_quality_warning_high">Mycket hög kvalitet ger minimal utrymmebesparing.</string>
     <string name="squeezer_types_category_label">Bildinstillningar</string>
     <string name="squeezer_video_settings_category_label">Videoinställningar</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Bekräfta komprimering</string>
     <string name="squeezer_preview_total_size">Total storlek</string>
     <string name="squeezer_preview_estimated_savings">Uppskattad besparing</string>
-    <string name="squeezer_compress_confirmation_title">Komprimera valda objekt?</string>
-    <string name="squeezer_compress_confirmation_message">Detta ersätter originalfilerna med komprimerade versioner. Denna åtgärd kan inte ångras.</string>
     <string name="squeezer_history_title">Komprimeringshistorik</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d objekt (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Ingen komprimeringshistorik</string>
     <string name="squeezer_history_clear_title">Rensa komprimeringshistorik</string>
     <string name="squeezer_history_clear_message">Detta gör det möjligt att komprimera tidigare komprimerade filer igen. Filerna i sig påverkas inte.</string>
-    <string name="squeezer_onboarding_title">Om bildkomprimering</string>
-    <string name="squeezer_onboarding_message">Bildkomprimering minskar filstorleken genom att ta bort visuella detaljer. Denna process är irreversibel – originalkvaliteten kan inte återställas.\n\nHär är en förhandsgranskning av hur dina bilder kommer se ut:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">Efter komprimering</string>
     <string name="squeezer_onboarding_video_original_label">Videobildruta</string>
     <string name="squeezer_onboarding_video_compressed_label">Förhandsgranskning (ungefärlig)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Faktisk videokvalitet kan variera</string>
-    <string name="squeezer_onboarding_quality_label">Kvalitet: %d%%</string>
     <string name="squeezer_compare_action">Visa jämförelse</string>
     <string name="squeezer_no_example_found">Inga bilder hittades i valda sökvägar.</string>
     <string name="squeezer_result_empty_message">Ingen komprimeringsbar media hittades.</string>
-    <string name="squeezer_setup_warning">Komprimering minskar kvaliteten permanent för att spara lagringsutrymme. Detta kan inte ångras. Granska dina inställningar noggrant innan du börjar.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d plats kan inte användas för komprimering och togs bort. Komprimering kräver direkt åtkomst till det interna lagringsutrymmet.</item>
         <item quantity="other">%d platser kan inte användas för komprimering och togs bort. Komprimering kräver direkt åtkomst till det interna lagringsutrymmet.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Minst %d dagar gammal</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Uppskattat ~%d%% sparande för JPEG-filer</string>
-    <string name="squeezer_onboarding_got_it">Jag fattar</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer komprimerar dina foton och videor igen så de tar upp mindre utrymme. Du byter lite kvalitet mot det utrymme du får tillbaka. Varje objekt visar dess beräknade besparing, så du kan välja vad som är värt det.</string>
     <string name="tour_squeezer_compress_body">Komprimera allt på en gång här, eller tryck på en enskild post för att förminska bara den. Långtryck för att välja flera. Du kommer alltid att se en förhandsvisning innan något ändras.</string>

--- a/app-tool-squeezer/src/main/res/values-sw/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-sw/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Umri wa chini wa faili</string>
     <string name="squeezer_min_age_description">Jumuisha tu faili za zamani kuliko umri huu.</string>
     <string name="squeezer_compression_settings_label">Jumla</string>
-    <string name="squeezer_quality_label">Ubora</string>
-    <string name="squeezer_quality_title">Ubora wa kubana</string>
     <string name="squeezer_quality_description">Ubora mdogo unamaanisha ukubwa mdogo wa faili lakini ubora wa kuona umepungua.</string>
-    <string name="squeezer_quality_example_format">Mfano: picha ya %1$s → inaokoa ~%2$s kwa ubora wa %3$d%%</string>
-    <string name="squeezer_quality_warning_low">Ubora wa chini unaweza kusababisha kasoro zinazoonekana.</string>
-    <string name="squeezer_quality_warning_high">Ubora wa juu sana unatoa akiba ndogo ya nafasi.</string>
     <string name="squeezer_types_category_label">Mipangilio ya picha</string>
     <string name="squeezer_video_settings_category_label">Mipangilio ya video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Thibitisha kubana</string>
     <string name="squeezer_preview_total_size">Ukubwa wa jumla</string>
     <string name="squeezer_preview_estimated_savings">Akiba iliyokadiriwa</string>
-    <string name="squeezer_compress_confirmation_title">Bana vitu vilivyochaguliwa?</string>
-    <string name="squeezer_compress_confirmation_message">Hii itabadilisha faili za asili na matoleo yaliyobanwa. Kitendo hiki hakiwezi kutenduliwa.</string>
     <string name="squeezer_history_title">Historia ya kubana</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">kipengele %1$d (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Hakuna historia ya kubana</string>
     <string name="squeezer_history_clear_title">Futa historia ya kubana</string>
     <string name="squeezer_history_clear_message">Hii itaruhusu faili zilizobaniwa awali kubaniwa tena. Faili zenyewe hazitaathiriwa.</string>
-    <string name="squeezer_onboarding_title">Kuhusu Kubana Picha</string>
-    <string name="squeezer_onboarding_message">Kubana picha kunapunguza ukubwa wa faili kwa kuondoa maelezo ya kuona. Mchakato huu hauwezi kutenduliwa - ubora wa asili hauwezi kurejeshwa.\n\nHapa kuna hakikisho la jinsi picha zako zitakavyoonekana:</string>
     <string name="squeezer_onboarding_original_label">Asili</string>
     <string name="squeezer_onboarding_compressed_label">Baada ya kubana</string>
     <string name="squeezer_onboarding_video_original_label">Fremu ya video</string>
     <string name="squeezer_onboarding_video_compressed_label">Hakikisho (takriban)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Ubora halisi wa video unaweza kutofautiana</string>
-    <string name="squeezer_onboarding_quality_label">Ubora: %d%%</string>
     <string name="squeezer_compare_action">Tazama kulinganisha</string>
     <string name="squeezer_no_example_found">Hakuna picha zilizopatikana katika njia zilizochaguliwa.</string>
     <string name="squeezer_result_empty_message">Hakuna midia inayoweza kubanwa iliyopatikana.</string>
-    <string name="squeezer_setup_warning">Kubana kunapunguza ubora kwa kudumu ili kuokoa nafasi ya hifadhi. Hii haiwezi kutenduliwa. Kagua mipangilio yako kwa makini kabla ya kuanza.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">Mahali %d haliwezi kutumika kwa kubana na limeondolewa. Kubana kunahitaji ufikiaji wa moja kwa moja wa hifadhi ya ndani.</item>
         <item quantity="other">Maeneo %d hayawezi kutumika kwa kubana na yameondolewa. Kubana kunahitaji ufikiaji wa moja kwa moja wa hifadhi ya ndani.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Angalau siku %d</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Makadirio ya ~%d%% akiba kwa faili za JPEG</string>
-    <string name="squeezer_onboarding_got_it">Nimeelewa</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer hubana tena picha na video zako ili zichukue nafasi kidogo. Unabadilishana ubora kidogo kwa nafasi unayopata. Kila kipengele kinaonyesha akiba inayokadiriwa, ili uweze kuamua kinachostahili.</string>
     <string name="tour_squeezer_compress_body">Bana kila kitu mara moja hapa, au gusa kipengele kimoja ili kukibana peke yake. Bonyeza kwa muda mrefu ili kuchagua kadhaa. Utaona mapitio kila wakati kabla ya mabadiliko yoyote.</string>

--- a/app-tool-squeezer/src/main/res/values-ta-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ta-rIN/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">குறைந்தபட்ச கோப்பு வயது</string>
     <string name="squeezer_min_age_description">இந்த வயதை விட பழைய கோப்புகளை மட்டும் சேர்க்கவும்.</string>
     <string name="squeezer_compression_settings_label">போது</string>
-    <string name="squeezer_quality_label">தரம்</string>
-    <string name="squeezer_quality_title">சுருக்கத் தரம்</string>
     <string name="squeezer_quality_description">குறைந்த தரம் என்பது சிறிய கோப்பு அளவைக் குறிக்கும், ஆனால் காட்சி தரம் குறையும்.</string>
-    <string name="squeezer_quality_example_format">எடுத்துக்காட்டு: %1$s படம் → %3$d%% தரத்தில் ~%2$s மிச்சம்</string>
-    <string name="squeezer_quality_warning_low">குறைந்த தரங்களில் கண்ணுக்குத் தெரியும் குறைபாடுகள் ஏற்படலாம்.</string>
-    <string name="squeezer_quality_warning_high">மிக உயர் தரம் குறைந்தபட்ச இட மிச்சத்தை வழங்குகிறது.</string>
     <string name="squeezer_types_category_label">படம் அமைப்புகள்</string>
     <string name="squeezer_video_settings_category_label">வீடியோ அமைப்புகள்</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">சுருக்கத்தை உறுதிப்படுத்து</string>
     <string name="squeezer_preview_total_size">மொத்த அளவு</string>
     <string name="squeezer_preview_estimated_savings">மதிப்பிடப்பட்ட மிச்சம்</string>
-    <string name="squeezer_compress_confirmation_title">தேர்ந்தெடுக்கப்பட்ட உருப்படிகளை சுருக்கவா?</string>
-    <string name="squeezer_compress_confirmation_message">இது அசல் கோப்புகளை சுருக்கப்பட்ட பதிப்புகளால் மாற்றும். இந்த செயலை மீட்டெடுக்க முடியாது.</string>
     <string name="squeezer_history_title">சுருக்க வரலாறு</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d உருப்படி (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">சுருக்க வரலாறு இல்லை</string>
     <string name="squeezer_history_clear_title">சுருக்க வரலாற்றை அழி</string>
     <string name="squeezer_history_clear_message">இது முந்பு சுருக்கப்பட்ட கோப்புகளை மீண்டும் சுருக்க அனுமதிக்கும். கோப்புகளே பாதிக்கப்படாது.</string>
-    <string name="squeezer_onboarding_title">பட சுருக்கம் பற்றி</string>
-    <string name="squeezer_onboarding_message">பட சுருக்கம் காட்சி விவரங்களை நீக்குவதன் மூலம் கோப்பு அளவைக் குறைக்கிறது. இந்தச் செயல்முறை மீளமுடியாதது - அசல் தரத்தை மீட்டெடுக்க முடியாது.\n\nஉங்கள் படங்கள் எப்படி இருக்கும் என்பதன் முன்னோட்டம்:</string>
     <string name="squeezer_onboarding_original_label">அசல்</string>
     <string name="squeezer_onboarding_compressed_label">சுருக்கத்திற்குப் பிறகு</string>
     <string name="squeezer_onboarding_video_original_label">வீடியோ சட்டகம்</string>
     <string name="squeezer_onboarding_video_compressed_label">முன்னோட்டம் (தோராயமான)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">உண்மையான வீடியோ தரம் வேறுபடலாம்</string>
-    <string name="squeezer_onboarding_quality_label">தரம்: %d%%</string>
     <string name="squeezer_compare_action">ஒப்பீட்டைக் காண்</string>
     <string name="squeezer_no_example_found">தேர்ந்தெடுக்கப்பட்ட பாதைகளில் படங்கள் காணப்படவில்லை.</string>
     <string name="squeezer_result_empty_message">சுருக்கக்கூடிய ஊடகம் எதுவும் கிடைக்கவில்லை.</string>
-    <string name="squeezer_setup_warning">சுருக்கம் தரத்தை நிரந்தரமாக குறைக்கும், சேமிப்பு இடத்தை மிச்சப்படுத்த. இதை மீட்டெடுக்க முடியாது. தொடங்குவதற்கு முன் உங்கள் அமைப்புகளை கவனமாக சரிபார்க்கவும்.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d இடத்தை சுருக்கத்திற்கு பயன்படுத்த முடியாது மற்றும் அகற்றப்பட்டது. சுருக்கம் உள் சேமிப்பகத்திற்கு நேரடி அணுகல் தேவைப்படுகிறது.</item>
         <item quantity="other">%d இடங்களை சுருக்கத்திற்கு பயன்படுத்த முடியாது மற்றும் அகற்றப்பட்டன. சுருக்கம் உள் சேமிப்பகத்திற்கு நேரடி அணுகல் தேவைப்படுகிறது.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">குறைந்தது %d நாட்கள் பழமையானது</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG கோப்புகளுக்கு மதிப்பிடப்பட்ட ~%d%% சேமிப்பு</string>
-    <string name="squeezer_onboarding_got_it">புரிந்தது</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer உங்கள் புகைப்படங்கள் மற்றும் வீடியோக்களை மீண்டும் சுருக்குகிறது, அதனால் அவை குறைவான இடம் எடுக்கின்றன. நீங்கள் கொஞ்சம் தரத்தை விட்டுக்கொடுத்து கூடுதல் இடத்தைப் பெறுகிறீர்கள். ஒவ்வொரு உருப்படிக்கும் அதன் மதிப்பிடுக்கப்பட்ட சேமிப்பு காட்டப்படுகிறது, அதனால் நீங்கள் என்ன மதிப்பு உள்ளது என்பதை முடிவு செய்யலாம்.</string>
     <string name="tour_squeezer_compress_body">இங்கு எல்லாவற்றையும் ஒரே முறையில் சுருக்கவும், அல்லது ஒரு பொருளை தட்டி அது மட்டும் சுருக்கவும். பல பொருட்களை தேர்வு செய்ய நீண்ட அழுத்தம் செய்யவும். எந்த மாற்றமும் நிகழ்வதற்கு முன் நீங்கள் எப்போழுமும் ஒரு முன்னோட்டத்தைக் காணலாம்.</string>

--- a/app-tool-squeezer/src/main/res/values-te-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-te-rIN/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">కనిష్ట ఫైల్ వయసు</string>
     <string name="squeezer_min_age_description">ఈ వయసు కంటే పాతవైన ఫైళ్ళను మాత్రమే చేర్చండి.</string>
     <string name="squeezer_compression_settings_label">సాధారణ</string>
-    <string name="squeezer_quality_label">నాణ్యత</string>
-    <string name="squeezer_quality_title">కుదింపు నాణ్యత</string>
     <string name="squeezer_quality_description">తక్కువ నాణ్యత అంటే చిన్న ఫైల్ పరిమాణం కానీ తక్కువ దృశ్య నాణ్యత.</string>
-    <string name="squeezer_quality_example_format">ఉదాహరణ: %1$s చిత్రం → %3$d%% నాణ్యతలో ~%2$s ఆదా</string>
-    <string name="squeezer_quality_warning_low">తక్కువ నాణ్యతలు కనిపించే ఆర్టిఫాక్ట్‌లకు కారణం కావచ్చు.</string>
-    <string name="squeezer_quality_warning_high">చాలా అధిక నాణ్యత కనిష్ట స్థల ఆదాను అందిస్తుంది.</string>
     <string name="squeezer_types_category_label">చిత్రం అమరికలు</string>
     <string name="squeezer_video_settings_category_label">వీడియో అమరికలు</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">కుదింపును నిర్ధారించండి</string>
     <string name="squeezer_preview_total_size">మొత్తం పరిమాణం</string>
     <string name="squeezer_preview_estimated_savings">అంచనా ఆదా</string>
-    <string name="squeezer_compress_confirmation_title">ఎంచుకున్న అంశాలను కంప్రెస్ చేయాలా?</string>
-    <string name="squeezer_compress_confirmation_message">ఇది అసలు ఫైళ్ళను కంప్రెస్ చేయబడిన వెర్షన్‌లతో భర్తీ చేస్తుంది. ఈ చర్యను రద్దు చేయడం సాధ్యం కాదు.</string>
     <string name="squeezer_history_title">కుదింపు చరిత్ర</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d అంశం (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">కుదింపు చరిత్ర లేదు</string>
     <string name="squeezer_history_clear_title">కుదింపు చరిత్రను క్లియర్ చేయండి</string>
     <string name="squeezer_history_clear_message">ఇది గతంలో కంప్రెస్ చేయబడిన ఫైళ్ళను మళ్ళీ కంప్రెస్ చేయడానికి అనుమతిస్తుంది. ఫైళ్ళు ప్రభావితం కావు.</string>
-    <string name="squeezer_onboarding_title">చిత్ర కుదింపు గురించి</string>
-    <string name="squeezer_onboarding_message">చిత్ర కుదింపు విజువల్ వివరాలను తొలగించడం ద్వారా ఫైల్ పరిమాణాన్ని తగ్గిస్తుంది. ఈ ప్రక్రియ తిరుగులేనిది - అసలు నాణ్యతను పునరుద్ధరించలేరు.\n\nమీ చిత్రాలు ఎలా కనిపిస్తాయో ఇక్కడ ప్రివ్యూ ఉంది:</string>
     <string name="squeezer_onboarding_original_label">అసలు</string>
     <string name="squeezer_onboarding_compressed_label">కుదింపు తర్వాత</string>
     <string name="squeezer_onboarding_video_original_label">వీడియో ఫ్రేమ్</string>
     <string name="squeezer_onboarding_video_compressed_label">ప్రివ్యూ (సుమారు)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">వాస్తవ వీడియో నాణ్యత భిన్నంగా ఉండవచ్చు</string>
-    <string name="squeezer_onboarding_quality_label">నాణ్యత: %d%%</string>
     <string name="squeezer_compare_action">పోలిక చూడండి</string>
     <string name="squeezer_no_example_found">ఎంచుకున్న పాథ్‌లలో చిత్రాలు కనుగొనబడలేదు.</string>
     <string name="squeezer_result_empty_message">కంప్రెస్ చేయగలిగే మీడియా ఏదీ కనుగొనబడలేదు.</string>
-    <string name="squeezer_setup_warning">కంప్రెషన్ నిల్వ స్థలాన్ని ఆదా చేయడానికి నాణ్యతను శాశ్వతంగా తగ్గిస్తుంది. ఇది రద్దు చేయడం సాధ్యం కాదు. ప్రారంభించే ముందు మీ అమరికలను జాగ్రత్తగా సమీక్షించండి.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d స్థానాన్ని కంప్రెషన్ కోసం ఉపయోగించలేము మరియు తొలగించబడింది. కంప్రెషన్‌కు అంతర్గత నిల్వకు నేరుగా యాక్సెస్ అవసరం.</item>
         <item quantity="other">%d స్థానాలను కంప్రెషన్ కోసం ఉపయోగించలేము మరియు తొలగించబడినాయి. కంప్రెషన్‌కు అంతర్గత నిల్వకు నేరుగా యాక్సెస్ అవసరం.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">కనీసం %d రోజులు పాతవి</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG ఫైలుల కోసం అంచనా వేసిన ~%d%% ఆదా</string>
-    <string name="squeezer_onboarding_got_it">అర్థమైంది</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer మీ ఫోటోలను మరియు వీడియోలను తిరిగి సంపీడించుకుంటుంది, తద్వారా అవి తక్కువ స్థలం ఆక్రమిస్తాయి. మీరు కొంచెం నాణ్యతను ఎక్కువ స్థలం కోసం వర్తకం చేస్తారు. ప్రతిటి అంశం దాని అంచనా చేసిన ఆదా చూపుతుంది, కాబట్టి మీరు ఏది విలువైనదో నిర్ణయించుకోవచ్చు.</string>
     <string name="tour_squeezer_compress_body">ఇక్కడ సమస్తమూ ఒకేసారి కుదించండి, లేదా ఒక ఏకైక అంశాన్ని నొక్కండి కేవలం దానిని చిన్నవిని చేయడానికి. బహుళ అంశాలను ఎంచుకోవడానికి దీర్ఘకాలిక నొక్కండి. ఏదైనా మార్పుకు ముందు మీరు ఎల్లప్పుడు ప్రీవ్యూను చూస్తారు.</string>

--- a/app-tool-squeezer/src/main/res/values-th/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-th/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">อายุไฟล์ขั้นต่ำ</string>
     <string name="squeezer_min_age_description">รวมเฉพาะไฟล์ที่เก่ากว่าอายุนี้เท่านั้น</string>
     <string name="squeezer_compression_settings_label">ทั่วไป</string>
-    <string name="squeezer_quality_label">คุณภาพ</string>
-    <string name="squeezer_quality_title">คุณภาพการบีบอัด</string>
     <string name="squeezer_quality_description">คุณภาพต่ำกว่าหมายถึงขนาดไฟล์เล็กลงแต่คุณภาพภาพลดลง</string>
-    <string name="squeezer_quality_example_format">ตัวอย่าง: รูปภาพ %1$s → ประหยัด ~%2$s ที่คุณภาพ %3$d%%</string>
-    <string name="squeezer_quality_warning_low">คุณภาพต่ำอาจทำให้เห็นสิ่งแปลกปลอมได้</string>
-    <string name="squeezer_quality_warning_high">คุณภาพสูงมากให้การประหยัดพื้นที่น้อย</string>
     <string name="squeezer_types_category_label">การตั้งค่าภาพ</string>
     <string name="squeezer_video_settings_category_label">การตั้งค่าวิดีโอ</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">ยืนยันการบีบอัด</string>
     <string name="squeezer_preview_total_size">ขนาดรวม</string>
     <string name="squeezer_preview_estimated_savings">ประหยัดโดยประมาณ</string>
-    <string name="squeezer_compress_confirmation_title">บีบอัดรายการที่เลือกหรือไม่?</string>
-    <string name="squeezer_compress_confirmation_message">การดำเนินการนี้จะแทนที่ไฟล์ต้นฉบับด้วยเวอร์ชันที่บีบอัดแล้ว ไม่สามารถยกเลิกการดำเนินการนี้ได้</string>
     <string name="squeezer_history_title">ประวัติการบีบอัด</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d รายการ (%2$s)</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">ไม่มีประวัติการบีบอัด</string>
     <string name="squeezer_history_clear_title">ล้างประวัติการบีบอัด</string>
     <string name="squeezer_history_clear_message">การดำเนินการนี้จะอนุญาตให้บีบอัดไฟล์ที่เคยบีบอัดแล้วอีกครั้ง ไฟล์เองจะไม่ได้รับผลกระทบ</string>
-    <string name="squeezer_onboarding_title">เกี่ยวกับการบีบอัดรูปภาพ</string>
-    <string name="squeezer_onboarding_message">การบีบอัดรูปภาพลดขนาดไฟล์โดยการลดรายละเอียดภาพ กระบวนการนี้ไม่สามารถย้อนกลับได้ - คุณภาพต้นฉบับไม่สามารถกู้คืนได้\n\nนี่คือตัวอย่างของรูปภาพของคุณจะมีลักษณะอย่างไร:</string>
     <string name="squeezer_onboarding_original_label">ต้นฉบับ</string>
     <string name="squeezer_onboarding_compressed_label">หลังบีบอัด</string>
     <string name="squeezer_onboarding_video_original_label">เฟรมวิดีโอ</string>
     <string name="squeezer_onboarding_video_compressed_label">ตัวอย่าง (โดยประมาณ)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">คุณภาพวิดีโอจริงอาจแตกต่างกัน</string>
-    <string name="squeezer_onboarding_quality_label">คุณภาพ: %d%%</string>
     <string name="squeezer_compare_action">ดูการเปรียบเทียบ</string>
     <string name="squeezer_no_example_found">ไม่พบรูปภาพในเส้นทางที่เลือก</string>
     <string name="squeezer_result_empty_message">ไม่พบสื่อที่สามารถบีบอัดได้</string>
-    <string name="squeezer_setup_warning">การบีบอัดจะลดคุณภาพอย่างถาวรเพื่อประหยัดพื้นที่จัดเก็บ ไม่สามารถยกเลิกได้ โปรดตรวจสอบการตั้งค่าของคุณอย่างรอบคอบก่อนเริ่ม</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">ไม่สามารถใช้ %d ตำแหน่งสำหรับการบีบอัดและถูกลบออกแล้ว การบีบอัดต้องการการเข้าถึงโดยตรงไปยังพื้นที่จัดเก็บภายใน</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">อย่างน้อย %d วัน</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">ประมาณการประหยัดได้ ~%d%% สำหรับไฟล์ JPEG</string>
-    <string name="squeezer_onboarding_got_it">เข้าใจแล้ว</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer จะบีบอัดภาพและวิดีโอของคุณใหม่เพื่อให้ใช้พื้นที่น้อยลง คุณจะแลกเปลี่ยนคุณภาพเล็กน้อยเพื่อให้ได้พื้นที่กลับคืนมา แต่ละรายการจะแสดงการประหยัดโดยประมาณ ดังนั้นคุณจึงสามารถตัดสินใจได้ว่าคุ้มค่าหรือไม่</string>
     <string name="tour_squeezer_compress_body">บีบอัดทั้งหมดพร้อมกันที่นี่ หรือแตะรายการเดียวเพื่อบีบอัดเฉพาะรายการนั้น กดค้างเพื่อเลือกหลายรายการ คุณจะเห็นตัวอย่างเสมอก่อนที่จะมีการเปลี่ยนแปลงใดๆ</string>

--- a/app-tool-squeezer/src/main/res/values-tr/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-tr/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Minimum dosya yaşı</string>
     <string name="squeezer_min_age_description">Yalnızca bu yaştan eski dosyaları dahil et.</string>
     <string name="squeezer_compression_settings_label">Genel</string>
-    <string name="squeezer_quality_label">Kalite</string>
-    <string name="squeezer_quality_title">Sıkıştırma kalitesi</string>
     <string name="squeezer_quality_description">Daha düşük kalite, daha küçük dosya boyutu ancak azaltılmış görsel kalite anlamına gelir.</string>
-    <string name="squeezer_quality_example_format">Örnek: %1$s resim → %3$d%% kalitede ~%2$s tasarruf</string>
-    <string name="squeezer_quality_warning_low">Düşük kaliteler görünür bozulmalara neden olabilir.</string>
-    <string name="squeezer_quality_warning_high">Çok yüksek kalite minimum alan tasarrufu sağlar.</string>
     <string name="squeezer_types_category_label">Görsel ayarlar</string>
     <string name="squeezer_video_settings_category_label">Video ayarları</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Sıkıştırmayı onayla</string>
     <string name="squeezer_preview_total_size">Toplam boyut</string>
     <string name="squeezer_preview_estimated_savings">Tahmini tasarruf</string>
-    <string name="squeezer_compress_confirmation_title">Seçili öğeler sıkıştırılsın mı?</string>
-    <string name="squeezer_compress_confirmation_message">Bu işlem orijinal dosyaları sıkıştırılmış sürümleriyle değiştirecektir. Bu işlem geri alınamaz.</string>
     <string name="squeezer_history_title">Sıkıştırma geçmişi</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d öğe (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Sıkıştırma geçmişi yok</string>
     <string name="squeezer_history_clear_title">Sıkıştırma geçmişini temizle</string>
     <string name="squeezer_history_clear_message">Bu, daha önce sıkıştırılmış dosyaların tekrar sıkıştırılabilmesine izin verecektir. Dosyaların kendisi etkilenmez.</string>
-    <string name="squeezer_onboarding_title">Resim Sıkıştırma Hakkında</string>
-    <string name="squeezer_onboarding_message">Resim sıkıştırma, görsel detayları kaldırarak dosya boyutunu küçültür. Bu işlem geri alınamaz - orijinal kalite geri yüklenemez.\n\nResimlerinizin nasıl görüneceğinin bir önizlemesi:</string>
     <string name="squeezer_onboarding_original_label">Orijinal</string>
     <string name="squeezer_onboarding_compressed_label">Sıkıştırma sonrası</string>
     <string name="squeezer_onboarding_video_original_label">Video karesi</string>
     <string name="squeezer_onboarding_video_compressed_label">Önizleme (yaklaşık)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Gerçek video kalitesi farklılık gösterebilir</string>
-    <string name="squeezer_onboarding_quality_label">Kalite: %d%%</string>
     <string name="squeezer_compare_action">Karşılaştırmayı görüntüle</string>
     <string name="squeezer_no_example_found">Seçilen yollarda resim bulunamadı.</string>
     <string name="squeezer_result_empty_message">Sıkıştırılabilir medya bulunamadı.</string>
-    <string name="squeezer_setup_warning">Sıkıştırma, depolama alanı kazanmak için kaliteyi kalıcı olarak azaltır. Bu geri alınamaz. Başlatmadan önce ayarlarınızı dikkatlice gözden geçirin.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d konum sıkıştırma için kullanılamaz ve kaldırıldı. Sıkıştırma, dahili depolamaya doğrudan erişim gerektirir.</item>
         <item quantity="other">%d konum sıkıştırma için kullanılamaz ve kaldırıldı. Sıkıştırma, dahili depolamaya doğrudan erişim gerektirir.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">En az %d gün eski</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG dosyaları için tahmini ~%d%% tasarruf</string>
-    <string name="squeezer_onboarding_got_it">Anladım</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer, fotoğraflarınızı ve videolarınızı yeniden sıkıştırarak daha az yer kaplamalarını sağlar. Kazandığınız yer karşılığında biraz kaliteden ödün verirsiniz. Her öğe tahmini tasarrufunu gösterir, böylece neyin buna değdiğine siz karar verirsiniz.</string>
     <string name="tour_squeezer_compress_body">Burada her şeyi bir kerede sıkıştırın veya tek bir öğeyi seçip sadece onu küçültün. Birkaçını seçmek için uzun basın. Her şey değişmeden önce her zaman bir önizleme göreceksiniz.</string>

--- a/app-tool-squeezer/src/main/res/values-uk/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-uk/strings.xml
@@ -54,12 +54,7 @@
     <string name="squeezer_min_age_title">Мінімальний вік файлу</string>
     <string name="squeezer_min_age_description">Включати лише файли, старіші за цей вік.</string>
     <string name="squeezer_compression_settings_label">Загальні</string>
-    <string name="squeezer_quality_label">Якість</string>
-    <string name="squeezer_quality_title">Якість стиснення</string>
     <string name="squeezer_quality_description">Нижча якість означає менший розмір файлу, але гіршу якість зображення.</string>
-    <string name="squeezer_quality_example_format">Приклад: %1$s зображення → зберігає ~%2$s з якістю %3$d%%</string>
-    <string name="squeezer_quality_warning_low">Нижча якість може спричинити появу видимих артефактів.</string>
-    <string name="squeezer_quality_warning_high">Дуже висока якість забезпечує мінімальну економію місця.</string>
     <string name="squeezer_types_category_label">Налаштування зображення</string>
     <string name="squeezer_video_settings_category_label">Налаштування відео</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -84,8 +79,6 @@
     <string name="squeezer_preview_dialog_title">Підтвердити стиснення</string>
     <string name="squeezer_preview_total_size">Загальний розмір</string>
     <string name="squeezer_preview_estimated_savings">Орієнтовна економія</string>
-    <string name="squeezer_compress_confirmation_title">Стиснути вибрані елементи?</string>
-    <string name="squeezer_compress_confirmation_message">Це замінить оригінальні файли стиснутими версіями. Цю дію не можна скасувати.</string>
     <string name="squeezer_history_title">Історія стиснення</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d елемент (%2$s)</item>
@@ -96,18 +89,14 @@
     <string name="squeezer_history_empty">Відсутність історії стиснення</string>
     <string name="squeezer_history_clear_title">Очистити історію стиснення</string>
     <string name="squeezer_history_clear_message">Це дозволить повторно стиснути файли, які вже були стиснуті раніше. Самі файли при цьому не зміняться.</string>
-    <string name="squeezer_onboarding_title">Про стиснення зображень</string>
-    <string name="squeezer_onboarding_message">Стиснення зображень зменшує розмір файлу шляхом видалення візуальних деталей. Цей процес є незворотним — оригінальну якість неможливо відновити. \n\nОсь попередній перегляд того, як будуть виглядати ваші зображення:</string>
     <string name="squeezer_onboarding_original_label">Оригінал</string>
     <string name="squeezer_onboarding_compressed_label">Після стиснення</string>
     <string name="squeezer_onboarding_video_original_label">Кадр відео</string>
     <string name="squeezer_onboarding_video_compressed_label">Попередній перегляд (приблизний)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Фактична якість відео може відрізнятися</string>
-    <string name="squeezer_onboarding_quality_label">Якість: %d%%</string>
     <string name="squeezer_compare_action">Переглянути порівняння</string>
     <string name="squeezer_no_example_found">У вибраних шляхах не знайдено зображень.</string>
     <string name="squeezer_result_empty_message">Не знайдено стиснутих медіа.</string>
-    <string name="squeezer_setup_warning">Стиснення назавжди погіршує якість, щоб заощадити місце на диску. Цю дію неможливо скасувати. Перед початком ретельно перевірте налаштування.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d місцезнаходження не може бути використане для стиснення та було видалено. Стиснення вимагає прямого доступу до внутрішньої пам\'яті.</item>
         <item quantity="few">%d розташування не можуть бути використані для стиснення та були видалені. Стиснення потребує прямого доступу до внутрішнього сховища.</item>
@@ -131,7 +120,6 @@
         <item quantity="other">Не менше %d днів</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Приблизно ~%d%% економії для файлів JPEG</string>
-    <string name="squeezer_onboarding_got_it">Зрозуміло</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer перестискує ваші фото та відео, щоб вони займали менше місця. Ви обмінюєте трохи якості на місце, яке повертаєте. Кожен елемент показує орієнтовну економію, тому ви можете вирішити, чи варто це.</string>
     <string name="tour_squeezer_compress_body">Стисніть усе одразу тут або натисніть один елемент, щоб зменшити лише його. Утримуйте, щоб вибрати кілька. Ви завжди бачитимете попередній перегляд перед будь-якими змінами.</string>

--- a/app-tool-squeezer/src/main/res/values-ur-rIN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-ur-rIN/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">کم از کم فائل عمر</string>
     <string name="squeezer_min_age_description">صرف اس عمر سے پرانی فائلیں شامل کریں۔</string>
     <string name="squeezer_compression_settings_label">عام</string>
-    <string name="squeezer_quality_label">معیار</string>
-    <string name="squeezer_quality_title">کمپریشن معیار</string>
     <string name="squeezer_quality_description">کم معیار کا مطلب ہے چھوٹا فائل سائز لیکن کم بصری معیار۔</string>
-    <string name="squeezer_quality_example_format">مثال: %1$s تصویر → %3$d%% معیار پر ~%2$s بچت</string>
-    <string name="squeezer_quality_warning_low">کم معیار میں نظر آنے والی خرابیاں ہو سکتی ہیں۔</string>
-    <string name="squeezer_quality_warning_high">بہت زیادہ معیار کم جگہ بچاتا ہے۔</string>
     <string name="squeezer_types_category_label">تصویر کی ترتیبات</string>
     <string name="squeezer_video_settings_category_label">ویڈیو کی ترتیبات</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">کمپریشن کی تصدیق</string>
     <string name="squeezer_preview_total_size">کل سائز</string>
     <string name="squeezer_preview_estimated_savings">تخمینی بچت</string>
-    <string name="squeezer_compress_confirmation_title">منتخب آئٹمز کمپریس کریں؟</string>
-    <string name="squeezer_compress_confirmation_message">یہ اصل فائلوں کو کمپریس شدہ ورژنز سے تبدیل کر دے گا۔ یہ عمل واپس نہیں کیا جا سکتا۔</string>
     <string name="squeezer_history_title">کمپریشن ہسٹری</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d آئٹم (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">کوئی کمپریشن ہسٹری نہیں</string>
     <string name="squeezer_history_clear_title">کمپریشن ہسٹری صاف کریں</string>
     <string name="squeezer_history_clear_message">یہ پہلے کمپریس شدہ فائلوں کو دوبارہ کمپریس کرنے کی اجازت دے گا۔ فائلیں خود متاثر نہیں ہوں گی۔</string>
-    <string name="squeezer_onboarding_title">تصویر کمپریشن کے بارے میں</string>
-    <string name="squeezer_onboarding_message">تصویر کمپریشن بصری تفصیلات ہٹا کر فائل سائز کم کرتی ہے۔ یہ عمل ناقابل واپسی ہے - اصل معیار بحال نہیں ہو سکتا۔\n\nآپ کی تصاویر کیسی نظر آئیں گی اس کا جائزہ:</string>
     <string name="squeezer_onboarding_original_label">اصل</string>
     <string name="squeezer_onboarding_compressed_label">کمپریشن کے بعد</string>
     <string name="squeezer_onboarding_video_original_label">ویڈیو فریم</string>
     <string name="squeezer_onboarding_video_compressed_label">پیش نظارہ (تقریبی)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">اصل ویڈیو کا معیار مختلف ہو سکتا ہے</string>
-    <string name="squeezer_onboarding_quality_label">معیار: %d%%</string>
     <string name="squeezer_compare_action">موازنہ دیکھیں</string>
     <string name="squeezer_no_example_found">منتخب پاتھز میں کوئی تصاویر نہیں ملیں۔</string>
     <string name="squeezer_result_empty_message">کوئی قابل۔ کمپریس میڈیا نہیں ملا۔</string>
-    <string name="squeezer_setup_warning">کمپریشن مستقل طور پر معیار کو کم کر دیتی ہے تاکہ ذخیرہ کی جگہ بچائی جا سکے۔ یہ واپس نہیں کیا جا سکتا۔ شروع کرنے سے پہلے اپنی ترتیبات کا بغور جائزہ لیں۔</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d مقام کمپریشن کے لیے استعمال نہیں ہو سکتا اور ہٹا دیا گیا۔ کمپریشن کے لیے اندرونی ذخیرے تک براہ راست رسائی درکار ہے۔</item>
         <item quantity="other">%d مقامات کمپریشن کے لیے استعمال نہیں ہو سکتے اور ہٹا دیے گئے۔ کمپریشن کے لیے اندرونی ذخیرے تک براہ راست رسائی درکار ہے۔</item>
@@ -109,7 +98,6 @@
         <item quantity="other">کم از کم %d دن پرانی</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG فائلوں کے لیے تخمینی ~%d%% بچت</string>
-    <string name="squeezer_onboarding_got_it">سمجھ گیا</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer آپ کی تصاویر اور ویڈیوز کو دوبارہ کمپریس کرتا ہے تاکہ وہ کم جگہ لیں۔ آپ معمولی کوالٹی سے سمجھوتہ کر کے جگہ حاصل کرتے ہیں۔ ہر چیز اپنی متوقع بچت دکھاتی ہے، تو آپ فیصلہ کر سکتے ہیں کہ یہ قابلِقدر ہے۔</string>
     <string name="tour_squeezer_compress_body">یہاں سب کچھ ایک ساتھ کمپریس کریں، یا صرف ایک چیز کو سکڑانے کے لیے اس پر ٹیپ کریں۔ متعدد کو منتخب کرنے کے لیے طویل دبائیں۔ آپ کو ہمیشہ کچھ بھی تبدیل ہونے سے پہلے پیش نظارہ نظر آئے گا۔</string>

--- a/app-tool-squeezer/src/main/res/values-uz/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-uz/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Minimal fayl yoshi</string>
     <string name="squeezer_min_age_description">Faqat ushbu yoshdan katta fayllarni qo\'shing.</string>
     <string name="squeezer_compression_settings_label">Umumiy</string>
-    <string name="squeezer_quality_label">Sifat</string>
-    <string name="squeezer_quality_title">Siqish sifati</string>
     <string name="squeezer_quality_description">Past sifat fayl hajmini kichraytiradi, lekin ko\'rinish sifatini pasaytiradi.</string>
-    <string name="squeezer_quality_example_format">Misol: %1$s rasm → %3$d%% sifatda ~%2$s tejaydi</string>
-    <string name="squeezer_quality_warning_low">Past sifat ko\'rinadigan artefaktlarni keltirib chiqarishi mumkin.</string>
-    <string name="squeezer_quality_warning_high">Juda yuqori sifat minimal joy tejaydi.</string>
     <string name="squeezer_types_category_label">Rasm sozlamalari</string>
     <string name="squeezer_video_settings_category_label">Video sozlamalari</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Siqishni tasdiqlash</string>
     <string name="squeezer_preview_total_size">Umumiy hajm</string>
     <string name="squeezer_preview_estimated_savings">Taxminiy tejash</string>
-    <string name="squeezer_compress_confirmation_title">Tanlangan elementlarni siqishmi?</string>
-    <string name="squeezer_compress_confirmation_message">Bu asl fayllarni siqilgan versiyalar bilan almashtiradi. Bu amalni bekor qilib bo\'lmaydi.</string>
     <string name="squeezer_history_title">Siqish tarixi</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d element (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Siqish tarixi yo\'q</string>
     <string name="squeezer_history_clear_title">Siqish tarixini tozalash</string>
     <string name="squeezer_history_clear_message">Bu ilgari siqilgan fayllarni qayta siqish imkonini beradi. Fayllarning o\'zi ta\'sirlanmaydi.</string>
-    <string name="squeezer_onboarding_title">Rasmlarni siqish haqida</string>
-    <string name="squeezer_onboarding_message">Rasmlarni siqish vizual tafsilotlarni olib tashlash orqali fayl hajmini kamaytiradi. Bu jarayon qaytarib bo\'lmaydi - asl sifatni tiklash mumkin emas.\n\nRasmlaringiz qanday ko\'rinishini ko\'ring:</string>
     <string name="squeezer_onboarding_original_label">Asl</string>
     <string name="squeezer_onboarding_compressed_label">Siqishdan keyin</string>
     <string name="squeezer_onboarding_video_original_label">Video kadri</string>
     <string name="squeezer_onboarding_video_compressed_label">Ko\'rinish (taxminiy)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Haqiqiy video sifati farq qilishi mumkin</string>
-    <string name="squeezer_onboarding_quality_label">Sifat: %d%%</string>
     <string name="squeezer_compare_action">Solishtirishni ko\'rish</string>
     <string name="squeezer_no_example_found">Tanlangan yo\'llarda rasmlar topilmadi.</string>
     <string name="squeezer_result_empty_message">Siqilishi mumkin bo\'lgan media topilmadi.</string>
-    <string name="squeezer_setup_warning">Siqish xotirani tejash uchun sifatni doimiy ravishda kamaytiradi. Bu amalni bekor qilib bo\'lmaydi. Boshlashdan oldin sozlamalaringizni diqqat bilan ko\'rib chiqing.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d manzilni siqish uchun ishlatib bo\'lmadi va olib tashlandi. Siqish ichki xotiraga to\'g\'ridan-to\'g\'ri kirish imkonini talab qiladi.</item>
         <item quantity="other">%d manzilni siqish uchun ishlatib bo\'lmadi va olib tashlandi. Siqish ichki xotiraga to\'g\'ridan-to\'g\'ri kirish imkonini talab qiladi.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Kamida %d kunlik</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG fayllar uchun taxminan ~%d%% tejash kutilmoqda</string>
-    <string name="squeezer_onboarding_got_it">Tushundim</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer sizning fotolaringiz va videolaringizni qayta siqadi, shunda ular kamroq joyni egallaydi. Bir oz sifatni qurbon qilib, ko\'proq joyni tejaysiz. Har bir element uning taxminiy tejamkorligini ko\'rsatadi, shuning uchun qaysi narsani qo\'lga kiritish qiymatli ekanligini qaror qila olasiz.</string>
     <string name="tour_squeezer_compress_body">Shu yerda hammasini birdaniga siqing yoki faqat bittasini kichraytirish uchun uni bosing. Bir nechtasini tanlash uchun uzoq bosib turing. Har qanday o\'zgarishdan oldin doim ko\'rib chiqish imkoniyati bo\'ladi.</string>

--- a/app-tool-squeezer/src/main/res/values-vi/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-vi/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">Tuổi tối thiểu của tệp</string>
     <string name="squeezer_min_age_description">Chỉ bao gồm các tệp cũ hơn thời gian này.</string>
     <string name="squeezer_compression_settings_label">Chung</string>
-    <string name="squeezer_quality_label">Chất lượng</string>
-    <string name="squeezer_quality_title">Chất lượng nén</string>
     <string name="squeezer_quality_description">Chất lượng thấp hơn có nghĩa là kích thước tệp nhỏ hơn nhưng chất lượng hình ảnh lại giảm.</string>
-    <string name="squeezer_quality_example_format">Ví dụ: %1$s ảnh → lưu ~%2$s với %3$d%% chất lượng</string>
-    <string name="squeezer_quality_warning_low">Chất lượng thấp hơn có thể gây ra hiện tượng nhiễu có thể nhìn thấy được.</string>
-    <string name="squeezer_quality_warning_high">Chất lượng rất cao nhưng lại tiết kiệm không gian tối thiểu.</string>
     <string name="squeezer_types_category_label">Cài đặt hình ảnh</string>
     <string name="squeezer_video_settings_category_label">Cài đặt video</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">Xác nhận nén</string>
     <string name="squeezer_preview_total_size">Tổng kích thước</string>
     <string name="squeezer_preview_estimated_savings">Tiết kiệm ước tính</string>
-    <string name="squeezer_compress_confirmation_title">Nén các mục đã chọn?</string>
-    <string name="squeezer_compress_confirmation_message">Thao tác này sẽ thay thế các tệp gốc bằng phiên bản nén. Không thể hoàn tác thao tác này.</string>
     <string name="squeezer_history_title">Lịch sử nén</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d mục (%2$s)</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">Không có lịch sử nén</string>
     <string name="squeezer_history_clear_title">Xóa lịch sử nén</string>
     <string name="squeezer_history_clear_message">Thao tác này sẽ cho phép nén lại các tệp đã được nén trước đó. Bản thân những tệp đó không bị ảnh hưởng.</string>
-    <string name="squeezer_onboarding_title">Về nén ảnh</string>
-    <string name="squeezer_onboarding_message">Nén ảnh làm giảm kích thước tập tin bằng cách loại bỏ các chi tiết hình ảnh. Qúa trình này không thể đảo ngược - chất lượng ban đầu không thể khôi phục được.\n\n Dưới đây là bản xem trước các hình ảnh của bạn sẽ trông như thế nào:</string>
     <string name="squeezer_onboarding_original_label">Bản gốc</string>
     <string name="squeezer_onboarding_compressed_label">Sau khi nén</string>
     <string name="squeezer_onboarding_video_original_label">Khung hình video</string>
     <string name="squeezer_onboarding_video_compressed_label">Xem trước (gần đúng)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Chất lượng video thực tế có thể khác</string>
-    <string name="squeezer_onboarding_quality_label">Chất lượng: %d%%</string>
     <string name="squeezer_compare_action">Xem so sánh</string>
     <string name="squeezer_no_example_found">Không tìm thấy hình ảnh nào trong các đường dẫn đã chọn.</string>
     <string name="squeezer_result_empty_message">Không tìm thấy phương tiện có thể nén.</string>
-    <string name="squeezer_setup_warning">Việc nén sẽ làm giảm vĩnh viễn chất lượng để tiết kiệm dung lượng lưu trữ. Không thể hoàn tác điều này. Hãy kiểm tra kỹ các cài đặt của bạn trước khi bắt đầu.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">%d vị trí không thể được sử dụng để nén và đã bị xóa. Việc nén yêu cầu quyền truy cập trực tiếp vào bộ nhớ trong.</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">Ít nhất %d ngày tuổi</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Ước tính tiết kiệm khoảng %d%% cho các tệp JPEG</string>
-    <string name="squeezer_onboarding_got_it">Hiểu rồi</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer nén lại các ảnh và video của bạn để chúng chiếm ít không gian hơn. Bạn đánh đổi một chút chất lượng để lấy lại không gian. Mỗi mục hiển thị mức tiết kiệm ước tính của nó, vì vậy bạn có thể quyết định những gì đáng giá.</string>
     <string name="tour_squeezer_compress_body">Nén mọi thứ cùng một lúc ở đây, hoặc nhấn một mục duy nhất để chỉ làm nhỏ cái đó. Nhấn và giữ để chọn nhiều mục. Bạn sẽ luôn thấy bản xem trước trước khi có bất kỳ thay đổi nào.</string>

--- a/app-tool-squeezer/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-zh-rCN/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">最小文件年龄</string>
     <string name="squeezer_min_age_description">仅包含早于此时间的文件。</string>
     <string name="squeezer_compression_settings_label">常规</string>
-    <string name="squeezer_quality_label">质量</string>
-    <string name="squeezer_quality_title">压缩质量</string>
     <string name="squeezer_quality_description">质量越低，文件越小，但视觉质量也越低。</string>
-    <string name="squeezer_quality_example_format">示例：%1$s 图片 → 以 %3$d%% 质量节省约 %2$s</string>
-    <string name="squeezer_quality_warning_low">较低的质量可能会导致明显的伪影。</string>
-    <string name="squeezer_quality_warning_high">非常高的质量只能节省极少空间。</string>
     <string name="squeezer_types_category_label">图片设置</string>
     <string name="squeezer_video_settings_category_label">视频设置</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">确认压缩</string>
     <string name="squeezer_preview_total_size">总大小</string>
     <string name="squeezer_preview_estimated_savings">预估节省量</string>
-    <string name="squeezer_compress_confirmation_title">压缩所选项目？</string>
-    <string name="squeezer_compress_confirmation_message">这将用压缩版本替换原始文件。此操作无法撤销。</string>
     <string name="squeezer_history_title">压缩历史</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d 个项目（%2$s）</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">没有压缩历史</string>
     <string name="squeezer_history_clear_title">清除压缩历史</string>
     <string name="squeezer_history_clear_message">这将允许之前压缩的文件再次被压缩。文件本身不受影响。</string>
-    <string name="squeezer_onboarding_title">关于图片压缩</string>
-    <string name="squeezer_onboarding_message">图片压缩通过移除视觉细节来缩小文件大小。此过程不可逆——原始质量无法恢复。\n\n以下是压缩后图片的预览：</string>
     <string name="squeezer_onboarding_original_label">原始</string>
     <string name="squeezer_onboarding_compressed_label">压缩后</string>
     <string name="squeezer_onboarding_video_original_label">视频帧</string>
     <string name="squeezer_onboarding_video_compressed_label">预览（近似）</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">实际视频质量可能有所不同</string>
-    <string name="squeezer_onboarding_quality_label">质量：%d%%</string>
     <string name="squeezer_compare_action">查看对比</string>
     <string name="squeezer_no_example_found">在所选路径中未找到图片。</string>
     <string name="squeezer_result_empty_message">未找到可压缩的媒体文件。</string>
-    <string name="squeezer_setup_warning">压缩会永久降低质量以节省存储空间。此操作无法撤销。开始前请仔细检查您的设置。</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">%d 个位置无法用于压缩，已被移除。压缩需要直接访问内部存储。</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">至少 %d 天前</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG 文件预计节省约 %d%%</string>
-    <string name="squeezer_onboarding_got_it">明白</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer 会重新压缩您的照片和视频，使其占用更少的空间。您可以用较少的质量换取更多的空间。每个项目都显示其估计的节省量，因此您可以决定哪些值得压缩。</string>
     <string name="tour_squeezer_compress_body">在此处一次性压缩所有内容，或点击单个项目以仅缩小该项目。长按可选择多个。在进行任何更改之前，您将始终看到预览。</string>

--- a/app-tool-squeezer/src/main/res/values-zh-rHK/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-zh-rHK/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">最小檔案年齡</string>
     <string name="squeezer_min_age_description">僅包含早於此年齡的檔案。</string>
     <string name="squeezer_compression_settings_label">一般</string>
-    <string name="squeezer_quality_label">品質</string>
-    <string name="squeezer_quality_title">壓縮品質</string>
     <string name="squeezer_quality_description">較低畫質意味著較小的檔案大小，但視覺品質降低。</string>
-    <string name="squeezer_quality_example_format">範例：%1$s 圖片 → 以 %3$d%% 品質節省約 %2$s</string>
-    <string name="squeezer_quality_warning_low">較低品質可能導致可見瑕疵。</string>
-    <string name="squeezer_quality_warning_high">非常高的品質只能提供極少的空間節省。</string>
     <string name="squeezer_types_category_label">圖片設定</string>
     <string name="squeezer_video_settings_category_label">影片設定</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">確認壓縮</string>
     <string name="squeezer_preview_total_size">總大小</string>
     <string name="squeezer_preview_estimated_savings">預計節省</string>
-    <string name="squeezer_compress_confirmation_title">壓縮已選項目？</string>
-    <string name="squeezer_compress_confirmation_message">此操作將以壓縮版本取代原始檔案。此操作無法撤銷。</string>
     <string name="squeezer_history_title">壓縮歷史記錄</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d 個項目（%2$s）</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">沒有壓縮歷史記錄</string>
     <string name="squeezer_history_clear_title">清除壓縮歷史記錄</string>
     <string name="squeezer_history_clear_message">此操作將允許對之前已壓縮的檔案再次進行壓縮。檔案本身不會受到影響。</string>
-    <string name="squeezer_onboarding_title">關於圖片壓縮</string>
-    <string name="squeezer_onboarding_message">圖片壓縮透過移除視覺細節來縮小檔案大小。此過程不可逆 - 無法恢復原始品質。\n\n以下是壓縮後的預覽效果：</string>
     <string name="squeezer_onboarding_original_label">原圖</string>
     <string name="squeezer_onboarding_compressed_label">壓縮後</string>
     <string name="squeezer_onboarding_video_original_label">影片畫面</string>
     <string name="squeezer_onboarding_video_compressed_label">預覽（不就是最終效果）</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">實際影片畫質可能有所不同</string>
-    <string name="squeezer_onboarding_quality_label">品質：%d%%</string>
     <string name="squeezer_compare_action">檢視比較</string>
     <string name="squeezer_no_example_found">在所選路徑中找不到圖片。</string>
     <string name="squeezer_result_empty_message">未找到可壓縮的媒體檔案。</string>
-    <string name="squeezer_setup_warning">壓縮會永久降低畫質以節省儲存空間。此操作無法撤銷。開始前請仔細檢查您的設定。</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">%d 個位置無法用於壓縮且已被移除。壓縮需要直接存取內部儲存空間。</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">至少 %d 天</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">預估 JPEG 檔案可節省 ~%d%%</string>
-    <string name="squeezer_onboarding_got_it">瞭解了</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer 會重新壓縮您的相片和影片以節省空間。您用少量質素換取節省的空間。每個項目都會顯示預計節省量，您可決定是否值得進行。</string>
     <string name="tour_squeezer_compress_body">在此一次壓縮所有內容，或點選單一項目只壓縮該項目。長按以選擇多個。進行任何變更前，您始終會看到預覽。</string>

--- a/app-tool-squeezer/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-zh-rTW/strings.xml
@@ -30,12 +30,7 @@
     <string name="squeezer_min_age_title">最小檔案年齡</string>
     <string name="squeezer_min_age_description">僅包含早於此時間的檔案。</string>
     <string name="squeezer_compression_settings_label">一般</string>
-    <string name="squeezer_quality_label">品質</string>
-    <string name="squeezer_quality_title">壓縮品質</string>
     <string name="squeezer_quality_description">品質越低，檔案越小，但視覺品質也越差。</string>
-    <string name="squeezer_quality_example_format">範例：%1$s 圖片 → 以 %3$d%% 品質節省約 %2$s</string>
-    <string name="squeezer_quality_warning_low">較低的品質可能會導致明顯的瑕疵。</string>
-    <string name="squeezer_quality_warning_high">非常高的品質只能節省極少空間。</string>
     <string name="squeezer_types_category_label">圖片設定</string>
     <string name="squeezer_video_settings_category_label">影片設定</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -60,8 +55,6 @@
     <string name="squeezer_preview_dialog_title">確認壓縮</string>
     <string name="squeezer_preview_total_size">總大小</string>
     <string name="squeezer_preview_estimated_savings">預估節省量</string>
-    <string name="squeezer_compress_confirmation_title">壓縮所選項目？</string>
-    <string name="squeezer_compress_confirmation_message">這將以壓縮版本取代原始檔案。此操作無法復原。</string>
     <string name="squeezer_history_title">壓縮歷史</string>
     <plurals name="squeezer_history_summary">
         <item quantity="other">%1$d 個項目（%2$s）</item>
@@ -69,18 +62,14 @@
     <string name="squeezer_history_empty">沒有壓縮歷史</string>
     <string name="squeezer_history_clear_title">清除壓縮歷史</string>
     <string name="squeezer_history_clear_message">這將允許先前壓縮的檔案再次被壓縮。檔案本身不受影響。</string>
-    <string name="squeezer_onboarding_title">關於圖片壓縮</string>
-    <string name="squeezer_onboarding_message">圖片壓縮透過移除視覺細節來縮小檔案大小。此過程不可逆 - 原始品質無法恢復。\n\n以下是壓縮後圖片的預覽：</string>
     <string name="squeezer_onboarding_original_label">原始</string>
     <string name="squeezer_onboarding_compressed_label">壓縮後</string>
     <string name="squeezer_onboarding_video_original_label">影片畫格</string>
     <string name="squeezer_onboarding_video_compressed_label">預覽（近似値）</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">實際影片品質可能有所不同</string>
-    <string name="squeezer_onboarding_quality_label">品質：%d%%</string>
     <string name="squeezer_compare_action">檢視比較</string>
     <string name="squeezer_no_example_found">在選取的路徑中找不到圖片。</string>
     <string name="squeezer_result_empty_message">未找到可壓縮的媒體。</string>
-    <string name="squeezer_setup_warning">壓縮會永久降低品質以節省儲存空間。此操作無法復原。開始前請仔細檢查您的設定。</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="other">%d 個位置無法用於壓縮，已被移除。壓縮需要直接存取內部儲存空間。</item>
     </plurals>
@@ -98,7 +87,6 @@
         <item quantity="other">至少 %d 天前</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">JPEG 檔案預估可節省 ~%d%%</string>
-    <string name="squeezer_onboarding_got_it">瞭解了</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer 會重新壓縮您的相片和影片，使其佔用更少空間。您可以用一點品質換取回收的空間。每個項目都會顯示其估計節省，讓您決定值不值得。</string>
     <string name="tour_squeezer_compress_body">在此一次性壓縮所有內容，或點選單一項目來只縮小那個。長按以選擇多個。在任何變更前，您總是會看到預覽。</string>

--- a/app-tool-squeezer/src/main/res/values-zu/strings.xml
+++ b/app-tool-squeezer/src/main/res/values-zu/strings.xml
@@ -38,12 +38,7 @@
     <string name="squeezer_min_age_title">Ubudala obuncane befayela</string>
     <string name="squeezer_min_age_description">Faka kuphela amafayela amadala kunaleli zinga.</string>
     <string name="squeezer_compression_settings_label">Okujwayelekile</string>
-    <string name="squeezer_quality_label">Ikhwalithi</string>
-    <string name="squeezer_quality_title">Ikhwalithi yokucindezela</string>
     <string name="squeezer_quality_description">Ikhwalithi ephansi kusho ifayela elincane kodwa ikhwalithi yombono inciphisiwe.</string>
-    <string name="squeezer_quality_example_format">Isibonelo: %1$s isithombe → onga ~%2$s ku-%3$d%% ikhwalithi</string>
-    <string name="squeezer_quality_warning_low">Amakhwalithi aphansi angabangela izinkinga ezibonakalayo.</string>
-    <string name="squeezer_quality_warning_high">Ikhwalithi ephezulu kakhulu ihlinzeka ngokonga kancane.</string>
     <string name="squeezer_types_category_label">Izilungiselelo zezithombe</string>
     <string name="squeezer_video_settings_category_label">Izilungiselelo zeviyo</string>
     <string name="squeezer_type_jpeg_title">JPEG</string>
@@ -68,8 +63,6 @@
     <string name="squeezer_preview_dialog_title">Qinisekisa ukucindezela</string>
     <string name="squeezer_preview_total_size">Usayizi ophelele</string>
     <string name="squeezer_preview_estimated_savings">Ukonga okulinganisiwe</string>
-    <string name="squeezer_compress_confirmation_title">Goqa izinto ezikhethiwe?</string>
-    <string name="squeezer_compress_confirmation_message">Lokhu kuzobuyisela amafayela asekuqaleni ngamaviyo egoqiwe. Lesi senzo asinakuguqulwa.</string>
     <string name="squeezer_history_title">Umlando wokucindezela</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d into (%2$s)</item>
@@ -78,18 +71,14 @@
     <string name="squeezer_history_empty">Akukho umlando wokucindezela</string>
     <string name="squeezer_history_clear_title">Sula umlando wokucindezela</string>
     <string name="squeezer_history_clear_message">Lokhu kuzovumela amafayela asevele egoqiwe ukuba agoqwe futhi. Amafayela ngokwawo awathinteki.</string>
-    <string name="squeezer_onboarding_title">Mayelana Nokucindezela Izithombe</string>
-    <string name="squeezer_onboarding_message">Ukucindezela isithombe kunciphisa usayizi wefayela ngokususa imininingwane ebonakalayo. Le nqubo ayihlehliseki - ikhwalithi yokuqala ayikwazi ukubuyiswa.\n\nNansi imboniso yangaphambili yokuthi izithombe zakho zizobukeka kanjani:</string>
     <string name="squeezer_onboarding_original_label">Okwangiempela</string>
     <string name="squeezer_onboarding_compressed_label">Ngemuva kokucindezela</string>
     <string name="squeezer_onboarding_video_original_label">Uhlaka lweviyo</string>
     <string name="squeezer_onboarding_video_compressed_label">Iphrevyu (ecatshangwayo)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Ikhwalithi yeviyo yangempela ingahluka</string>
-    <string name="squeezer_onboarding_quality_label">Ikhwalithi: %d%%</string>
     <string name="squeezer_compare_action">Buka ukuqhathanisa</string>
     <string name="squeezer_no_example_found">Azikho izithombe ezitholakele ezindleleni ezikhethiwe.</string>
     <string name="squeezer_result_empty_message">Akukho imidiya engoqwa etholakele.</string>
-    <string name="squeezer_setup_warning">Ukugoqwa kwehlisa ikhwalithi ngokunaphakade ukonga indawo yokugcina. Lokhu akunakuguqulwa. Hlola izilungiselelo zakho ngokucophelela ngaphambi kokuqala.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">Indawo engu-%d ayikwazi ukusetshenziswa ukugoqwa futhi isuswe. Ukugoqwa kudinga ukufinyelela ngokuqondile kwesitoreji sangaphakathi.</item>
         <item quantity="other">%d izindawo azikwazi ukusetshenziswa ukugoqwa futhi zisuswe. Ukugoqwa kudinga ukufinyelela ngokuqondile kwesitoreji sangaphakathi.</item>
@@ -109,7 +98,6 @@
         <item quantity="other">Okungenani izinsuku ezingu-%d</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Icilelo elilindelekile elingaba %d%% lwamafayili e-JPEG</string>
-    <string name="squeezer_onboarding_got_it">Ngiyaqonda</string>
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">I-Squeezer iyubusha izifanekiso zakho nevidiyo upho ukuze zicele isikhala esincane. Uthintela ubuciko obukaningincinci ngesikhala osuthola. Into ngayinye ikhombisa okusesha okuqikitshwe, ngakho ungakwazi ukunquma okuthile okumfanele.</string>
     <string name="tour_squeezer_compress_body">Cinza izinto zonke ngesikhathi esisodwa lapha, noma cindezela into eyodwa ukuncinane kuleyo kuphela. Cindezela isikhathi eside ukuze ukhethile eziningizane. Uzohlala ubona imodeli phambi kokuba okuthile itshintshwe.</string>

--- a/app-tool-squeezer/src/main/res/values/strings.xml
+++ b/app-tool-squeezer/src/main/res/values/strings.xml
@@ -50,12 +50,7 @@
     <string name="squeezer_min_age_title">Minimum file age</string>
     <string name="squeezer_min_age_description">Only include files older than this age.</string>
     <string name="squeezer_compression_settings_label">General</string>
-    <string name="squeezer_quality_label">Quality</string>
-    <string name="squeezer_quality_title">Compression quality</string>
     <string name="squeezer_quality_description">Lower quality means smaller file size but reduced visual quality.</string>
-    <string name="squeezer_quality_example_format">Example: %1$s image → saves ~%2$s at %3$d%% quality</string>
-    <string name="squeezer_quality_warning_low">Lower qualities may cause visible artifacts.</string>
-    <string name="squeezer_quality_warning_high">Very high quality provides minimal space savings.</string>
     <string name="squeezer_types_category_label">Image settings</string>
     <string name="squeezer_protected_category_label">What gets lost</string>
     <string name="squeezer_video_settings_category_label">Video settings</string>
@@ -94,8 +89,6 @@
     <string name="squeezer_preview_dialog_title">Confirm compression</string>
     <string name="squeezer_preview_total_size">Total size</string>
     <string name="squeezer_preview_estimated_savings">Estimated savings</string>
-    <string name="squeezer_compress_confirmation_title">Compress selected items?</string>
-    <string name="squeezer_compress_confirmation_message">This will replace original files with compressed versions. This action cannot be undone.</string>
     <string name="squeezer_history_title">Compression history</string>
     <plurals name="squeezer_history_summary">
         <item quantity="one">%1$d item (%2$s)</item>
@@ -104,14 +97,11 @@
     <string name="squeezer_history_empty">No compression history</string>
     <string name="squeezer_history_clear_title">Clear compression history</string>
     <string name="squeezer_history_clear_message">This will allow previously compressed files to be compressed again. The files themselves are not affected.</string>
-    <string name="squeezer_onboarding_title">About Image Compression</string>
-    <string name="squeezer_onboarding_message">Image compression reduces file size by removing visual detail. This process is irreversible - the original quality cannot be restored.\n\nHere\'s a preview of how your images will look:</string>
     <string name="squeezer_onboarding_original_label">Original</string>
     <string name="squeezer_onboarding_compressed_label">After compression</string>
     <string name="squeezer_onboarding_video_original_label">Video frame</string>
     <string name="squeezer_onboarding_video_compressed_label">Preview (approximate)</string>
     <string name="squeezer_onboarding_video_quality_disclaimer">Actual video quality may differ</string>
-    <string name="squeezer_onboarding_quality_label">Quality: %d%%</string>
     <string name="squeezer_compare_action">View comparison</string>
     <string name="squeezer_no_example_found">No images found in selected paths.</string>
     <string name="squeezer_result_empty_message">No compressible media found.</string>
@@ -128,7 +118,6 @@
         <item quantity="one">%d very large photo</item>
         <item quantity="other">%d very large photos</item>
     </plurals>
-    <string name="squeezer_setup_warning">Compression permanently reduces quality to save storage space. This cannot be undone. Review your settings carefully before starting.</string>
     <plurals name="squeezer_setup_path_dropped_message">
         <item quantity="one">%d location can\'t be used for compression and was removed. Compression requires direct access to internal storage.</item>
         <item quantity="other">%d locations can\'t be used for compression and were removed. Compression requires direct access to internal storage.</item>
@@ -148,7 +137,6 @@
         <item quantity="other">At least %d days old</item>
     </plurals>
     <string name="squeezer_estimated_savings_percent">Estimated ~%d%% savings for JPEG files</string>
-    <string name="squeezer_onboarding_got_it">Got it</string>
 
     <!-- Guided tour -->
     <string name="tour_squeezer_intro_body">Squeezer re-compresses your photos and videos so they take up less space. You trade a little quality for the room you get back. Each item shows its estimated saving, so you can decide what\'s worth it.</string>


### PR DESCRIPTION
## What changed

Removes twelve pieces of text from the Squeezer tool that no screen in the app displays any more. They are leftovers from earlier versions of the quality picker, the onboarding dialog, the compression confirmation dialog and the setup screen. Nothing changes for people using the app.

The practical effect is for translators: these had to be translated into every language on Crowdin, and none of that work could ever reach a user.

## Technical Context

- Every one of the twelve was verified unreferenced repo-wide, not just in Kotlin: `squeezer_quality_label`, `_quality_title`, `_quality_example_format`, `_quality_warning_low`, `_quality_warning_high`, `_onboarding_title`, `_onboarding_message`, `_onboarding_quality_label`, `_onboarding_got_it`, `_compress_confirmation_title`, `_compress_confirmation_message`, `_setup_warning`.
- The onboarding dialog itself is still live. Its other strings (`_onboarding_original_label`, `_onboarding_compressed_label`, the video variants) are untouched; only the retired title, message, quality label and dismiss button go. Same for the quality settings, where `squeezer_quality_description` stays.
- Base and locale files are deleted together, 888 elements across 74 files. A base-only deletion leaves every locale with a translation whose base string is gone, which lint reports as `ExtraTranslation`, escalated to `fatal` for non-beta builds in `app/build.gradle.kts:101`.
- The bulk of the diff is 73 identical 12-line deletions in `values-*/strings.xml`. The base file is the only one worth reading closely.
- Found while writing translator context for this file on Crowdin: the annotator could locate a call site for every other string in the module but not these. The remaining 88 Squeezer strings now have context and character limits on Crowdin; these twelve were deliberately left without it rather than given guessed placement.