### PR TITLE
Swiper: Remove leftover text from the old swipe tutorial

### DIFF
--- a/app-tool-swiper/src/main/res/values-af-rZA/strings.xml
+++ b/app-tool-swiper/src/main/res/values-af-rZA/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibreer wanneer hou- of verwyder-besluite geneem word.</string>
     <string name="swiper_discard_session_confirmation_title">Verwerp sessie?</string>
     <string name="swiper_discard_session_confirmation_message">Alle besluite sal verlore gaan. Is jy seker?</string>
-    <string name="swiper_no_preview_available">Geen voorskou beskikbaar nie</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Gaan voort met sessie van %1$d dag gelede (%2$d%% voltooi)</item>
         <item quantity="other">Gaan voort met sessie van %1$d dae gelede (%2$d%% voltooi)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Terug!</string>
     <string name="swiper_stamp_undo_3">Oeps!</string>
     <string name="swiper_stamp_undo_4">Wag!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tik enige plek om te begin</string>
-    <string name="swiper_gesture_overlay_left_delete">← Verwyder</string>
-    <string name="swiper_gesture_overlay_right_keep">Hou →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Hou</string>
-    <string name="swiper_gesture_overlay_right_delete">Verwyder →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Slaan oor</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Ontdoen</string>
     <string name="swiper_help_title">Hoe Swiper werk</string>
     <string name="swiper_help_message">Swiep elke lêer om \'n besluit te neem:\n\n← Swiep links: %1$s\n→ Swiep regs: %2$s\n↑ Swiep op: Slaan oor\n↓ Swiep af: Ontdoen (na eerste swiep)\n\nJy kan ook die knoppies onderaan gebruik.\n\nAs jy klaar is, tik \"Hersien\" om al jou besluite te sien. Niks word verwyder totdat jy op die hersieningsskerm bevestig nie.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Verstaan</string>
     <string name="swiper_file_type_filter_title">Wys slegs hierdie lêertipes</string>
     <string name="swiper_file_type_filter_hint">Merk die tipes wat jy wil sien. As geen gemerk is nie, word alle lêers gewys.</string>
     <string name="swiper_file_type_category_images">Beelde</string>

--- a/app-tool-swiper/src/main/res/values-am/strings.xml
+++ b/app-tool-swiper/src/main/res/values-am/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">ማስቀመጥ ወይም መሰረዝ ውሳኔዎችን ሲያደርጉ ይንቀጠቀጡ።</string>
     <string name="swiper_discard_session_confirmation_title">ክፍለ ጊዜ ይጣል?</string>
     <string name="swiper_discard_session_confirmation_message">ሁሉም ውሳኔዎች ይጠፋሉ። እርግጠኛ ነዎት?</string>
-    <string name="swiper_no_preview_available">ቅድመ-ዕይታ የለም</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">ከ%1$d ቀን በፊት ክፍለ ጊዜ ቀጥል (%2$d%% ተጠናቋል)</item>
         <item quantity="other">ከ%1$d ቀናት በፊት ክፍለ ጊዜ ቀጥል (%2$d%% ተጠናቋል)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">ተመለስ!</string>
     <string name="swiper_stamp_undo_3">ወይ!</string>
     <string name="swiper_stamp_undo_4">ቆይ!</string>
-    <string name="swiper_gesture_overlay_dismiss">ለመጀመር የትም ይንኩ</string>
-    <string name="swiper_gesture_overlay_left_delete">← ሰርዝ</string>
-    <string name="swiper_gesture_overlay_right_keep">አስቀምጥ →</string>
-    <string name="swiper_gesture_overlay_left_keep">← አስቀምጥ</string>
-    <string name="swiper_gesture_overlay_right_delete">ሰርዝ →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ ዝለል</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ መልስ</string>
     <string name="swiper_help_title">ማንሸራተቻ እንዴት እንደሚሰራ</string>
     <string name="swiper_help_message">ውሳኔ ለማድረግ እያንዳንዱን ፋይል ያንሸራትቱ:\n\n← ወደ ግራ ያንሸራትቱ: %1$s\n→ ወደ ቀኝ ያንሸራትቱ: %2$s\n↑ ወደ ላይ ያንሸራትቱ: ዝለል\n↓ ወደ ታች ያንሸራትቱ: መልስ (ከመጀመሪያው ማንሸራተት በኋላ)\n\nከታች ያሉትን ቁልፎችም መጠቀም ይችላሉ።\n\nሲያልቁ ሁሉንም ውሳኔዎችዎን ለማየት \"ይገምግሙ\" ይንኩ። በግምገማ ስክሪኑ ላይ እስኪያረጋግጡ ድረስ ምንም አይሰረዝም።</string>
-    <string name="swiper_gesture_overlay_dismiss_action">ገባኝ</string>
     <string name="swiper_file_type_filter_title">እነዚህን የፋይል ዓይነቶች ብቻ አሳይ</string>
     <string name="swiper_file_type_filter_hint">ማየት የሚፈልጓቸውን ዓይነቶች ምልክት ያድርጉ። ምንም ምልክት ካልተደረገ ሁሉም ፋይሎች ይታያሉ።</string>
     <string name="swiper_file_type_category_images">ምስሎች</string>

--- a/app-tool-swiper/src/main/res/values-ar/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ar/strings.xml
@@ -80,7 +80,6 @@
     <string name="swiper_settings_haptic_feedback_summary">اهتزاز عند اتخاذ قرارات الاحتفاظ أو الحذف.</string>
     <string name="swiper_discard_session_confirmation_title">تجاهل الجلسة؟</string>
     <string name="swiper_discard_session_confirmation_message">ستضيع جميع القرارات. هل أنت متأكد؟</string>
-    <string name="swiper_no_preview_available">لا تتوفر معاينة</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="zero">متابعة الجلسة من %1$d أيام مضت (%2$d%% مكتملة)</item>
         <item quantity="one">متابعة الجلسة من %1$d يوم مضى (%2$d%% مكتملة)</item>
@@ -201,16 +200,8 @@
     <string name="swiper_stamp_undo_2">عودة!</string>
     <string name="swiper_stamp_undo_3">أوبس!</string>
     <string name="swiper_stamp_undo_4">انتظر!</string>
-    <string name="swiper_gesture_overlay_dismiss">انقر في أي مكان للبدء</string>
-    <string name="swiper_gesture_overlay_left_delete">← حذف</string>
-    <string name="swiper_gesture_overlay_right_keep">احتفظ →</string>
-    <string name="swiper_gesture_overlay_left_keep">← احتفظ</string>
-    <string name="swiper_gesture_overlay_right_delete">حذف →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ تخطَّ</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ تراجع</string>
     <string name="swiper_help_title">كيف يعمل Swiper</string>
     <string name="swiper_help_message">مرر كل ملف لاتخاذ قرار:\n\n← مرر لليسار: %1$s\n→ مرر لليمين: %2$s\n↑ مرر للأعلى: تخطَّ\n↓ مرر للأسفل: تراجع (بعد أول تمريرة)\n\nيمكنك أيضًا استخدام الأزرار في الأسفل.\n\nعند الانتهاء، انقر على \"مراجعة\" لرؤية جميع قراراتك. لن يتم حذف أي شيء حتى تؤكد في شاشة المراجعة.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">عُلم</string>
     <string name="swiper_file_type_filter_title">إظهار أنواع الملفات هذه فقط</string>
     <string name="swiper_file_type_filter_hint">حدد الأنواع التي تريد رؤيتها. إذا لم يتم تحديد أي نوع، سيتم عرض جميع الملفات.</string>
     <string name="swiper_file_type_category_images">الصور</string>

--- a/app-tool-swiper/src/main/res/values-az/strings.xml
+++ b/app-tool-swiper/src/main/res/values-az/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Saxlama və ya silmə qərarları verdikdə titrəmə.</string>
     <string name="swiper_discard_session_confirmation_title">Sessiya ləğv edilsin?</string>
     <string name="swiper_discard_session_confirmation_message">Bütün qərarlar itiriləcək. Əminsiniz?</string>
-    <string name="swiper_no_preview_available">Ön baxış mövcud deyil</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d gün əvvəlki sessiyanı davam etdir (%2$d%% tamamlanıb)</item>
         <item quantity="other">%1$d gün əvvəlki sessiyanı davam etdir (%2$d%% tamamlanıb)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Geri!</string>
     <string name="swiper_stamp_undo_3">Ups!</string>
     <string name="swiper_stamp_undo_4">Dayan!</string>
-    <string name="swiper_gesture_overlay_dismiss">Başlamaq üçün istənilən yerə toxunun</string>
-    <string name="swiper_gesture_overlay_left_delete">← Sil</string>
-    <string name="swiper_gesture_overlay_right_keep">Saxla →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Saxla</string>
-    <string name="swiper_gesture_overlay_right_delete">Sil →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Keç</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Geri al</string>
     <string name="swiper_help_title">Swiper necə işləyir</string>
     <string name="swiper_help_message">Qərar vermək üçün hər faylı sürüşdürün:\n\n← Sola sürüşdürün: %1$s\n→ Sağa sürüşdürün: %2$s\n↑ Yuxarı sürüşdürün: Keç\n↓ Aşağı sürüşdürün: Geri al (ilk sürüşdürmədən sonra)\n\nAşağıdakı düymələrdən də istifadə edə bilərsiniz.\n\nBitirdikdə, bütün qərarlarınızı görmək üçün \"Baxış\" düyməsinə toxunun. Baxış ekranında təsdiqləyənə qədər heç nə silinmir.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Başa düşdüm</string>
     <string name="swiper_file_type_filter_title">Yalnız bu fayl növlərini göstər</string>
     <string name="swiper_file_type_filter_hint">Görmək istədiyiniz növləri seçin. Heç biri seçilməyibsə, bütün fayllar göstərilir.</string>
     <string name="swiper_file_type_category_images">Şəkillər</string>

--- a/app-tool-swiper/src/main/res/values-be/strings.xml
+++ b/app-tool-swiper/src/main/res/values-be/strings.xml
@@ -68,7 +68,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Вібрацыя пры прыняцці або выдаленні рашэнняў.</string>
     <string name="swiper_discard_session_confirmation_title">Адхіліць сесію?</string>
     <string name="swiper_discard_session_confirmation_message">Усе рашэнні будуць страчаныя. Вы ўпэўнены?</string>
-    <string name="swiper_no_preview_available">Папярэдні прагляд недаступны</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Працягнуць сесію з %1$d дня таму (%2$d%% завершана)</item>
         <item quantity="few">Працягнуць сесію з %1$d дзён таму (%2$d%% завершана)</item>
@@ -167,16 +166,8 @@
     <string name="swiper_stamp_undo_2">Назад!</string>
     <string name="swiper_stamp_undo_3">Ой!</string>
     <string name="swiper_stamp_undo_4">Пачакайце!</string>
-    <string name="swiper_gesture_overlay_dismiss">Дакраніцеся ў любым месцы, каб пачаць</string>
-    <string name="swiper_gesture_overlay_left_delete">← Выдаліць</string>
-    <string name="swiper_gesture_overlay_right_keep">Пакінуць →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Пакінуць</string>
-    <string name="swiper_gesture_overlay_right_delete">Выдаліць →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Прапусціць</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Скасаваць</string>
     <string name="swiper_help_title">Як працуе Swiper</string>
     <string name="swiper_help_message">Правядзіце пальцам па кожным файле, каб прыняць рашэнне:\n\n← Правесці ўлева: %1$s\n→ Правесці ўправа: %2$s\n↑ Правесці ўверх: Прапусціць\n↓ Правесці ўніз: Скасаваць (пасля першага правядзення)\n\nВы таксама можаце выкарыстоўваць кнопкі ўнізе.\n\nКалі скончыце, дакраніцеся \"Агляд\", каб убачыць усе вашы рашэнні. Нічога не выдаляецца, пакуль вы не пацвердзіце на экране агляду.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Зразумела</string>
     <string name="swiper_file_type_filter_title">Паказваць толькі гэтыя тыпы файлаў</string>
     <string name="swiper_file_type_filter_hint">Адзначце тыпы, якія вы хочаце бачыць. Калі нічога не адзначана, паказваюцца ўсе файлы.</string>
     <string name="swiper_file_type_category_images">Выявы</string>

--- a/app-tool-swiper/src/main/res/values-bg/strings.xml
+++ b/app-tool-swiper/src/main/res/values-bg/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Вибрация при вземане на решения за запазване или изтриване.</string>
     <string name="swiper_discard_session_confirmation_title">Отхвърляне на сесията?</string>
     <string name="swiper_discard_session_confirmation_message">Всички решения ще бъдат загубени. Сигурни ли сте?</string>
-    <string name="swiper_no_preview_available">Няма наличен преглед</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Продължаване на сесия от преди %1$d ден (%2$d%% завършена)</item>
         <item quantity="other">Продължаване на сесия от преди %1$d дни (%2$d%% завършена)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Назад!</string>
     <string name="swiper_stamp_undo_3">Опа!</string>
     <string name="swiper_stamp_undo_4">Чакай!</string>
-    <string name="swiper_gesture_overlay_dismiss">Докоснете навсякъде за начало</string>
-    <string name="swiper_gesture_overlay_left_delete">← Изтриване</string>
-    <string name="swiper_gesture_overlay_right_keep">Запазване →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Запазване</string>
-    <string name="swiper_gesture_overlay_right_delete">Изтриване →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Пропускане</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Отмяна</string>
     <string name="swiper_help_title">Как работи Swiper</string>
     <string name="swiper_help_message">Плъзнете всеки файл, за да вземете решение:\n\n← Плъзнете наляво: %1$s\n→ Плъзнете надясно: %2$s\n↑ Плъзнете нагоре: Пропускане\n↓ Плъзнете надолу: Отмяна (след първото плъзгане)\n\nМожете също да използвате бутоните в долната част.\n\nКогато приключите, докоснете \"Преглед\", за да видите всичките си решения. Нищо не се изтрива, докато не потвърдите на екрана за преглед.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Разбрах</string>
     <string name="swiper_file_type_filter_title">Показвай само тези типове файлове</string>
     <string name="swiper_file_type_filter_hint">Отметнете типовете, които искате да виждате. Ако нито един не е отметнат, се показват всички файлове.</string>
     <string name="swiper_file_type_category_images">Изображения</string>

--- a/app-tool-swiper/src/main/res/values-bn-rBD/strings.xml
+++ b/app-tool-swiper/src/main/res/values-bn-rBD/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">রাখা বা মোছার সিদ্ধান্তের সময় কম্পন।</string>
     <string name="swiper_discard_session_confirmation_title">সেশন বাতিল করবেন?</string>
     <string name="swiper_discard_session_confirmation_message">সমস্ত সিদ্ধান্ত হারিয়ে যাবে। আপনি কি নিশ্চিত?</string>
-    <string name="swiper_no_preview_available">কোনো প্রিভিউ পাওয়া যায়নি</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d দিন আগের সেশন চালিয়ে যান (%2$d%% সম্পন্ন)</item>
         <item quantity="other">%1$d দিন আগের সেশন চালিয়ে যান (%2$d%% সম্পন্ন)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">ফিরে!</string>
     <string name="swiper_stamp_undo_3">উফ!</string>
     <string name="swiper_stamp_undo_4">দাঁড়ান!</string>
-    <string name="swiper_gesture_overlay_dismiss">শুরু করতে যেকোনো জায়গায় ট্যাপ করুন</string>
-    <string name="swiper_gesture_overlay_left_delete">← মুছুন</string>
-    <string name="swiper_gesture_overlay_right_keep">রাখুন →</string>
-    <string name="swiper_gesture_overlay_left_keep">← রাখুন</string>
-    <string name="swiper_gesture_overlay_right_delete">মুছুন →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ এড়িয়ে যান</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ পূর্বাবস্থা</string>
     <string name="swiper_help_title">Swiper কিভাবে কাজ করে</string>
     <string name="swiper_help_message">সিদ্ধান্ত নিতে প্রতিটি ফাইল সোয়াইপ করুন:\n\n← বামে সোয়াইপ: %1$s\n→ ডানে সোয়াইপ: %2$s\n↑ উপরে সোয়াইপ: এড়িয়ে যান\n↓ নিচে সোয়াইপ: পূর্বাবস্থা (প্রথম সোয়াইপের পর)\n\nআপনি নিচের বোতামগুলিও ব্যবহার করতে পারেন।\n\nশেষ হলে, আপনার সব সিদ্ধান্ত দেখতে \"পর্যালোচনা\" ট্যাপ করুন। পর্যালোচনা স্ক্রিনে নিশ্চিত না করা পর্যন্ত কিছুই মুছে ফেলা হবে না।</string>
-    <string name="swiper_gesture_overlay_dismiss_action">বুঝেছি</string>
     <string name="swiper_file_type_filter_title">শুধুমাত্র এই ফাইল ধরনগুলো দেখান</string>
     <string name="swiper_file_type_filter_hint">আপনি যে ধরনগুলো দেখতে চান তা চেক করুন। যদি কোনোটি চেক না করা থাকে, সমস্ত ফাইল দেখানো হবে।</string>
     <string name="swiper_file_type_category_images">ছবি</string>

--- a/app-tool-swiper/src/main/res/values-ca/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ca/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibra quan prengueu decisions sobre si voleu conservar o eliminar.</string>
     <string name="swiper_discard_session_confirmation_title">Voleu descartar la sessió?</string>
     <string name="swiper_discard_session_confirmation_message">Totes les decisions es perdran. N\'esteu segur?</string>
-    <string name="swiper_no_preview_available">No hi ha cap previsualització disponible</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Continua la sessió de fa %1$d dia (%2$d%% finalitzada)</item>
         <item quantity="other">Continua la sessió de fa %1$d dies (%2$d%% finalitzada)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Enrere!</string>
     <string name="swiper_stamp_undo_3">Vaja!</string>
     <string name="swiper_stamp_undo_4">Espera!</string>
-    <string name="swiper_gesture_overlay_dismiss">Toqueu qualsevol lloc per començar</string>
-    <string name="swiper_gesture_overlay_left_delete">← Suprimeix</string>
-    <string name="swiper_gesture_overlay_right_keep">Mantén →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Mantén</string>
-    <string name="swiper_gesture_overlay_right_delete">Suprimeix →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Omet</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Desfés</string>
     <string name="swiper_help_title">Com funciona l\'escombrador</string>
     <string name="swiper_help_message">Llisqueu cada fitxer per prendre una decisió:\n\n← Llisca a l\'esquerra: %1$s\n→ Llisca a la dreta: %2$s\n↑ Llisca amunt: Omet\n↓ Llisca avall: Desfés (després del primer lliscament)\n\nTambé podeu usar els botons de la part inferior.\n\nQuan hàgiu acabat, toqueu «Revisa» per veure totes les decisions. No se suprimeix res fins que ho confirmeu a la pantalla de revisió.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Entesos</string>
     <string name="swiper_file_type_filter_title">Mostra només aquests tipus de fitxers</string>
     <string name="swiper_file_type_filter_hint">Marqueu els tipus que voleu veure. Si no n\'hi ha cap de marcat, es mostren tots els fitxers.</string>
     <string name="swiper_file_type_category_images">Imatges</string>

--- a/app-tool-swiper/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ckb-rIR/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">لەرزاندن کاتێ بڕیاری پاراستن یان سڕینەوە دەدرێت.</string>
     <string name="swiper_discard_session_confirmation_title">دانیشتن بەتاڵ بکرێت؟</string>
     <string name="swiper_discard_session_confirmation_message">هەموو بڕیارەکان دەچنە دەست. دڵنیایت؟</string>
-    <string name="swiper_no_preview_available">پێشبینی بەردەست نییە</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">بەردەوامکردنی دانیشتن لە %1$d ڕۆژ پێش ئێستا (%2$d%% تەواوبووە)</item>
         <item quantity="other">بەردەوامکردنی دانیشتن لە %1$d ڕۆژ پێش ئێستا (%2$d%% تەواوبووە)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">دواوە!</string>
     <string name="swiper_stamp_undo_3">ئۆپس!</string>
     <string name="swiper_stamp_undo_4">وەستە!</string>
-    <string name="swiper_gesture_overlay_dismiss">بۆ دەستپێکردن لە هەر شوێنێک دەست بدە</string>
-    <string name="swiper_gesture_overlay_left_delete">← سڕینەوە</string>
-    <string name="swiper_gesture_overlay_right_keep">هێشتنەوە →</string>
-    <string name="swiper_gesture_overlay_left_keep">← هێشتنەوە</string>
-    <string name="swiper_gesture_overlay_right_delete">سڕینەوە →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ تێپەڕاندن</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ گەڕانەوە</string>
     <string name="swiper_help_title">چۆن Swiper کاردەکات</string>
     <string name="swiper_help_message">هەر فایلێک هەڵبسوڕێنە بۆ بڕیاردان:\n\n← هەڵسوڕاندن بۆ چەپ: %1$s\n→ هەڵسوڕاندن بۆ ڕاست: %2$s\n↑ هەڵسوڕاندن بۆ سەرەوە: تێپەڕاندن\n↓ هەڵسوڕاندن بۆ خوارەوە: گەڕانەوە (دوای یەکەم هەڵسوڕاندن)\n\nدەتوانیت دوگمەکانی خوارەوەش بەکاربهێنیت.\n\nکاتێک تەواو بوو، \"پێداچوونەوە\" بکە بۆ بینینی هەموو بڕیارەکانت. هیچ شتێک ناسڕێتەوە تاکو لە ڕوونمای پێداچوونەوەدا پشتڕاست بکەیتەوە.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">تێگەیشتم</string>
     <string name="swiper_file_type_filter_title">تەنها ئەم جۆرە فایلانە نیشان بدە</string>
     <string name="swiper_file_type_filter_hint">جۆرەکانی کە دەتەوێت ببینیت هەڵبژێرە. ئەگەر هیچیان هەڵنەبژێردرا، هەموو فایلەکان نیشان دەدرێن.</string>
     <string name="swiper_file_type_category_images">وێنەکان</string>

--- a/app-tool-swiper/src/main/res/values-cs/strings.xml
+++ b/app-tool-swiper/src/main/res/values-cs/strings.xml
@@ -68,7 +68,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrovat při rozhodnutí zachování nebo mazání.</string>
     <string name="swiper_discard_session_confirmation_title">Zahodit relaci?</string>
     <string name="swiper_discard_session_confirmation_message">Všechna rozhodnutí budou ztracena. Jste si jisti?</string>
-    <string name="swiper_no_preview_available">Náhled není dostupný</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Pokračovat v relaci před %1$d dnem (%2$d%% dokončeno)</item>
         <item quantity="few">Pokračovat v relaci před %1$d dny (%2$d%% dokončeno)</item>
@@ -167,16 +166,8 @@
     <string name="swiper_stamp_undo_2">Zpět!</string>
     <string name="swiper_stamp_undo_3">Oops!</string>
     <string name="swiper_stamp_undo_4">Počkat!</string>
-    <string name="swiper_gesture_overlay_dismiss">Začněte klepnutím kamkoli</string>
-    <string name="swiper_gesture_overlay_left_delete">← Smazat</string>
-    <string name="swiper_gesture_overlay_right_keep">Ponechat →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Ponechat</string>
-    <string name="swiper_gesture_overlay_right_delete">Smazat →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Přeskočit</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Vrať zpět</string>
     <string name="swiper_help_title">Jak funguje Swiper</string>
     <string name="swiper_help_message">Přejeďte prstem po každém souboru a rozhodněte se:\n\n← Přejetí doleva: %1$s\n→ Přejetí doprava: %2$s\n↑ Přejetí nahoru: Přeskočit\n↓ Přejetí dolů: Zrušit (po prvním přejetí)\n\nMůžete také použít tlačítka v dolní části.\n\nAž budete hotovi, klepněte na \"Posoudit\" a zobrazte všechna svá rozhodnutí. Nic se nesmaže, dokud nepotvrdíte na obrazovce s přehledem.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Rozumím</string>
     <string name="swiper_file_type_filter_title">Zobrazit pouze tyto typy souborů</string>
     <string name="swiper_file_type_filter_hint">Zaškrtněte typy, které chcete zobrazit. Pokud není zaškrtnuto nic, zobrazí se všechny soubory.</string>
     <string name="swiper_file_type_category_images">Obrázky</string>

--- a/app-tool-swiper/src/main/res/values-cy/strings.xml
+++ b/app-tool-swiper/src/main/res/values-cy/strings.xml
@@ -65,7 +65,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Dirgrynu wrth wneud penderfyniadau cadw neu ddileu.</string>
     <string name="swiper_discard_session_confirmation_title">Taflu\'r sesiwn?</string>
     <string name="swiper_discard_session_confirmation_message">Bydd pob penderfyniad yn cael ei golli. Ydych chi\'n sicr?</string>
-    <string name="swiper_no_preview_available">Dim rhagolwg ar gael</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="zero">Parhau â sesiwn o %1$d diwrnod yn ôl (%2$d%% wedi\'i gwblhau)</item>
         <item quantity="one">Parhau â sesiwn o %1$d diwrnod yn ôl (%2$d%% wedi\'i gwblhau)</item>
@@ -178,13 +177,6 @@
     <string name="swiper_stamp_undo_2">Nôl!</string>
     <string name="swiper_stamp_undo_3">Wps!</string>
     <string name="swiper_stamp_undo_4">Aros!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tapiwch unrhyw le i ddechrau</string>
-    <string name="swiper_gesture_overlay_left_delete">← Dileu</string>
-    <string name="swiper_gesture_overlay_right_keep">Cadw →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Cadw</string>
-    <string name="swiper_gesture_overlay_right_delete">Dileu →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Sgipio</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Dadwneud</string>
     <string name="swiper_help_title">Sut mae Swiper yn gweithio</string>
     <string name="swiper_help_message">Sweipiwch bob ffeil i wneud penderfyniad:\n\n← Sweipio i\'r chwith: %1$s\n→ Sweipio i\'r dde: %2$s\n↑ Sweipio i fyny: Sgipio\n↓ Sweipio i lawr: Dadwneud (ar ôl y sweipio cyntaf)\n\nGallwch hefyd ddefnyddio\'r botymau ar y gwaelod.\n\nPan fyddwch chi\'n barod, tapiwch \"Adolygu\" i weld eich holl benderfyniadau. Ni fydd unrhyw beth yn cael ei ddileu nes i chi gadarnhau ar y sgrin adolygu.</string>
 </resources>

--- a/app-tool-swiper/src/main/res/values-da/strings.xml
+++ b/app-tool-swiper/src/main/res/values-da/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrer ved behold- eller sletbeslutninger.</string>
     <string name="swiper_discard_session_confirmation_title">Kassér session?</string>
     <string name="swiper_discard_session_confirmation_message">Alle beslutninger vil gå tabt. Er du sikker?</string>
-    <string name="swiper_no_preview_available">Ingen forhåndsvisning tilgængelig</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Fortsæt session fra %1$d dag siden (%2$d%% færdig)</item>
         <item quantity="other">Fortsæt session fra %1$d dage siden (%2$d%% færdig)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Tilbage!</string>
     <string name="swiper_stamp_undo_3">Ups!</string>
     <string name="swiper_stamp_undo_4">Vent!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tryk hvor som helst for at starte</string>
-    <string name="swiper_gesture_overlay_left_delete">← Slet</string>
-    <string name="swiper_gesture_overlay_right_keep">Behold →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Behold</string>
-    <string name="swiper_gesture_overlay_right_delete">Slet →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Spring over</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Fortryd</string>
     <string name="swiper_help_title">Sådan fungerer Swiper</string>
     <string name="swiper_help_message">Stryg hver fil for at tage en beslutning:\n\n← Stryg til venstre: %1$s\n→ Stryg til højre: %2$s\n↑ Stryg op: Spring over\n↓ Stryg ned: Fortryd (efter første stryg)\n\nDu kan også bruge knapperne i bunden.\n\nNår du er færdig, tryk \"Gennemgå\" for at se alle dine beslutninger. Intet slettes, før du bekræfter på gennemgangsskærmen.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Forstået</string>
     <string name="swiper_file_type_filter_title">Vis kun disse filtyper</string>
     <string name="swiper_file_type_filter_hint">Markér de typer du vil se. Hvis ingen er markeret, vises alle filer.</string>
     <string name="swiper_file_type_category_images">Billeder</string>

--- a/app-tool-swiper/src/main/res/values-de/strings.xml
+++ b/app-tool-swiper/src/main/res/values-de/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrieren bei Behalten- oder Löschen-Entscheidungen.</string>
     <string name="swiper_discard_session_confirmation_title">Sitzung verwerfen?</string>
     <string name="swiper_discard_session_confirmation_message">Alle Entscheidungen gehen verloren. Bist du sicher?</string>
-    <string name="swiper_no_preview_available">Keine Vorschau verfügbar</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Sitzung von vor %1$d Tag fortsetzen (%2$d%% fertig)</item>
         <item quantity="other">Sitzung von vor %1$d Tagen fortsetzen (%2$d%% fertig)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Zurück!</string>
     <string name="swiper_stamp_undo_3">Ups!</string>
     <string name="swiper_stamp_undo_4">Warte!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tippe irgendwo, um zu starten</string>
-    <string name="swiper_gesture_overlay_left_delete">← Löschen</string>
-    <string name="swiper_gesture_overlay_right_keep">Behalten →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Behalten</string>
-    <string name="swiper_gesture_overlay_right_delete">Löschen →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Überspringen</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Rückgängig</string>
     <string name="swiper_help_title">So funktioniert Swiper</string>
     <string name="swiper_help_message">Wische über jede Datei, um eine Entscheidung zu treffen:\n\n← Nach links wischen: %1$s\n→ Nach rechts wischen: %2$s\n↑ Nach oben wischen: Überspringen\n↓ Nach unten wischen: Rückgängig (nach dem ersten Wischen)\n\nDu kannst auch die Buttons unten verwenden.\n\nWenn du fertig bist, tippe auf „Übersicht“, um alle deine Entscheidungen anzuzeigen. Nichts wird gelöscht, bis du es auf dem Übersichts-Bildschirm bestätigst.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Verstanden</string>
     <string name="swiper_file_type_filter_title">Nur diese Dateitypen anzeigen</string>
     <string name="swiper_file_type_filter_hint">Wähle die Typen aus, die du sehen möchtest. Wenn keine ausgewählt sind, werden alle Dateien angezeigt.</string>
     <string name="swiper_file_type_category_images">Bilder</string>

--- a/app-tool-swiper/src/main/res/values-el/strings.xml
+++ b/app-tool-swiper/src/main/res/values-el/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Δόνηση κατά τη λήψη αποφάσεων διατήρησης ή διαγραφής.</string>
     <string name="swiper_discard_session_confirmation_title">Απόρριψη συνεδρίας;</string>
     <string name="swiper_discard_session_confirmation_message">Όλες οι αποφάσεις θα χαθούν. Είστε σίγουροι;</string>
-    <string name="swiper_no_preview_available">Δεν υπάρχει διαθέσιμη προεπισκόπηση</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Συνέχεια συνεδρίας από %1$d ημέρα πριν (%2$d%% ολοκληρωμένο)</item>
         <item quantity="other">Συνέχεια συνεδρίας από %1$d ημέρες πριν (%2$d%% ολοκληρωμένο)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Πίσω!</string>
     <string name="swiper_stamp_undo_3">Ωχ!</string>
     <string name="swiper_stamp_undo_4">Περίμενε!</string>
-    <string name="swiper_gesture_overlay_dismiss">Πατήστε οπουδήποτε για να ξεκινήσετε</string>
-    <string name="swiper_gesture_overlay_left_delete">← Διαγραφή</string>
-    <string name="swiper_gesture_overlay_right_keep">Διατήρηση →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Διατήρηση</string>
-    <string name="swiper_gesture_overlay_right_delete">Διαγραφή →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Παράλειψη</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Αναίρεση</string>
     <string name="swiper_help_title">Πώς λειτουργεί το Swiper</string>
     <string name="swiper_help_message">Σαρώστε κάθε αρχείο για να λάβετε μια απόφαση:\n\n← Σάρωση αριστερά: %1$s\n→ Σάρωση δεξιά: %2$s\n↑ Σάρωση πάνω: Παράλειψη\n↓ Σάρωση κάτω: Αναίρεση (μετά την πρώτη σάρωση)\n\nΜπορείτε επίσης να χρησιμοποιήσετε τα κουμπιά στο κάτω μέρος.\n\nΌταν τελειώσετε, πατήστε \"Αξιολόγηση\" για να δείτε όλες τις αποφάσεις σας. Τίποτα δεν διαγράφεται μέχρι να επιβεβαιώσετε στην οθόνη αξιολόγησης.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Το κατάλαβα</string>
     <string name="swiper_file_type_filter_title">Εμφάνιση μόνο αυτών των τύπων αρχείων</string>
     <string name="swiper_file_type_filter_hint">Επιλέξτε τους τύπους που θέλετε να δείτε. Αν δεν επιλεγεί κανένας, εμφανίζονται όλα τα αρχεία.</string>
     <string name="swiper_file_type_category_images">Εικόνες</string>

--- a/app-tool-swiper/src/main/res/values-eo/strings.xml
+++ b/app-tool-swiper/src/main/res/values-eo/strings.xml
@@ -45,7 +45,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibri ĉe decidoj de konservi aŭ forigi.</string>
     <string name="swiper_discard_session_confirmation_title">Ĉu forĵeti seancon?</string>
     <string name="swiper_discard_session_confirmation_message">Ĉiuj decidoj perdiĝos. Ĉu vi certas?</string>
-    <string name="swiper_no_preview_available">Neniu antaŭrigardo disponebla</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Daŭrigi seancon de antaŭ %1$d tago (%2$d%% finita)</item>
         <item quantity="other">Daŭrigi seancon de antaŭ %1$d tagoj (%2$d%% finita)</item>
@@ -118,13 +117,6 @@
     <string name="swiper_stamp_undo_2">Reen!</string>
     <string name="swiper_stamp_undo_3">Ho!</string>
     <string name="swiper_stamp_undo_4">Atendu!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tuŝu ie ajn por komenci</string>
-    <string name="swiper_gesture_overlay_left_delete">← Forigi</string>
-    <string name="swiper_gesture_overlay_right_keep">Konservi →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Konservi</string>
-    <string name="swiper_gesture_overlay_right_delete">Forigi →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Preterpasi</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Malfari</string>
     <string name="swiper_help_title">Kiel Swiper funkcias</string>
     <string name="swiper_help_message">Svingu ĉiun dosieron por decidi:\n\n← Svingu maldekstren: %1$s\n→ Svingu dekstren: %2$s\n↑ Svingu supren: Preterpasi\n↓ Svingu malsupren: Malfari (post la unua svingo)\n\nVi ankaŭ povas uzi la butonojn ĉe la malsupro.\n\nKiam vi finis, tuŝu \"Revizio\" por vidi ĉiujn viajn decidojn. Nenio estas forigita ĝis vi konfirmas en la revizia ekrano.</string>
 </resources>

--- a/app-tool-swiper/src/main/res/values-es-rAR/strings.xml
+++ b/app-tool-swiper/src/main/res/values-es-rAR/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrar al tomar decisiones de mantener o eliminar.</string>
     <string name="swiper_discard_session_confirmation_title">¿Descartar sesión?</string>
     <string name="swiper_discard_session_confirmation_message">Todas las decisiones se perderán. ¿Estás seguro?</string>
-    <string name="swiper_no_preview_available">Vista previa no disponible</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Continuar sesión de hace %1$d día (%2$d%% completado)</item>
         <item quantity="other">Continuar sesión de hace %1$d días (%2$d%% completado)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">¡Volver!</string>
     <string name="swiper_stamp_undo_3">¡Uy!</string>
     <string name="swiper_stamp_undo_4">¡Esperá!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tocá en cualquier lugar para empezar</string>
-    <string name="swiper_gesture_overlay_left_delete">← Eliminar</string>
-    <string name="swiper_gesture_overlay_right_keep">Conservar →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Conservar</string>
-    <string name="swiper_gesture_overlay_right_delete">Eliminar →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Saltar</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Deshacer</string>
     <string name="swiper_help_title">Cómo funciona Swiper</string>
     <string name="swiper_help_message">Deslizá cada archivo para tomar una decisión:\n\n← Deslizar a la izquierda: %1$s\n→ Deslizar a la derecha: %2$s\n↑ Deslizar hacia arriba: Saltar\n↓ Deslizar hacia abajo: Deshacer (después del primer deslizamiento)\n\nTambién podés usar los botones de abajo.\n\nCuando termines, tocá \"Revisar\" para ver todas tus decisiones. No se elimina nada hasta que confirmes en la pantalla de revisión.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Entendido</string>
     <string name="swiper_file_type_filter_title">Mostrar solo estos tipos de archivo</string>
     <string name="swiper_file_type_filter_hint">Marcá los tipos que querés ver. Si no hay ninguno marcado, se muestran todos los archivos.</string>
     <string name="swiper_file_type_category_images">Imágenes</string>

--- a/app-tool-swiper/src/main/res/values-es-rMX/strings.xml
+++ b/app-tool-swiper/src/main/res/values-es-rMX/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrar al tomar decisiones de conservar o eliminar.</string>
     <string name="swiper_discard_session_confirmation_title">¿Descartar sesión?</string>
     <string name="swiper_discard_session_confirmation_message">Todas las decisiones se perderán. ¿Estás seguro?</string>
-    <string name="swiper_no_preview_available">Vista previa no disponible</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Continuar sesión de hace %1$d día (%2$d%% completado)</item>
         <item quantity="other">Continuar sesión de hace %1$d días (%2$d%% completado)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">¡Atrás!</string>
     <string name="swiper_stamp_undo_3">¡Ups!</string>
     <string name="swiper_stamp_undo_4">¡Espera!</string>
-    <string name="swiper_gesture_overlay_dismiss">Toca en cualquier lugar para comenzar</string>
-    <string name="swiper_gesture_overlay_left_delete">← Eliminar</string>
-    <string name="swiper_gesture_overlay_right_keep">Conservar →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Conservar</string>
-    <string name="swiper_gesture_overlay_right_delete">Eliminar →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Omitir</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Deshacer</string>
     <string name="swiper_help_title">Cómo funciona Swiper</string>
     <string name="swiper_help_message">Desliza cada archivo para tomar una decisión:\n\n← Desliza a la izquierda: %1$s\n→ Desliza a la derecha: %2$s\n↑ Desliza hacia arriba: Omitir\n↓ Desliza hacia abajo: Deshacer (después del primer deslizamiento)\n\nTambién puedes usar los botones de la parte inferior.\n\nCuando termines, toca \"Revisar\" para ver todas tus decisiones. Nada se elimina hasta que confirmes en la pantalla de revisión.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Entendido</string>
     <string name="swiper_file_type_filter_title">Mostrar solo estos tipos de archivo</string>
     <string name="swiper_file_type_filter_hint">Marca los tipos que deseas ver. Si no se marca ninguno, se muestran todos los archivos.</string>
     <string name="swiper_file_type_category_images">Imágenes</string>

--- a/app-tool-swiper/src/main/res/values-es/strings.xml
+++ b/app-tool-swiper/src/main/res/values-es/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrar al tomar decisiones de conservar o eliminar.</string>
     <string name="swiper_discard_session_confirmation_title">¿Descartar sesión?</string>
     <string name="swiper_discard_session_confirmation_message">Todas las decisiones se perderán. ¿Estás seguro?</string>
-    <string name="swiper_no_preview_available">Vista previa no disponible</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Continuar sesión de hace %1$d día (%2$d%% completado)</item>
         <item quantity="other">Continuar sesión de hace %1$d días (%2$d%% completado)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">¡Volver!</string>
     <string name="swiper_stamp_undo_3">¡Ups!</string>
     <string name="swiper_stamp_undo_4">¡Espera!</string>
-    <string name="swiper_gesture_overlay_dismiss">Toca en cualquier lugar para empezar</string>
-    <string name="swiper_gesture_overlay_left_delete">← Eliminar</string>
-    <string name="swiper_gesture_overlay_right_keep">Conservar →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Conservar</string>
-    <string name="swiper_gesture_overlay_right_delete">Eliminar →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Omitir</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Deshacer</string>
     <string name="swiper_help_title">Cómo funciona el Limpiador</string>
     <string name="swiper_help_message">Desliza cada archivo para tomar una decisión:\n\n← Deslizar a la izquierda: %1$s\n→ Deslizar a la derecha: %2$s\n↑ Deslizar hacia arriba: Omitir\n↓ Deslizar hacia abajo: Deshacer (después del primer deslizamiento)\n\nTambién puedes usar los botones de la parte inferior.\n\nCuando termines, toca \"Revisar\" para ver todas tus decisiones. No se elimina nada hasta que confirmes en la pantalla de revisión.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Entiendo</string>
     <string name="swiper_file_type_filter_title">Mostrar solo estos tipos de archivo</string>
     <string name="swiper_file_type_filter_hint">Selecciona los tipos que quieres ver. Si ninguno está seleccionado, se muestran todos los archivos.</string>
     <string name="swiper_file_type_category_images">Imágenes</string>

--- a/app-tool-swiper/src/main/res/values-et-rEE/strings.xml
+++ b/app-tool-swiper/src/main/res/values-et-rEE/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Telefon väriseb säilitamisel või kustutamisel.</string>
     <string name="swiper_discard_session_confirmation_title">Kustutada seanss?</string>
     <string name="swiper_discard_session_confirmation_message">Otsused? Mäluauku! Oled kindel?</string>
-    <string name="swiper_no_preview_available">Eelvaade puudub</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Jätka %1$d päeva tagust seanssi (%2$d%% valmis)</item>
         <item quantity="other">Jätka %1$d päeva tagust seanssi (%2$d%% valmis)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Tagasi!</string>
     <string name="swiper_stamp_undo_3">Isver-susver!</string>
     <string name="swiper_stamp_undo_4">Pea hoogu!</string>
-    <string name="swiper_gesture_overlay_dismiss">Alustamiseks puuduta kuhugi</string>
-    <string name="swiper_gesture_overlay_left_delete">← Kustuta</string>
-    <string name="swiper_gesture_overlay_right_keep">Säilita →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Säilita</string>
-    <string name="swiper_gesture_overlay_right_delete">Kustuta →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Jäta vahele</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Võta tagasi</string>
     <string name="swiper_help_title">Kuidas Pühkija töötab</string>
     <string name="swiper_help_message">Otsustamiseks pühi iga faili:\n\n← Pühi vasakule: %1$s\n→ Pühi paremale: %2$s\n↑ Pühi üles: jäta vahele\n↓ Pühi alla: võta tagasi (pärast esimest pühkimist)\n\nVõid kasutada ka alumisi nuppe.\n\nKui oled lõpetanud, puuduta „Vaata üle“, et näha kõiki oma otsuseid. Midagi ei kustutata enne, kui kinnitad ülevaatekuval.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Selge!</string>
     <string name="swiper_file_type_filter_title">Kuva ainult neid failitüüpe</string>
     <string name="swiper_file_type_filter_hint">Märgi tüübid, mida soovid näha. Kui ühtegi pole märgitud, kuvatakse kõik failid.</string>
     <string name="swiper_file_type_category_images">Pildid</string>

--- a/app-tool-swiper/src/main/res/values-eu-rES/strings.xml
+++ b/app-tool-swiper/src/main/res/values-eu-rES/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Dardara gorde edo ezabatze-erabakiak hartzerakoan.</string>
     <string name="swiper_discard_session_confirmation_title">Baztertu saioa?</string>
     <string name="swiper_discard_session_confirmation_message">Erabaki guztiak galduko dira. Ziur zaude?</string>
-    <string name="swiper_no_preview_available">Ez dago aurreikuspenak erabilgarri</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Jarraitu saioa %1$d egun bueltatik (%2$d%% bukatua)</item>
         <item quantity="other">Jarraitu saioa %1$d egun bueltatik (%2$d%% bukatua)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Atzera!</string>
     <string name="swiper_stamp_undo_3">Aupa!</string>
     <string name="swiper_stamp_undo_4">Itxaron!</string>
-    <string name="swiper_gesture_overlay_dismiss">Sakatu edonon hasteko</string>
-    <string name="swiper_gesture_overlay_left_delete">← Ezabatu</string>
-    <string name="swiper_gesture_overlay_right_keep">Gorde →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Gorde</string>
-    <string name="swiper_gesture_overlay_right_delete">Ezabatu →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Saltatu</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Desegin</string>
     <string name="swiper_help_title">Swiper nola funtzionatzen duen</string>
     <string name="swiper_help_message">Irristatu fitxategi bakoitza erabaki bat hartzeko:\n\n← Irristatu ezkerrera: %1$s\n→ Irristatu eskuinera: %2$s\n↑ Irristatu gora: Saltatu\n↓ Irristatu behera: Desegin (lehen irristadaren ondoren)\n\nBeheko botoiak ere erabil ditzakezu.\n\nBukatutakoan, sakatu \"Berrikusi\" zure erabaki guztiak ikusteko. Ezer ez da ezabatuko berrikusketa pantailan baieztatu arte.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Ulertuta</string>
     <string name="swiper_file_type_filter_title">Erakutsi fitxategi mota hauek soilik</string>
     <string name="swiper_file_type_filter_hint">Hautatu ikusi nahi dituzun motak. Bat ere hautatzen ez bada, fitxategi guztiak erakutsiko dira.</string>
     <string name="swiper_file_type_category_images">Irudiak</string>

--- a/app-tool-swiper/src/main/res/values-fa/strings.xml
+++ b/app-tool-swiper/src/main/res/values-fa/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">لرزش هنگام تصمیم‌گیری حفظ یا حذف.</string>
     <string name="swiper_discard_session_confirmation_title">جلسه کنار گذاشته شود؟</string>
     <string name="swiper_discard_session_confirmation_message">تمام تصمیم‌ها از دست خواهند رفت. آیا مطمئن هستید؟</string>
-    <string name="swiper_no_preview_available">پیش‌نمایش در دسترس نیست</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">ادامه جلسه از %1$d روز پیش (%2$d%% تکمیل شده)</item>
         <item quantity="other">ادامه جلسه از %1$d روز پیش (%2$d%% تکمیل شده)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">برگرد!</string>
     <string name="swiper_stamp_undo_3">اوه!</string>
     <string name="swiper_stamp_undo_4">صبر!</string>
-    <string name="swiper_gesture_overlay_dismiss">برای شروع هر جایی ضربه بزنید</string>
-    <string name="swiper_gesture_overlay_left_delete">← حذف</string>
-    <string name="swiper_gesture_overlay_right_keep">نگه‌داشتن →</string>
-    <string name="swiper_gesture_overlay_left_keep">← نگه‌داشتن</string>
-    <string name="swiper_gesture_overlay_right_delete">حذف →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ رد شدن</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ بازگشت</string>
     <string name="swiper_help_title">نحوه کار Swiper</string>
     <string name="swiper_help_message">هر فایل را بکشید تا تصمیم بگیرید:\n\n← کشیدن به چپ: %1$s\n→ کشیدن به راست: %2$s\n↑ کشیدن به بالا: رد شدن\n↓ کشیدن به پایین: بازگشت (پس از اولین کشیدن)\n\nهمچنین می‌توانید از دکمه‌های پایین استفاده کنید.\n\nوقتی کارتان تمام شد، روی \"بررسی\" ضربه بزنید تا همه تصمیم‌هایتان را ببینید. تا زمانی که در صفحه بررسی تأیید نکنید، هیچ چیز حذف نمی‌شود.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">فهمیدم</string>
     <string name="swiper_file_type_filter_title">فقط این نوع‌های فایل را نشان بده</string>
     <string name="swiper_file_type_filter_hint">نوع‌هایی که می‌خواهید ببینید را علامت بزنید. اگر هیچ‌کدام علامت‌زده نشده باشد، همه فایل‌ها نشان داده می‌شوند.</string>
     <string name="swiper_file_type_category_images">تصاویر</string>

--- a/app-tool-swiper/src/main/res/values-fi/strings.xml
+++ b/app-tool-swiper/src/main/res/values-fi/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Värise tehdessä säilytys- tai poistopäätöksiä.</string>
     <string name="swiper_discard_session_confirmation_title">Hylätäänkö istunto?</string>
     <string name="swiper_discard_session_confirmation_message">Kaikki päätökset menetetään. Oletko varma?</string>
-    <string name="swiper_no_preview_available">Esikatselu ei saatavilla</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Jatka istuntoa %1$d päivän takaa (%2$d%% valmis)</item>
         <item quantity="other">Jatka istuntoa %1$d päivän takaa (%2$d%% valmis)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Takaisin!</string>
     <string name="swiper_stamp_undo_3">Oho!</string>
     <string name="swiper_stamp_undo_4">Odota!</string>
-    <string name="swiper_gesture_overlay_dismiss">Napauta mitä tahansa aloittaaksesi</string>
-    <string name="swiper_gesture_overlay_left_delete">← Poista</string>
-    <string name="swiper_gesture_overlay_right_keep">Säilytä →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Säilytä</string>
-    <string name="swiper_gesture_overlay_right_delete">Poista →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Ohita</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Kumoa</string>
     <string name="swiper_help_title">Miten Pyyhkäisijä toimii</string>
     <string name="swiper_help_message">Pyyhkäise jokainen tiedosto päätöksen tekemiseksi:\n\n← Pyyhkäise vasemmalle: %1$s\n→ Pyyhkäise oikealle: %2$s\n↑ Pyyhkäise ylös: Ohita\n↓ Pyyhkäise alas: Kumoa (ensimmäisen pyyhkäisyn jälkeen)\n\nVoit myös käyttää alareunan painikkeita.\n\nKun olet valmis, napauta \"Tarkista\" nähdäksesi kaikki päätöksesi. Mitään ei poisteta ennen kuin vahvistat tarkistusnäytöllä.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Selvä</string>
     <string name="swiper_file_type_filter_title">Näytä vain nämä tiedostotyypit</string>
     <string name="swiper_file_type_filter_hint">Valitse tyypit, jotka haluat nähdä. Jos mitään ei ole valittu, kaikki tiedostot näytetään.</string>
     <string name="swiper_file_type_category_images">Kuvat</string>

--- a/app-tool-swiper/src/main/res/values-fil/strings.xml
+++ b/app-tool-swiper/src/main/res/values-fil/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Mag-vibrate kapag gumagawa ng desisyon na itabi o i-delete.</string>
     <string name="swiper_discard_session_confirmation_title">Itapon ang session?</string>
     <string name="swiper_discard_session_confirmation_message">Mawawala ang lahat ng desisyon. Sigurado ka ba?</string>
-    <string name="swiper_no_preview_available">Walang preview na available</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Ipagpatuloy ang session mula %1$d araw na ang nakalipas (%2$d%% tapos na)</item>
         <item quantity="other">Ipagpatuloy ang session mula %1$d araw na ang nakalipas (%2$d%% tapos na)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Bumalik!</string>
     <string name="swiper_stamp_undo_3">Ay!</string>
     <string name="swiper_stamp_undo_4">Teka!</string>
-    <string name="swiper_gesture_overlay_dismiss">I-tap kahit saan para magsimula</string>
-    <string name="swiper_gesture_overlay_left_delete">← Burahin</string>
-    <string name="swiper_gesture_overlay_right_keep">Itabi →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Itabi</string>
-    <string name="swiper_gesture_overlay_right_delete">Burahin →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Laktawan</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ I-undo</string>
     <string name="swiper_help_title">Paano gumagana ang Swiper</string>
     <string name="swiper_help_message">I-swipe ang bawat file para gumawa ng desisyon:\n\n← I-swipe pakaliwa: %1$s\n→ I-swipe pakanan: %2$s\n↑ I-swipe pataas: Laktawan\n↓ I-swipe pababa: I-undo (pagkatapos ng unang swipe)\n\nMaaari ka ring gumamit ng mga button sa ibaba.\n\nKapag tapos ka na, i-tap ang \"Suriin\" para makita ang lahat ng iyong desisyon. Walang nabubura hanggang hindi mo kinukumpirma sa review screen.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Kuha ko</string>
     <string name="swiper_file_type_filter_title">Ipakita lamang ang mga uri ng file na ito</string>
     <string name="swiper_file_type_filter_hint">Suriin ang mga uri na nais mong makita. Kung wala ang namarkahan, lahat ng mga file ay ipinapakita.</string>
     <string name="swiper_file_type_category_images">Mga Larawan</string>

--- a/app-tool-swiper/src/main/res/values-fr/strings.xml
+++ b/app-tool-swiper/src/main/res/values-fr/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrer pour les décisions de conservation ou de suppression.</string>
     <string name="swiper_discard_session_confirmation_title">Abandonner la session ?</string>
     <string name="swiper_discard_session_confirmation_message">Toutes les décisions seront perdues. Confirmez-vous ?</string>
-    <string name="swiper_no_preview_available">Aucun aperçu n’est proposé</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Poursuivre la session d’il y a %1$d jour (%2$d %% terminé)</item>
         <item quantity="other">Poursuivre la session d’il y a %1$d jours (%2$d %% terminé)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Annuler !</string>
     <string name="swiper_stamp_undo_3">Oups !</string>
     <string name="swiper_stamp_undo_4">Attendre !</string>
-    <string name="swiper_gesture_overlay_dismiss">Touchez n’importe où pour commencer</string>
-    <string name="swiper_gesture_overlay_left_delete">← Supprimer</string>
-    <string name="swiper_gesture_overlay_right_keep">Conserver →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Conserver</string>
-    <string name="swiper_gesture_overlay_right_delete">Supprimer →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Ignorer</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Annuler</string>
     <string name="swiper_help_title">Fonctionnement du Balayeur</string>
     <string name="swiper_help_message">Balayez chaque fichier pour prendre une décision :\n\n← Balayer vers la gauche : %1$s\n→ Balayer vers la droite : %2$s\n↑ Balayer vers le haut : Ignorer\n↓ Balayer vers le bas : Annuler (après le premier balayage)\n\nVous pouvez aussi utiliser les boutons situés en bas.\n\nQuand vous avez terminé, touchez « Examiner » pour afficher vos décisions. Rien n’est supprimé tant que vous ne confirmez pas sur l’écran de révision.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">J’ai compris</string>
     <string name="swiper_file_type_filter_title">N’afficher que ces types de fichiers</string>
     <string name="swiper_file_type_filter_hint">Cochez les types que vous voulez voir. Si aucun n’est coché, tous les fichiers sont affichés.</string>
     <string name="swiper_file_type_category_images">Images</string>

--- a/app-tool-swiper/src/main/res/values-ga/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ga/strings.xml
@@ -60,7 +60,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Crith agus cinntí coinneála nó scriosaidh á ndéanamh.</string>
     <string name="swiper_discard_session_confirmation_title">Diúscair an seisiún?</string>
     <string name="swiper_discard_session_confirmation_message">Caillfear gach cinneadh. An bhfuil tú cinnte?</string>
-    <string name="swiper_no_preview_available">Níl réamhamharc ar fáil</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Lean ar aghaidh le seisiún ó %1$d lá ó shin (%2$d%% críochnaithe)</item>
         <item quantity="two">Lean ar aghaidh le seisiún ó %1$d lá ó shin (%2$d%% críochnaithe)</item>
@@ -163,13 +162,6 @@
     <string name="swiper_stamp_undo_2">Siar!</string>
     <string name="swiper_stamp_undo_3">Úps!</string>
     <string name="swiper_stamp_undo_4">Fan!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tapáil áit ar bith chun tosú</string>
-    <string name="swiper_gesture_overlay_left_delete">← Scrios</string>
-    <string name="swiper_gesture_overlay_right_keep">Coinnigh →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Coinnigh</string>
-    <string name="swiper_gesture_overlay_right_delete">Scrios →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Scipeáil</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Cealaigh</string>
     <string name="swiper_help_title">Conas a oibríonn Swiper</string>
     <string name="swiper_help_message">Svaidhpeáil gach comhad chun cinneadh a dhéanamh:\n\n← Svaidhpeáil ar chlé: %1$s\n→ Svaidhpeáil ar dheis: %2$s\n↑ Svaidhpeáil suas: Scipeáil\n↓ Svaidhpeáil síos: Cealaigh (tar éis an chéad svaidhpeáil)\n\nIs féidir leat na cnaipí ag an mbun a úsáid freisin.\n\nNuair atá tú réidh, tapáil \"Athbhreithniú\" chun do chinntí go léir a fheiceáil. Ní scriostar aon rud go dtí go ndearbhaíonn tú ar an scáileán athbhreithnithe.</string>
 </resources>

--- a/app-tool-swiper/src/main/res/values-gl-rES/strings.xml
+++ b/app-tool-swiper/src/main/res/values-gl-rES/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrar ao tomar decisións de gardar ou eliminar.</string>
     <string name="swiper_discard_session_confirmation_title">Descartar sesión?</string>
     <string name="swiper_discard_session_confirmation_message">Perderanse todas as decisións. Estás seguro?</string>
-    <string name="swiper_no_preview_available">Non hai vista previa dispoñible</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Continuar sesión de hai %1$d día (%2$d%% rematado)</item>
         <item quantity="other">Continuar sesión de hai %1$d días (%2$d%% rematado)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Atrás!</string>
     <string name="swiper_stamp_undo_3">Ops!</string>
     <string name="swiper_stamp_undo_4">Agarda!</string>
-    <string name="swiper_gesture_overlay_dismiss">Toca en calquera lugar para comezar</string>
-    <string name="swiper_gesture_overlay_left_delete">← Eliminar</string>
-    <string name="swiper_gesture_overlay_right_keep">Manter →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Manter</string>
-    <string name="swiper_gesture_overlay_right_delete">Eliminar →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Saltar</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Desfacer</string>
     <string name="swiper_help_title">Como funciona Swiper</string>
     <string name="swiper_help_message">Pasa o dedo en cada ficheiro para tomar unha decisión:\n\n← Pasar á esquerda: %1$s\n→ Pasar á dereita: %2$s\n↑ Pasar cara arriba: Saltar\n↓ Pasar cara abaixo: Desfacer (despois do primeiro xesto)\n\nTamén podes usar os botóns de abaixo.\n\nCando remates, toca \"Revisar\" para ver todas as túas decisións. Non se elimina nada ata que confirmes na pantalla de revisión.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Entendido</string>
     <string name="swiper_file_type_filter_title">Mostrar só estes tipos de ficheiro</string>
     <string name="swiper_file_type_filter_hint">Marca os tipos que queres ver. Se non se marca ningún, móstranse todos os ficheiros.</string>
     <string name="swiper_file_type_category_images">Imaxes</string>

--- a/app-tool-swiper/src/main/res/values-hi-rIN/strings.xml
+++ b/app-tool-swiper/src/main/res/values-hi-rIN/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">रखने या हटाने का निर्णय लेते समय कंपन करें।</string>
     <string name="swiper_discard_session_confirmation_title">सत्र छोड़ें?</string>
     <string name="swiper_discard_session_confirmation_message">सभी निर्णय खो जाएंगे। क्या आप निश्चित हैं?</string>
-    <string name="swiper_no_preview_available">कोई पूर्वावलोकन उपलब्ध नहीं</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d दिन पहले का सत्र जारी रखें (%2$d%% पूर्ण)</item>
         <item quantity="other">%1$d दिन पहले का सत्र जारी रखें (%2$d%% पूर्ण)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">पीछे!</string>
     <string name="swiper_stamp_undo_3">अरे!</string>
     <string name="swiper_stamp_undo_4">रुको!</string>
-    <string name="swiper_gesture_overlay_dismiss">शुरू करने के लिए कहीं भी टैप करें</string>
-    <string name="swiper_gesture_overlay_left_delete">← हटाएं</string>
-    <string name="swiper_gesture_overlay_right_keep">रखें →</string>
-    <string name="swiper_gesture_overlay_left_keep">← रखें</string>
-    <string name="swiper_gesture_overlay_right_delete">हटाएं →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ छोड़ें</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ पूर्ववत करें</string>
     <string name="swiper_help_title">Swiper कैसे काम करता है</string>
     <string name="swiper_help_message">प्रत्येक फ़ाइल पर निर्णय लेने के लिए स्वाइप करें:\n\n← बाएं स्वाइप करें: %1$s\n→ दाएं स्वाइप करें: %2$s\n↑ ऊपर स्वाइप करें: छोड़ें\n↓ नीचे स्वाइप करें: पूर्ववत करें (पहले स्वाइप के बाद)\n\nआप नीचे दिए गए बटनों का भी उपयोग कर सकते हैं।\n\nजब आप कर लें, तो अपने सभी निर्णय देखने के लिए \"समीक्षा\" पर टैप करें। समीक्षा स्क्रीन पर पुष्टि करने तक कुछ भी हटाया नहीं जाता।</string>
-    <string name="swiper_gesture_overlay_dismiss_action">समझ गया</string>
     <string name="swiper_file_type_filter_title">केवल ये फ़ाइल प्रकार दिखाएं</string>
     <string name="swiper_file_type_filter_hint">वे प्रकार चुनें जो आप देखना चाहते हैं। यदि कोई नहीं चुना गया, तो सभी फ़ाइलें दिखाई जाएंगी।</string>
     <string name="swiper_file_type_category_images">चित्र</string>

--- a/app-tool-swiper/src/main/res/values-hr/strings.xml
+++ b/app-tool-swiper/src/main/res/values-hr/strings.xml
@@ -62,7 +62,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibracija pri donošenju odluka o zadržavanju ili brisanju.</string>
     <string name="swiper_discard_session_confirmation_title">Odbaciti sesiju?</string>
     <string name="swiper_discard_session_confirmation_message">Sve odluke će biti izgubljene. Jeste li sigurni?</string>
-    <string name="swiper_no_preview_available">Pregled nije dostupan</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Nastavite sesiju od prije %1$d dan (%2$d%% završeno)</item>
         <item quantity="few">Nastavite sesiju od prije %1$d dana (%2$d%% završeno)</item>
@@ -150,16 +149,8 @@
     <string name="swiper_stamp_undo_2">Natrag!</string>
     <string name="swiper_stamp_undo_3">Ups!</string>
     <string name="swiper_stamp_undo_4">Čekaj!</string>
-    <string name="swiper_gesture_overlay_dismiss">Dodirnite bilo gdje za početak</string>
-    <string name="swiper_gesture_overlay_left_delete">← Izbriši</string>
-    <string name="swiper_gesture_overlay_right_keep">Zadrži →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Zadrži</string>
-    <string name="swiper_gesture_overlay_right_delete">Izbriši →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Preskoči</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Poništi</string>
     <string name="swiper_help_title">Kako Swiper radi</string>
     <string name="swiper_help_message">Povucite svaku datoteku za donošenje odluke:\n\n← Povucite ulijevo: %1$s\n→ Povucite udesno: %2$s\n↑ Povucite prema gore: Preskoči\n↓ Povucite prema dolje: Poništi (nakon prvog povlačenja)\n\nMožete koristiti i gumbe na dnu.\n\nKada završite, dodirnite \"Pregled\" za prikaz svih vaših odluka. Ništa se ne briše dok ne potvrdite na zaslonu za pregled.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">U redu</string>
     <string name="swiper_file_type_filter_title">Prikaži samo ove vrste datoteka</string>
     <string name="swiper_file_type_filter_hint">Označite vrste koje želite vidjeti. Ako ništa nije označeno, prikazuju se sve datoteke.</string>
     <string name="swiper_file_type_category_images">Slike</string>

--- a/app-tool-swiper/src/main/res/values-hu/strings.xml
+++ b/app-tool-swiper/src/main/res/values-hu/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Rezgés a megtartás vagy törlés döntéseknél.</string>
     <string name="swiper_discard_session_confirmation_title">Munkamenet elvetése?</string>
     <string name="swiper_discard_session_confirmation_message">Minden döntés elvész. Biztosan folytatod?</string>
-    <string name="swiper_no_preview_available">Nincs elérhető előnézet</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Munkamenet folytatása %1$d napja (%2$d%% kész)</item>
         <item quantity="other">Munkamenet folytatása %1$d napja (%2$d%% kész)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Mégsem!</string>
     <string name="swiper_stamp_undo_3">Hoppá!</string>
     <string name="swiper_stamp_undo_4">Várj!</string>
-    <string name="swiper_gesture_overlay_dismiss">Érintsd meg bárhol a kezdéshez</string>
-    <string name="swiper_gesture_overlay_left_delete">← Törlés</string>
-    <string name="swiper_gesture_overlay_right_keep">Megtartás →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Megtartás</string>
-    <string name="swiper_gesture_overlay_right_delete">Törlés →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Kihagyás</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Visszavonás</string>
     <string name="swiper_help_title">Hogyan működik a Swiper</string>
     <string name="swiper_help_message">Húzd az egyes fájlokat a döntéshez:\n\n← Húzás balra: %1$s\n→ Húzás jobbra: %2$s\n↑ Húzás felfelé: Kihagyás\n↓ Húzás lefelé: Visszavonás (az első húzás után)\n\nAz alul lévő gombokat is használhatod.\n\nHa végeztél, érintsd meg az \"Áttekintés\" gombot az összes döntésed megtekintéséhez. Semmi nem törlődik, amíg meg nem erősíted az áttekintő képernyőn.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Megvan</string>
     <string name="swiper_file_type_filter_title">Csak ezeket a fájltípusokat mutassa</string>
     <string name="swiper_file_type_filter_hint">Jelöld be a megtekinteni kívánt típusokat. Ha egyik sincs bejelölve, az összes fájl megjelenik.</string>
     <string name="swiper_file_type_category_images">Képek</string>

--- a/app-tool-swiper/src/main/res/values-in/strings.xml
+++ b/app-tool-swiper/src/main/res/values-in/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Bergetar saat membuat keputusan simpan atau hapus.</string>
     <string name="swiper_discard_session_confirmation_title">Buang sesi?</string>
     <string name="swiper_discard_session_confirmation_message">Semua keputusan akan hilang. Apakah Anda yakin?</string>
-    <string name="swiper_no_preview_available">Pratinjau tidak tersedia</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">Lanjutkan sesi dari %1$d hari yang lalu (%2$d%% selesai)</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">Kembali!</string>
     <string name="swiper_stamp_undo_3">Ups!</string>
     <string name="swiper_stamp_undo_4">Tunggu!</string>
-    <string name="swiper_gesture_overlay_dismiss">Ketuk di mana saja untuk mulai</string>
-    <string name="swiper_gesture_overlay_left_delete">← Hapus</string>
-    <string name="swiper_gesture_overlay_right_keep">Simpan →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Simpan</string>
-    <string name="swiper_gesture_overlay_right_delete">Hapus →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Lewati</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Batal</string>
     <string name="swiper_help_title">Cara kerja Pemilah</string>
     <string name="swiper_help_message">Geser setiap file untuk membuat keputusan:\n\n← Geser ke kiri: %1$s\n→ Geser ke kanan: %2$s\n↑ Geser ke atas: Lewati\n↓ Geser ke bawah: Batal (setelah geseran pertama)\n\nAnda juga dapat menggunakan tombol di bagian bawah.\n\nSetelah selesai, ketuk \"Tinjau\" untuk melihat semua keputusan Anda. Tidak ada yang dihapus sampai Anda mengonfirmasi di layar tinjauan.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Mengerti</string>
     <string name="swiper_file_type_filter_title">Hanya tampilkan tipe file ini</string>
     <string name="swiper_file_type_filter_hint">Centang tipe yang ingin Anda lihat. Jika tidak ada yang dicentang, semua file ditampilkan.</string>
     <string name="swiper_file_type_category_images">Gambar</string>

--- a/app-tool-swiper/src/main/res/values-is/strings.xml
+++ b/app-tool-swiper/src/main/res/values-is/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Titra þegar halda eða eyða ákvörðunum er tekið.</string>
     <string name="swiper_discard_session_confirmation_title">Fleygja lotu?</string>
     <string name="swiper_discard_session_confirmation_message">Allar ákvarðanir glatast. Ertu viss?</string>
-    <string name="swiper_no_preview_available">Engin forskoðun tiltæk</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Halda áfram með lotu frá %1$d degi síðan (%2$d%% lokið)</item>
         <item quantity="other">Halda áfram með lotu frá %1$d dögum síðan (%2$d%% lokið)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Til baka!</string>
     <string name="swiper_stamp_undo_3">Úps!</string>
     <string name="swiper_stamp_undo_4">Bíddu!</string>
-    <string name="swiper_gesture_overlay_dismiss">Ýttu hvar sem er til að byrja</string>
-    <string name="swiper_gesture_overlay_left_delete">← Eyða</string>
-    <string name="swiper_gesture_overlay_right_keep">Halda →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Halda</string>
-    <string name="swiper_gesture_overlay_right_delete">Eyða →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Sleppa</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Afturkalla</string>
     <string name="swiper_help_title">Hvernig Strjúkari virkar</string>
     <string name="swiper_help_message">Strjúktu hverri skrá til að taka ákvörðun:\n\n← Strjúktu til vinstri: %1$s\n→ Strjúktu til hægri: %2$s\n↑ Strjúktu upp: Sleppa\n↓ Strjúktu niður: Afturkalla (eftir fyrsta strjúk)\n\nÞú getur líka notað hnappana neðst.\n\nÞegar þú ert búin/n, ýttu á \"Yfirfara\" til að sjá allar ákvarðanir þínar. Ekkert er eytt fyrr en þú staðfestir á yfirferðarskjánum.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Ég skil</string>
     <string name="swiper_file_type_filter_title">Sýna aðeins þessar skráargerðir</string>
     <string name="swiper_file_type_filter_hint">Hakaðu við þær gerðir sem þú vilt sjá. Ef engar eru hakað við, birtast allar skrár.</string>
     <string name="swiper_file_type_category_images">Myndir</string>

--- a/app-tool-swiper/src/main/res/values-it/strings.xml
+++ b/app-tool-swiper/src/main/res/values-it/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibra quando si prendono decisioni di tenere o eliminare.</string>
     <string name="swiper_discard_session_confirmation_title">Scartare la sessione?</string>
     <string name="swiper_discard_session_confirmation_message">Tutte le decisioni saranno perse. Sei sicuro?</string>
-    <string name="swiper_no_preview_available">Nessuna anteprima disponibile</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Continua sessione da %1$d giorno fa (%2$d%% completato)</item>
         <item quantity="other">Continua sessione da %1$d giorni fa (%2$d%% completato)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Indietro!</string>
     <string name="swiper_stamp_undo_3">Ops!</string>
     <string name="swiper_stamp_undo_4">Aspetta!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tocca ovunque per iniziare</string>
-    <string name="swiper_gesture_overlay_left_delete">← Elimina</string>
-    <string name="swiper_gesture_overlay_right_keep">Tieni →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Tieni</string>
-    <string name="swiper_gesture_overlay_right_delete">Elimina →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Salta</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Annulla</string>
     <string name="swiper_help_title">Come funziona Swiper</string>
     <string name="swiper_help_message">Scorri ogni file per prendere una decisione:\n\n← Scorri a sinistra: %1$s\n→ Scorri a destra: %2$s\n↑ Scorri in alto: Salta\n↓ Scorri in basso: Annulla (dopo il primo scorrimento)\n\nPuoi anche usare i pulsanti in basso.\n\nQuando hai finito, tocca \"Revisione\" per vedere tutte le tue decisioni. Nulla viene eliminato finché non confermi nella schermata di revisione.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Fatto</string>
     <string name="swiper_file_type_filter_title">Mostra solo questi tipi di file</string>
     <string name="swiper_file_type_filter_hint">Seleziona i tipi che vuoi vedere. Se nessuno è selezionato, vengono mostrati tutti i file.</string>
     <string name="swiper_file_type_category_images">Immagini</string>

--- a/app-tool-swiper/src/main/res/values-iw/strings.xml
+++ b/app-tool-swiper/src/main/res/values-iw/strings.xml
@@ -68,7 +68,6 @@
     <string name="swiper_settings_haptic_feedback_summary">רטט בעת קבלת החלטות שמירה או מחיקה.</string>
     <string name="swiper_discard_session_confirmation_title">לבטל הפעלה?</string>
     <string name="swiper_discard_session_confirmation_message">כל ההחלטות יאבדו. האם אתה בטוח?</string>
-    <string name="swiper_no_preview_available">אין תצוגה מקדימה זמינה</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">המשך הפעלה מלפני יום %1$d (%2$d%% הושלם)</item>
         <item quantity="two">המשך הפעלה מלפני %1$d ימים (%2$d%% הושלם)</item>
@@ -167,16 +166,8 @@
     <string name="swiper_stamp_undo_2">חזור!</string>
     <string name="swiper_stamp_undo_3">אופס!</string>
     <string name="swiper_stamp_undo_4">רגע!</string>
-    <string name="swiper_gesture_overlay_dismiss">הקש בכל מקום כדי להתחיל</string>
-    <string name="swiper_gesture_overlay_left_delete">← מחק</string>
-    <string name="swiper_gesture_overlay_right_keep">שמור →</string>
-    <string name="swiper_gesture_overlay_left_keep">← שמור</string>
-    <string name="swiper_gesture_overlay_right_delete">מחק →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ דלג</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ בטל</string>
     <string name="swiper_help_title">איך Swiper עובד</string>
     <string name="swiper_help_message">החלק כל קובץ כדי לקבל החלטה:\n\n← החלק שמאלה: %1$s\n→ החלק ימינה: %2$s\n↑ החלק למעלה: דלג\n↓ החלק למטה: בטל (אחרי ההחלקה הראשונה)\n\nאפשר גם להשתמש בכפתורים בתחתית.\n\nכשסיימת, הקש \"סקירה\" כדי לראות את כל ההחלטות שלך. שום דבר לא נמחק עד שתאשר במסך הסקירה.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">הבנתי</string>
     <string name="swiper_file_type_filter_title">הצג רק סוגי קבצים אלה</string>
     <string name="swiper_file_type_filter_hint">סמן את הסוגים שברצונך לראות. אם לא סומן אף סוג, כל הקבצים יוצגו.</string>
     <string name="swiper_file_type_category_images">תמונות</string>

--- a/app-tool-swiper/src/main/res/values-ja/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ja/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">保持または削除の決定時に振動します。</string>
     <string name="swiper_discard_session_confirmation_title">セッションを破棄しますか？</string>
     <string name="swiper_discard_session_confirmation_message">すべての決定が失われます。よろしいですか？</string>
-    <string name="swiper_no_preview_available">プレビューを利用できません</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">%1$d 日前のセッションを続行（%2$d%% 完了）</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">戻る！</string>
     <string name="swiper_stamp_undo_3">おっと！</string>
     <string name="swiper_stamp_undo_4">待って！</string>
-    <string name="swiper_gesture_overlay_dismiss">どこかをタップして開始</string>
-    <string name="swiper_gesture_overlay_left_delete">← 削除</string>
-    <string name="swiper_gesture_overlay_right_keep">保持 →</string>
-    <string name="swiper_gesture_overlay_left_keep">← 保持</string>
-    <string name="swiper_gesture_overlay_right_delete">削除 →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ スキップ</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ 元に戻す</string>
     <string name="swiper_help_title">Swiperの使い方</string>
     <string name="swiper_help_message">各ファイルをスワイプして判断してください:\n\n← 左にスワイプ: %1$s\n→ 右にスワイプ: %2$s\n↑ 上にスワイプ: スキップ\n↓ 下にスワイプ: 元に戻す（最初のスワイプ後）\n\n下部のボタンも使用できます。\n\n完了したら、「レビュー」をタップしてすべての判断を確認してください。レビュー画面で確認するまで何も削除されません。</string>
-    <string name="swiper_gesture_overlay_dismiss_action">わかりました。</string>
     <string name="swiper_file_type_filter_title">これらのファイルタイプのみ表示</string>
     <string name="swiper_file_type_filter_hint">表示したいタイプを選択してください。何も選択されていない場合、すべてのファイルが表示されます。</string>
     <string name="swiper_file_type_category_images">画像</string>

--- a/app-tool-swiper/src/main/res/values-ka-rGE/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ka-rGE/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">ვიბრაცია შენახვის ან წაშლის გადაწყვეტილებებისას.</string>
     <string name="swiper_discard_session_confirmation_title">სესიის გაუქმება?</string>
     <string name="swiper_discard_session_confirmation_message">ყველა გადაწყვეტილება დაიკარგება. დარწმუნებული ხართ?</string>
-    <string name="swiper_no_preview_available">წინასწარი ნახვა მიუწვდომელია</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d დღის წინანდელი სესიის გაგრძელება (%2$d%% დასრულებული)</item>
         <item quantity="other">%1$d დღის წინანდელი სესიის გაგრძელება (%2$d%% დასრულებული)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">უკან!</string>
     <string name="swiper_stamp_undo_3">უპს!</string>
     <string name="swiper_stamp_undo_4">მოიცა!</string>
-    <string name="swiper_gesture_overlay_dismiss">დასაწყებად შეეხეთ ნებისმიერ ადგილას</string>
-    <string name="swiper_gesture_overlay_left_delete">← წაშლა</string>
-    <string name="swiper_gesture_overlay_right_keep">შენახვა →</string>
-    <string name="swiper_gesture_overlay_left_keep">← შენახვა</string>
-    <string name="swiper_gesture_overlay_right_delete">წაშლა →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ გამოტოვება</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ გაუქმება</string>
     <string name="swiper_help_title">როგორ მუშაობს Swiper</string>
     <string name="swiper_help_message">გადაფურცლეთ თითოეული ფაილი გადაწყვეტილების მისაღებად:\n\n← გადაფურცლეთ მარცხნივ: %1$s\n→ გადაფურცლეთ მარჯვნივ: %2$s\n↑ გადაფურცლეთ ზემოთ: გამოტოვება\n↓ გადაფურცლეთ ქვემოთ: გაუქმება (პირველი გადაფურცვლის შემდეგ)\n\nასევე შეგიძლიათ გამოიყენოთ ღილაკები ბოლოში.\n\nდასრულების შემდეგ, შეეხეთ \"მიმოხილვას\" ყველა გადაწყვეტილების სანახავად. არაფერი წაიშლება, სანამ მიმოხილვის ეკრანზე არ დაადასტურებთ.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Გავიგე</string>
     <string name="swiper_file_type_filter_title">მხოლოდ ამ ტიპის ფაილების ჩვენება</string>
     <string name="swiper_file_type_filter_hint">მონიშნეთ ის ტიპები, რომელთა ნახვა გსურთ. თუ არცერთი არ არის მონიშნული, ყველა ფაილი გამოჩნდება.</string>
     <string name="swiper_file_type_category_images">სურათები</string>

--- a/app-tool-swiper/src/main/res/values-kaa/strings.xml
+++ b/app-tool-swiper/src/main/res/values-kaa/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Saqlap qalıw yamasa o\'shiriw sheshimlerin bergende terbeniw.</string>
     <string name="swiper_discard_session_confirmation_title">Sessiyanı tashlap?</string>
     <string name="swiper_discard_session_confirmation_message">Barlıq sheshimler joǵaltıladı. Isenimlimsiz?</string>
-    <string name="swiper_no_preview_available">Aldın alıw joq</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d ku\'n aldınǵı sessiyanı dawam ettiw (%2$d%% tayar)</item>
         <item quantity="other">%1$d ku\'n aldınǵı sessiyanı dawam ettiw (%2$d%% tayar)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Artqa!</string>
     <string name="swiper_stamp_undo_3">Oy!</string>
     <string name="swiper_stamp_undo_4">Toqtań!</string>
-    <string name="swiper_gesture_overlay_dismiss">Baslaw ushın islegen jerge basıń</string>
-    <string name="swiper_gesture_overlay_left_delete">← O\'shiriw</string>
-    <string name="swiper_gesture_overlay_right_keep">Saqlap qalıw →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Saqlap qalıw</string>
-    <string name="swiper_gesture_overlay_right_delete">O\'shiriw →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ O\'tiw</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Qaytarıw</string>
     <string name="swiper_help_title">Swiper qalay islaydi</string>
     <string name="swiper_help_message">Sheshim qabıl etiw ushın hár fayldi sırǵıtıń:\n\n← Sheske sırǵıtıw: %1$s\n→ Oń táreplege sırǵıtıw: %2$s\n↑ Joqarıǵa sırǵıtıw: O\'tiw\n↓ Tómenke sırǵıtıw: Qaytarıw (birinshi sırǵıtıwdan keyin)\n\nSiz tómendegi túymelerdi de paydalana alasız.\n\nTamam bolǵanda, barlıq sheshimlerińizdi kóriw ushın \"Ko\'rip shıǵıw\" túymesin basıń. Ko\'rip shıǵıw ekranında tastıyıqlaǵansha hesh nárse o\'shirilmeydi.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Túsinikli</string>
     <string name="swiper_file_type_filter_title">Tek usı fayl tiplerin kórset</string>
     <string name="swiper_file_type_filter_hint">Kórgіńіz kelgen tiplerdi belgilеń. Heshqaysısı belgilenбесе, барлыq fayllar kórsеtіledі.</string>
     <string name="swiper_file_type_category_images">Súwretler</string>

--- a/app-tool-swiper/src/main/res/values-km-rKH/strings.xml
+++ b/app-tool-swiper/src/main/res/values-km-rKH/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">សម្លូងនៅពេលសម្រេចជម្រើសរក្សា អ្វីលុប។</string>
     <string name="swiper_discard_session_confirmation_title">លុបបន្ថែយសម័អត់?</string>
     <string name="swiper_discard_session_confirmation_message">ជម្រើសតាងអស់នឹងត្រូវបានបាត់។ តើអ្នកពិតជា?</string>
-    <string name="swiper_no_preview_available">មិនមានការមើលពាក្ស័ល់ត្រូវបាន</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">បន្ត្ឡើងសម័អត់ពី %1$d ថ្ង័មុន (%2$d%% រក្ច)</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">ត្រលប់!</string>
     <string name="swiper_stamp_undo_3">អ័!</string>
     <string name="swiper_stamp_undo_4">័ត!</string>
-    <string name="swiper_gesture_overlay_dismiss">ចុចណាន្តដើម្បីចំឡើង</string>
-    <string name="swiper_gesture_overlay_left_delete">← លុប</string>
-    <string name="swiper_gesture_overlay_right_keep">រក្សា →</string>
-    <string name="swiper_gesture_overlay_left_keep">← រក្សា</string>
-    <string name="swiper_gesture_overlay_right_delete">លុប →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ លឹចលញ</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ ត្រលប់វិញ</string>
     <string name="swiper_help_title">Swiper ត្រូវបានដំឡើរ្ការយ័ង\u1798័ច</string>
     <string name="swiper_help_message">ស្វើបឯកសារនិមួយដើម្បីសម្រេចជម្រើស៖\n\n← ស្វើបស្តាំ៖ %1$s\n→ ស្វើបស្តាំត្វែ៖ %2$s\n↑ ស្វើបឡើ៖ លឹចលញ\n↓ ស្វើបចុ៖ ត្រលប់វិញ ប័កស្វើបដំបូង\n\nអ្នកអាចប្រើបរស់បុត្តនៅខាងក្រោមផង់ដោយ។\n\nនៅពេលអ្នករួចៅ ចុច “ស្វែង” ដើម្បីមើលជម្រើសតាងអស់។ មិនមានឯកសារត្រូវលុបរើត្រូវបានបញ្ជាក់នៅហន្តៀស្វែង។</string>
-    <string name="swiper_gesture_overlay_dismiss_action">យល់ហើយ</string>
     <string name="swiper_file_type_filter_title">បង្ហាញតែប្រភេទឯកសារទាំងនេះ</string>
     <string name="swiper_file_type_filter_hint">សូមធីកប្រភេទដែលអ្នកចង់មើល។ ប្រសិនបើមិនមានប្រភេទណាត្រូវបានធីក ឯកសារទាំងអស់នឹងត្រូវបានបង្ហាញ។</string>
     <string name="swiper_file_type_category_images">រូបភាព</string>

--- a/app-tool-swiper/src/main/res/values-kmr-rTR/strings.xml
+++ b/app-tool-swiper/src/main/res/values-kmr-rTR/strings.xml
@@ -22,7 +22,6 @@
     <string name="swiper_status_action_delete_selected">Yên bijartî jê bibin</string>
     <string name="swiper_status_action_reset_selected">Yên bijartî vegerînin</string>
     <string name="swiper_delete_confirmation_title">Pelan jê bibin?</string>
-    <string name="swiper_no_preview_available">Pêşdîtinek tune</string>
     <string name="swiper_sessions_header_title">Amade ne ji bo sererastkirin?</string>
     <string name="swiper_sessions_suggestions_label">Biceribînin dest pê bikin bi:</string>
     <string name="swiper_sessions_suggestion_downloads">Peldanka daxistinê</string>

--- a/app-tool-swiper/src/main/res/values-ko/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ko/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">유지 또는 삭제 결정 시 진동합니다.</string>
     <string name="swiper_discard_session_confirmation_title">세션을 삭제하시겠습니까?</string>
     <string name="swiper_discard_session_confirmation_message">모든 결정이 손실됩니다. 확실합니까?</string>
-    <string name="swiper_no_preview_available">미리보기 없음</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">%1$d일 전 세션 계속 (%2$d%% 완료)</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">뒤로!</string>
     <string name="swiper_stamp_undo_3">앗!</string>
     <string name="swiper_stamp_undo_4">잠깐!</string>
-    <string name="swiper_gesture_overlay_dismiss">아무 곳이나 탭하여 시작</string>
-    <string name="swiper_gesture_overlay_left_delete">← 삭제</string>
-    <string name="swiper_gesture_overlay_right_keep">보관 →</string>
-    <string name="swiper_gesture_overlay_left_keep">← 보관</string>
-    <string name="swiper_gesture_overlay_right_delete">삭제 →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ 건너뛰기</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ 되돌리기</string>
     <string name="swiper_help_title">Swiper 사용 방법</string>
     <string name="swiper_help_message">각 파일을 스와이프하여 결정하세요:\n\n← 왼쪽으로 스와이프: %1$s\n→ 오른쪽으로 스와이프: %2$s\n↑ 위로 스와이프: 건너뛰기\n↓ 아래로 스와이프: 되돌리기 (첫 스와이프 이후)\n\n하단 버튼을 사용할 수도 있습니다.\n\n완료되면 \"검토\"를 탭하여 모든 결정을 확인하세요. 검토 화면에서 확인하기 전까지는 아무것도 삭제되지 않습니다.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">확인</string>
     <string name="swiper_file_type_filter_title">이 파일 형식만 표시</string>
     <string name="swiper_file_type_filter_hint">보고 싶은 유형을 선택하세요. 아무것도 선택하지 않으면 모든 파일이 표시됩니다.</string>
     <string name="swiper_file_type_category_images">이미지</string>

--- a/app-tool-swiper/src/main/res/values-ku-rTR/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ku-rTR/strings.xml
@@ -22,7 +22,6 @@
     <string name="swiper_status_action_delete_selected">هەڵبژێردراوەکان بسڕەوە</string>
     <string name="swiper_status_action_reset_selected">هەڵبژێردراوەکان ڕیسێت بکەوە</string>
     <string name="swiper_delete_confirmation_title">فایلەکان بسڕیتەوە؟</string>
-    <string name="swiper_no_preview_available">پێشبینینی بەردەست نییە</string>
     <string name="swiper_sessions_header_title">ئامادەیت بۆ ڕێکخستنەوە؟</string>
     <string name="swiper_sessions_suggestions_label">هەوڵ بدە دەست پێ بکەیت بە:</string>
     <string name="swiper_sessions_suggestion_downloads">بوخچەی داگرتنەکان</string>

--- a/app-tool-swiper/src/main/res/values-lo-rLA/strings.xml
+++ b/app-tool-swiper/src/main/res/values-lo-rLA/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">ສັ່ນໄຫວເມື່ອຕັດສິນໃຈເກັບຫຣືອລົບ.</string>
     <string name="swiper_discard_session_confirmation_title">ຊົ່ວ່າຈະຮົງເງາການ?</string>
     <string name="swiper_discard_session_confirmation_message">ການຕັດສິນໃຈທັງຫມດຈະສູນຫາຍ. ທ່ານແນໃຈບໍ?</string>
-    <string name="swiper_no_preview_available">ໄມ່ມີການຕັວອຍ່າງ</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">ຕໍ່ເງາການຈາກ %1$d ວັນທີ່ແລ້ວ (%2$d%% ສຳເລັດ)</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">ຖອຍຫລັງ!</string>
     <string name="swiper_stamp_undo_3">ອຸ້!</string>
     <string name="swiper_stamp_undo_4">ຣອ!</string>
-    <string name="swiper_gesture_overlay_dismiss">ກດທີ່ໃດກ່ອນເລີ່ມ</string>
-    <string name="swiper_gesture_overlay_left_delete">← ລຶບ</string>
-    <string name="swiper_gesture_overlay_right_keep">ເກັບ →</string>
-    <string name="swiper_gesture_overlay_left_keep">← ເກັບ</string>
-    <string name="swiper_gesture_overlay_right_delete">ລຶບ →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ ຂ້າມ</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ ຍົກເລີກ</string>
     <string name="swiper_help_title">Swiper ທຳງານໄດ້ໂດຍວິຘີໃດ</string>
     <string name="swiper_help_message">ສົບແຕ່ລະໄຟລ໌ເພື່ອຕັດສິນໃຈ:\n\n← ສົບຊ້າຍ: %1$s\n→ ສົບຂວາ: %2$s\n↑ ສົບຂຶ້ນ: ຂ້າມ\n↓ ສົບລງ: ຍ້ອນຄືນ (ຫລັງຈາກສົບແລ້ວ)\n\nທ່ານສາມາຖໃຊ້ປຸ່ມດ້ານລ່າງດ້ວຍ.\n\nເມື່ອສຳເລັດແລ້ວ, ກດ \"ຕຣວຈສອບ\" ເພື່ອດູການຕັດສິນໃຈທັງຫມດ. ໄມ່ມີສິ່ງໃດຖືກລົບຈນກວ່າທ່ານຍືນຍັນບນຫນ້າຕຣວຈສອບ.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">ເຂົ້າໃຈແລ້ວ</string>
     <string name="swiper_file_type_filter_title">ສະແດງສະເພາະປະເພດໄຟລ໌ເຫຼົ່ານີ້</string>
     <string name="swiper_file_type_filter_hint">ໝາຍປະເພດທີ່ທ່ານຕ້ອງການເບິ່ງ. ຖ້າບໍ່ໄດ້ໝາຍໄວ້, ໄຟລ໌ທັງໝົດຈະຖືກສະແດງ.</string>
     <string name="swiper_file_type_category_images">ຮູບພາບ</string>

--- a/app-tool-swiper/src/main/res/values-lt/strings.xml
+++ b/app-tool-swiper/src/main/res/values-lt/strings.xml
@@ -68,7 +68,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibruoti priimant sprendimą palikti arba ištrinti.</string>
     <string name="swiper_discard_session_confirmation_title">Atmesti seansus?</string>
     <string name="swiper_discard_session_confirmation_message">Visi sprendimai bus prarasti. Ar tikrai?</string>
-    <string name="swiper_no_preview_available">Peržiūra neprieinama</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Tęsti sesiją iš prieš %1$d dieną (%2$d%% atlikta)</item>
         <item quantity="few">Tęsti sesiją nuo prieš %1$d dienas (%2$d%% baigta)</item>
@@ -167,16 +166,8 @@
     <string name="swiper_stamp_undo_2">Atgal!</string>
     <string name="swiper_stamp_undo_3">Oi!</string>
     <string name="swiper_stamp_undo_4">Palaukti!</string>
-    <string name="swiper_gesture_overlay_dismiss">Palieskite bet kur, kad pradėtumėte</string>
-    <string name="swiper_gesture_overlay_left_delete">← Trinti</string>
-    <string name="swiper_gesture_overlay_right_keep">Palikti →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Palikti</string>
-    <string name="swiper_gesture_overlay_right_delete">Trinti →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Praleisti</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Atšaukti</string>
     <string name="swiper_help_title">Kaip veikia Swiper</string>
     <string name="swiper_help_message">Perbraukite kiekvieną failą, kad priimtumėte sprendimą:\n\n← Braukti kairėn: %1$s\n→ Braukti dešinėn: %2$s\n↑ Braukti aukštyn: Praleisti\n↓ Braukti žemyn: Atcofti (po pirmojo braukimo)\n\nTaip pat galite naudoti mygtukus aplačioje.\n\nKai baigsite, palieskite „Peržiūra“, kad pamatytumėte visus sprendimus. Nieko naičinama, kol nepatvirtinsite peržiūros ekrane.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Supratau</string>
     <string name="swiper_file_type_filter_title">Rodyti tik šiuos failų tipus</string>
     <string name="swiper_file_type_filter_hint">Pažimėkite tipus, kuriuos norite matyti. Jei nieko nepažimėta, rodomi visi failai.</string>
     <string name="swiper_file_type_category_images">Vaizdai</string>

--- a/app-tool-swiper/src/main/res/values-lv/strings.xml
+++ b/app-tool-swiper/src/main/res/values-lv/strings.xml
@@ -62,7 +62,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrēt, pieņemot lēmumus par saglabāšanu vai dzēšanu.</string>
     <string name="swiper_discard_session_confirmation_title">Atcelt sesiju?</string>
     <string name="swiper_discard_session_confirmation_message">Visi lēmumi tiks zaudeti. Vai esat pārliecināts?</string>
-    <string name="swiper_no_preview_available">Priekšskatījums nav pieejams</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="zero">Turpināt sesiju no %1$d dienām atpakal (%2$d%% pabeigts)</item>
         <item quantity="one">Turpināt sesiju no %1$d dienas atpakal (%2$d%% pabeigts)</item>
@@ -150,16 +149,8 @@
     <string name="swiper_stamp_undo_2">Atpakaļ!</string>
     <string name="swiper_stamp_undo_3">Ups!</string>
     <string name="swiper_stamp_undo_4">Pagaidi!</string>
-    <string name="swiper_gesture_overlay_dismiss">Pieskarieties jebkur, lai sāktu</string>
-    <string name="swiper_gesture_overlay_left_delete">← Dzēst</string>
-    <string name="swiper_gesture_overlay_right_keep">Paturēt →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Paturēt</string>
-    <string name="swiper_gesture_overlay_right_delete">Dzēst →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Izlaist</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Atsaukt</string>
     <string name="swiper_help_title">Kā darbojas Swiper</string>
     <string name="swiper_help_message">Velciet katru failu, lai pieņemtu lēmumu:\n\n← Velciet pa kreisi: %1$s\n→ Velciet pa labi: %2$s\n↑ Velciet uz augšu: Izlaist\n↓ Velciet uz leju: Atcelt (pēc pirmā vilkšanas)\n\nVarat arī izmantot pogas apakšā.\n\nKad esat pabeidzis, pieskarieties \"Pārskatīt\", lai redzētu visus lēmumus. Nekas netiks dzēsts, kamēr neapstiprināsiet pārskata ekrānā.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Sapratu</string>
     <string name="swiper_file_type_filter_title">Rādīt tikai šos failu tipus</string>
     <string name="swiper_file_type_filter_hint">Atzīmējiet tipus, kurus vēlaties redzēt. Ja neviens nav atzīmēts, tiek rādīti visi faili.</string>
     <string name="swiper_file_type_category_images">Attēli</string>

--- a/app-tool-swiper/src/main/res/values-mk-rMK/strings.xml
+++ b/app-tool-swiper/src/main/res/values-mk-rMK/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Вибрирај при донесување одлуки за задржување или бришење.</string>
     <string name="swiper_discard_session_confirmation_title">Отфрли сесија?</string>
     <string name="swiper_discard_session_confirmation_message">Сите одлуки ќе бидат изгубени. Дали сте сигурни?</string>
-    <string name="swiper_no_preview_available">Нема достапен преглед</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Продолжи сесија од пред %1$d ден (%2$d%% завршено)</item>
         <item quantity="other">Продолжи сесија од пред %1$d дена (%2$d%% завршено)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Назад!</string>
     <string name="swiper_stamp_undo_3">Упс!</string>
     <string name="swiper_stamp_undo_4">Чекај!</string>
-    <string name="swiper_gesture_overlay_dismiss">Допрете каде било за да почнете</string>
-    <string name="swiper_gesture_overlay_left_delete">← Избриши</string>
-    <string name="swiper_gesture_overlay_right_keep">Задржи →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Задржи</string>
-    <string name="swiper_gesture_overlay_right_delete">Избриши →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Прескокни</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Врати</string>
     <string name="swiper_help_title">Како работи Swiper</string>
     <string name="swiper_help_message">Лизгајте секоја датотека за да донесете одлука:\n\n← Лизгајте лево: %1$s\n→ Лизгајте десно: %2$s\n↑ Лизгајте горе: Прескокни\n↓ Лизгајте долу: Врати (по првото лизгање)\n\nМожете исто така да ги користите копчињата на дното.\n\nКога ќе завршите, допрете \"Прегледај\" за да ги видите сите ваши одлуки. Ништо не се брише додека не потврдите на екранот за преглед.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Разбрав</string>
     <string name="swiper_file_type_filter_title">Прикажи само овие типови датотеки</string>
     <string name="swiper_file_type_filter_hint">Значете ги типовите што сакате да ги видите. Ако ништо не е значено, се прикажуваат сите датотеки.</string>
     <string name="swiper_file_type_category_images">Слики</string>

--- a/app-tool-swiper/src/main/res/values-ml-rIN/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ml-rIN/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">സൂക്ഷിക്കുക അഥവാ ഡിലീറ്റ് തീരുമാനം എടുക്കുമ്പോൾ വൈബ്രേറ്റ് ചെയ്യുക.</string>
     <string name="swiper_discard_session_confirmation_title">സെഷൻ ഉപേക്ഷിക്കണോ?</string>
     <string name="swiper_discard_session_confirmation_message">എല്ലാ തീരുമാനങ്ങളും നഷ്ടപ്പെടും. തീർച്ചയാണോ?</string>
-    <string name="swiper_no_preview_available">പ്രിവ്യൂ ലഭ്യമല്ല</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d ദിവസം മുൻപാക്കുള്ള സെഷൻ തുടരുക (%2$d%% തീർന്നു)</item>
         <item quantity="other">%1$d ദിവസം മുൻപാക്കുള്ള സെഷൻ തുടരുക (%2$d%% തീർന്നു)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">പിർവായി!</string>
     <string name="swiper_stamp_undo_3">ഊപ്സ്!</string>
     <string name="swiper_stamp_undo_4">കാത്തിരിക്കൂ!</string>
-    <string name="swiper_gesture_overlay_dismiss">ആരംഭിക്കാൻ എവിടെയും ടാപ്പ് ചെയ്യുക</string>
-    <string name="swiper_gesture_overlay_left_delete">← ഇല്ലാതാക്കുക</string>
-    <string name="swiper_gesture_overlay_right_keep">സൂക്ഷിക്കുക →</string>
-    <string name="swiper_gesture_overlay_left_keep">← സൂക്ഷിക്കുക</string>
-    <string name="swiper_gesture_overlay_right_delete">ഇല്ലാതാക്കുക →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ ഒഴിവാക്കുക</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ പഴയപടിയാക്കുക</string>
     <string name="swiper_help_title">Swiper എങ്ങനെ പ്രവർത്തിക്കുന്നു</string>
     <string name="swiper_help_message">ഓരോ ഫയലും സ്വൈപ്പ് ചെയ്ത് തീരുമാനമെടുക്കുക:\n\n← ഇടത്തേക്ക് സ്വൈപ്പ്: %1$s\n→ വലത്തേക്ക് സ്വൈപ്പ്: %2$s\n↑ മുകളിലേക്ക് സ്വൈപ്പ്: ഒഴിവാക്കുക\n↓ താഴേക്ക് സ്വൈപ്പ്: പഴയപടിയാക്കുക (ആദ്യ സ്വൈപ്പിന് ശേഷം)\n\nതാഴെ ഉള്ള ബട്ടണുകളും ഉപയോഗിക്കാം.\n\nതീർന്നാൽ, നിങ്ങളുടെ എല്ലാ തീരുമാനങ്ങളും കാണാൻ \"അവലോകനം\" ടാപ്പ് ചെയ്യുക. അവലോകന സ്ക്രീനിൽ സ്ഥിരീകരിക്കുന്നത് വരെ ഒന്നും ഇല്ലാതാകില്ല.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">മനസ്സിലായി</string>
     <string name="swiper_file_type_filter_title">ഈ ഫയൽ തരങ്ങൾ മാത്രം കാണിക്കുക</string>
     <string name="swiper_file_type_filter_hint">നിങ്ങൾ കാണാൻ ആഗ്രഹിക്കുന്ന തരങ്ങൾ തിരഞ്ഞെടുക്കുക. ഒന്നും തിരഞ്ഞെടുത്തില്ലെങ്കിൽ, എല്ലാ ഫയലുകളും കാണിക്കും.</string>
     <string name="swiper_file_type_category_images">ചിത്രങ്ങൾ</string>

--- a/app-tool-swiper/src/main/res/values-mn-rMN/strings.xml
+++ b/app-tool-swiper/src/main/res/values-mn-rMN/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Хадгалах эсвэл устгах шийдвэр гаргахад чичирнэ.</string>
     <string name="swiper_discard_session_confirmation_title">Сессийг устгах уу?</string>
     <string name="swiper_discard_session_confirmation_message">Бүх шийдвэр алдагдана. Итгэлтэй байна уу?</string>
-    <string name="swiper_no_preview_available">Урьдчилсан харагдац байхгүй</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d өдрийн өмнөх сессийг үргэлжлүүлэх (%2$d%% дууссан)</item>
         <item quantity="other">%1$d өдрийн өмнөх сессийг үргэлжлүүлэх (%2$d%% дууссан)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Буцах!</string>
     <string name="swiper_stamp_undo_3">Уучлаарай!</string>
     <string name="swiper_stamp_undo_4">Хүлээ!</string>
-    <string name="swiper_gesture_overlay_dismiss">Эхлэхийн тулд хаана ч товшино уу</string>
-    <string name="swiper_gesture_overlay_left_delete">← Устгах</string>
-    <string name="swiper_gesture_overlay_right_keep">Хадгалах →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Хадгалах</string>
-    <string name="swiper_gesture_overlay_right_delete">Устгах →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Алгасах</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Буцаах</string>
     <string name="swiper_help_title">Swiper хэрхэн ажилладаг</string>
     <string name="swiper_help_message">Файл бүрийг гүйлгэж шийдвэр гарга:\n\n← Зүүн тийш гүйлгэх: %1$s\n→ Баруун тийш гүйлгэх: %2$s\n↑ Дээш гүйлгэх: Алгасах\n↓ Доош гүйлгэх: Буцаах (анхны гүйлгэлтийн дараа)\n\nДоод талын товчлууруудыг бас ашиглаж болно.\n\nДууссаны дараа \"Хянах\" дээр дарж бүх шийдвэрээ харна уу. Хяналтын дэлгэц дээр баталгаажуулах хүртэл юу ч устгагдахгүй.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Ойлголоо</string>
     <string name="swiper_file_type_filter_title">Зөвхөн эдгээр файлын төрлийг харуулах</string>
     <string name="swiper_file_type_filter_hint">Харахыг хүсэж буй төрлүүдийг тэмдэглэнэ үү. Хэрэв жагсаалт хоосон бол бүх файл харагдана.</string>
     <string name="swiper_file_type_category_images">Зургууд</string>

--- a/app-tool-swiper/src/main/res/values-ms/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ms/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Getar apabila membuat keputusan simpan atau padam.</string>
     <string name="swiper_discard_session_confirmation_title">Buang sesi?</string>
     <string name="swiper_discard_session_confirmation_message">Semua keputusan akan hilang. Adakah anda pasti?</string>
-    <string name="swiper_no_preview_available">Tiada pratonton tersedia</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">Teruskan sesi dari %1$d hari lalu (%2$d%% selesai)</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">Balik!</string>
     <string name="swiper_stamp_undo_3">Alamak!</string>
     <string name="swiper_stamp_undo_4">Tunggu!</string>
-    <string name="swiper_gesture_overlay_dismiss">Ketik di mana-mana untuk mula</string>
-    <string name="swiper_gesture_overlay_left_delete">← Padam</string>
-    <string name="swiper_gesture_overlay_right_keep">Simpan →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Simpan</string>
-    <string name="swiper_gesture_overlay_right_delete">Padam →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Langkau</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Batal</string>
     <string name="swiper_help_title">Cara Swiper berfungsi</string>
     <string name="swiper_help_message">Leret setiap fail untuk membuat keputusan:\n\n← Leret ke kiri: %1$s\n→ Leret ke kanan: %2$s\n↑ Leret ke atas: Langkau\n↓ Leret ke bawah: Batal (selepas leretan pertama)\n\nAnda juga boleh menggunakan butang di bahagian bawah.\n\nApabila selesai, ketik \"Semak\" untuk melihat semua keputusan anda. Tiada apa yang dipadam sehingga anda mengesahkan pada skrin semakan.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Faham</string>
     <string name="swiper_file_type_filter_title">Tunjukkan jenis fail ini sahaja</string>
     <string name="swiper_file_type_filter_hint">Tandakan jenis yang ingin anda lihat. Jika tiada yang ditandakan, semua fail ditunjukkan.</string>
     <string name="swiper_file_type_category_images">Imej</string>

--- a/app-tool-swiper/src/main/res/values-mt/strings.xml
+++ b/app-tool-swiper/src/main/res/values-mt/strings.xml
@@ -22,7 +22,6 @@
     <string name="swiper_status_action_delete_selected">Ħassar magħżula</string>
     <string name="swiper_status_action_reset_selected">Irrisettja magħżula</string>
     <string name="swiper_delete_confirmation_title">Tħassar fajls?</string>
-    <string name="swiper_no_preview_available">L-ebda preview disponibbli</string>
     <string name="swiper_sessions_header_title">Lest biex tirranġa?</string>
     <string name="swiper_sessions_suggestions_label">Ipprova ibda b\':</string>
     <string name="swiper_sessions_suggestion_downloads">Folder tad-downloads</string>

--- a/app-tool-swiper/src/main/res/values-my-rMM/strings.xml
+++ b/app-tool-swiper/src/main/res/values-my-rMM/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">သိုထားလုးများ သိုထားသွား ခြင်းခြင်းသည်လုးကို ခုံးခ်ခုံးချသည်။</string>
     <string name="swiper_discard_session_confirmation_title">သှားရှားကို ဖယ်ချပါလား?</string>
     <string name="swiper_discard_session_confirmation_message">ဆုံးပြေဆုံးများအားထေက်ပျောသွားမည်။ သခြေပါလား?</string>
-    <string name="swiper_no_preview_available">အင်ဂါ ပြသောသောမရှိပါ</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">%1$d ရက်က သှားရှားကို ဆက်ပြန်ပါ (%2$d%% ပြီးသား)</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">နောက်!</string>
     <string name="swiper_stamp_undo_3">ဟင်!</string>
     <string name="swiper_stamp_undo_4">ခဏ!</string>
-    <string name="swiper_gesture_overlay_dismiss">စတင်ရန် မည်သည့်နေရာတွင်မဆို တို့ပါ</string>
-    <string name="swiper_gesture_overlay_left_delete">← ဖျက်မည်</string>
-    <string name="swiper_gesture_overlay_right_keep">သိမ်းမည် →</string>
-    <string name="swiper_gesture_overlay_left_keep">← သိမ်းမည်</string>
-    <string name="swiper_gesture_overlay_right_delete">ဖျက်မည် →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ ကျော်မည်</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ ပြန်ယူမည်</string>
     <string name="swiper_help_title">Swiper အလုပ်လုပ်ပုံ</string>
     <string name="swiper_help_message">ဖိုင်တစ်ခုစီကို ပွတ်ဆွဲပြီး ဆုံးဖြတ်ပါ:\n\n← ဘယ်ဘက်သို့ ပွတ်ဆွဲ: %1$s\n→ ညာဘက်သို့ ပွတ်ဆွဲ: %2$s\n↑ အပေါ်သို့ ပွတ်ဆွဲ: ကျော်မည်\n↓ အောက်သို့ ပွတ်ဆွဲ: ပြန်ယူမည် (ပထမ ပွတ်ဆွဲပြီးနောက်)\n\nအောက်ခြေ ခလုတ်များကိုလည်း သုံးနိုင်ပါသည်။\n\nပြီးသွားသောအခါ \"ပြန်စစ်\" ကို တို့ပြီး သင့်ဆုံးဖြတ်ချက်များ အားလုံးကို ကြည့်ပါ။ ပြန်စစ်သည့် မျက်နှာပြင်တွင် အတည်ပြုသည့်အထိ ဘာမျှ မဖျက်ပါ။</string>
-    <string name="swiper_gesture_overlay_dismiss_action">နား လည်ပါပြီ</string>
     <string name="swiper_file_type_filter_title">ဤဖိုင်အမျိုးအစားများကိုသာ ပြပါ</string>
     <string name="swiper_file_type_filter_hint">ကြည့်လိုသောအမျိုးအစားများကို စစ်ဆေးပါ။ မည်သည့်အမျိုးအစားမှ မစစ်ဆေးပါက ဖိုင်အားလုံးကို ပြပါမည်။</string>
     <string name="swiper_file_type_category_images">ပုံများ</string>

--- a/app-tool-swiper/src/main/res/values-nb/strings.xml
+++ b/app-tool-swiper/src/main/res/values-nb/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrer ved behold- eller sletteavgjørelser.</string>
     <string name="swiper_discard_session_confirmation_title">Forkaste økt?</string>
     <string name="swiper_discard_session_confirmation_message">Alle avgjørelser vil gå tapt. Er du sikker?</string>
-    <string name="swiper_no_preview_available">Ingen forhåndsvisning tilgjengelig</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Fortsett økt fra %1$d dag siden (%2$d%% ferdig)</item>
         <item quantity="other">Fortsett økt fra %1$d dager siden (%2$d%% ferdig)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Tilbake!</string>
     <string name="swiper_stamp_undo_3">Oisann!</string>
     <string name="swiper_stamp_undo_4">Vent!</string>
-    <string name="swiper_gesture_overlay_dismiss">Trykk hvor som helst for å starte</string>
-    <string name="swiper_gesture_overlay_left_delete">← Slett</string>
-    <string name="swiper_gesture_overlay_right_keep">Behold →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Behold</string>
-    <string name="swiper_gesture_overlay_right_delete">Slett →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Hopp over</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Angre</string>
     <string name="swiper_help_title">Slik fungerer Swiper</string>
     <string name="swiper_help_message">Sveip over hver fil for å ta en avgjørelse:\n\n← Sveip til venstre: %1$s\n→ Sveip til høyre: %2$s\n↑ Sveip opp: Hopp over\n↓ Sveip ned: Angre (etter første sveip)\n\nDu kan også bruke knappene nederst.\n\nNår du er ferdig, trykk \"Gjennomgå\" for å se alle avgjørelsene dine. Ingenting slettes før du bekrefter på gjennomgangsskjermen.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Forstått</string>
     <string name="swiper_file_type_filter_title">Vis bare disse filtypene</string>
     <string name="swiper_file_type_filter_hint">Merk av typene du vil se. Hvis ingen er valgt, vises alle filer.</string>
     <string name="swiper_file_type_category_images">Bilder</string>

--- a/app-tool-swiper/src/main/res/values-ne-rNP/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ne-rNP/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">राख्ने वा मेटाउने निर्णय गर्दा कम्पन गर्नुहोस्।</string>
     <string name="swiper_discard_session_confirmation_title">सत्र त्याग गर्ने?</string>
     <string name="swiper_discard_session_confirmation_message">सबै निर्णयहरू हराउनेछन्। के तपाईं निश्चित हुनुहुन्छ?</string>
-    <string name="swiper_no_preview_available">पूर्वावलोकन उपलब्ध छैन</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">1 दिन अघिको सत्र जारी राख्नुहोस् (%2$d%% समाप्त)</item>
         <item quantity="other">%1$d दिन अघिको सत्र जारी राख्नुहोस् (%2$d%% समाप्त)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">पछाडि!</string>
     <string name="swiper_stamp_undo_3">अरे!</string>
     <string name="swiper_stamp_undo_4">पर्खनुहोस्!</string>
-    <string name="swiper_gesture_overlay_dismiss">सुरु गर्न कुनै ठाउँमा ट्याप गर्नुहोस्</string>
-    <string name="swiper_gesture_overlay_left_delete">← मेटाउनुहोस्</string>
-    <string name="swiper_gesture_overlay_right_keep">राख्नुहोस् →</string>
-    <string name="swiper_gesture_overlay_left_keep">← राख्नुहोस्</string>
-    <string name="swiper_gesture_overlay_right_delete">मेटाउनुहोस् →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ छोड्नुहोस्</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ पूर्ववत गर्नुहोस्</string>
     <string name="swiper_help_title">Swiper कसरी काम गर्छ</string>
     <string name="swiper_help_message">प्रत्येक फाइल स्वाइप गरेर निर्णय लिनुहोस्:\n\n← बायाँ स्वाइप: %1$s\n→ दायाँ स्वाइप: %2$s\n↑ माथि स्वाइप: छोड्नुहोस्\n↓ तल स्वाइप: पूर्ववत गर्नुहोस् (पहिलो स्वाइपपछि)\n\nतपाइँ तलको बटनहरू पनि प्रयोग गर्न सक्नुहुन्छ।\n\nजब तपाइँ सकिनुहुन्छ, आफ्ना सबै निर्णयहरू हेर्न \"समीक्षा\" ट्याप गर्नुहोस्। समीक्षा स्क्रिनमा तपाइँले पुष्टि नगरेसम्म केही मेटाइँदैन।</string>
-    <string name="swiper_gesture_overlay_dismiss_action">बुझे</string>
     <string name="swiper_file_type_filter_title">यी फाइल प्रकारहरू मात्र देखाउनुहोस्</string>
     <string name="swiper_file_type_filter_hint">तपाईं हेर्न चाहनुभएका प्रकारहरू जाँच गर्नुहोस्। यदि कुनै पनि जाँच गरिएको छैन भने, सबै फाइलहरू देखाइन्छन्।</string>
     <string name="swiper_file_type_category_images">तस्बिरहरू</string>

--- a/app-tool-swiper/src/main/res/values-nl/strings.xml
+++ b/app-tool-swiper/src/main/res/values-nl/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Trillen bij het nemen van bewaar- of verwijderbeslissingen.</string>
     <string name="swiper_discard_session_confirmation_title">Sessie verwijderen?</string>
     <string name="swiper_discard_session_confirmation_message">Alle beslissingen gaan verloren. Weet je het zeker?</string>
-    <string name="swiper_no_preview_available">Geen voorbeeld beschikbaar</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Sessie voortzetten van %1$d dag geleden (%2$d%% voltooid)</item>
         <item quantity="other">Sessie voortzetten van %1$d dagen geleden (%2$d%% voltooid)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Terug!</string>
     <string name="swiper_stamp_undo_3">Oeps!</string>
     <string name="swiper_stamp_undo_4">Wachten!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tik ergens om te beginnen</string>
-    <string name="swiper_gesture_overlay_left_delete">← Verwijderen</string>
-    <string name="swiper_gesture_overlay_right_keep">Bewaren →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Bewaren</string>
-    <string name="swiper_gesture_overlay_right_delete">Verwijderen →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Overslaan</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Ongedaan maken</string>
     <string name="swiper_help_title">Hoe Swiper werkt</string>
     <string name="swiper_help_message">Veeg over elk bestand om een ​​beslissing te nemen:\n\n← Veeg naar links: %1$s\n→ Veeg naar rechts: %2$s\n↑ Veeg omhoog: Overslaan\n↓ Veeg omlaag: Ongedaan maken (na de eerste veegbeweging)\n\nJe kunt ook de knoppen onderaan gebruiken.\n\nAls je klaar bent, tik je op \'Beoordelen\' om al je beslissingen te bekijken. Niets wordt verwijderd totdat je bevestigt op het beoordelingsscherm.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Begrepen</string>
     <string name="swiper_file_type_filter_title">Toon alleen deze bestandstypen</string>
     <string name="swiper_file_type_filter_hint">Vink de typen aan die je wilt zien. Als er geen zijn aangevinkt, worden alle bestanden getoond.</string>
     <string name="swiper_file_type_category_images">Afbeeldingen</string>

--- a/app-tool-swiper/src/main/res/values-or-rIN/strings.xml
+++ b/app-tool-swiper/src/main/res/values-or-rIN/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">ରଖିବା କିମ୍ବା ଡିଲିଟ୍ ନିଷ୍ପତ୍ତି ନେବା ସମୟରେ କମ୍ପନ।</string>
     <string name="swiper_discard_session_confirmation_title">ସେସନ୍ ଖାରଜ କରିବେ?</string>
     <string name="swiper_discard_session_confirmation_message">ସମସ୍ତ ନିଷ୍ପତ୍ତି ହରାଇ ଯିବ। ଆପଣ ନିଶ୍ଚିତ?</string>
-    <string name="swiper_no_preview_available">ପୂର୍ବାବଲୋକନ ଉପಲବ୍ଧ ନାହିଁ</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d ଦିନ ଆଗରୁ ସେସନ୍ ଜାରି ରଖନ୍ତୁ (%2$d%% ସମ୍ପୂର୍ଣ୍ଣ)</item>
         <item quantity="other">%1$d ଦିନ ଆଗରୁ ସେସନ୍ ଜାରି ରଖନ୍ତୁ (%2$d%% ସମ୍ପୂର୍ଣ୍ଣ)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">ପଛକୁ!</string>
     <string name="swiper_stamp_undo_3">ଓହୋ!</string>
     <string name="swiper_stamp_undo_4">ଅପେକ୍ଷା!</string>
-    <string name="swiper_gesture_overlay_dismiss">ଆରମ୍ଭ କରିବାକୁ ଯେକୌଣସି ସ୍ଥାନରେ ଟ୍ୟାପ୍ କରନ୍ତୁ</string>
-    <string name="swiper_gesture_overlay_left_delete">← ବିଲୋପ</string>
-    <string name="swiper_gesture_overlay_right_keep">ରଖନ୍ତୁ →</string>
-    <string name="swiper_gesture_overlay_left_keep">← ରଖନ୍ତୁ</string>
-    <string name="swiper_gesture_overlay_right_delete">ବିଲୋପ →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ ଛାଡ଼ନ୍ତୁ</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ ପ୍ରତ୍ୟାବର୍ତ୍ତନ</string>
     <string name="swiper_help_title">Swiper କିପରି କାମ କରେ</string>
     <string name="swiper_help_message">ନିଷ୍ପତ୍ତି ନେବାକୁ ପ୍ରତ୍ୟେକ ଫାଇଲ୍ ସ୍ୱାଇପ୍ କରନ୍ତୁ:\n\n← ବାମକୁ ସ୍ୱାଇପ୍: %1$s\n→ ଡାହାଣକୁ ସ୍ୱାଇପ୍: %2$s\n↑ ଉପରକୁ ସ୍ୱାଇପ୍: ଛାଡ଼ନ୍ତୁ\n↓ ତଳକୁ ସ୍ୱାଇପ୍: ପ୍ରତ୍ୟାବର୍ତ୍ତନ (ପ୍ରଥମ ସ୍ୱାଇପ୍ ପରେ)\n\nଆପଣ ତଳେ ଥିବା ବଟନ୍ ମଧ୍ୟ ବ୍ୟବହାର କରିପାରିବେ।\n\nସମାପ୍ତ ହେଲେ, ଆପଣଙ୍କ ସମସ୍ତ ନିଷ୍ପତ୍ତି ଦେଖିବାକୁ \"ସମୀକ୍ଷା\" ଟ୍ୟାପ୍ କରନ୍ତୁ। ସମୀକ୍ଷା ସ୍କ୍ରିନରେ ନିଶ୍ଚିତ ନ କରିବା ପର୍ଯ୍ୟନ୍ତ କିଛି ବିଲୋପ ହେବ ନାହିଁ।</string>
-    <string name="swiper_gesture_overlay_dismiss_action">ବୁଝିଗଲି</string>
     <string name="swiper_file_type_filter_title">କେବଳ ଏହି ଫାଇଲ ପ୍ରକାରଗୁଡ଼ିକ ଦେଖାନ୍ତୁ</string>
     <string name="swiper_file_type_filter_hint">ଆପଣ ଦେଖିବାକୁ ଚାହୁଁଥିବା ପ୍ରକାରଗୁଡ଼ିକ ଚୟନ କରନ୍ତୁ। ଯଦି କୌଣସିଟି ଚୟନ ହୋଇ ନ ଥାଏ, ସମସ୍ତ ଫାଇଲ ଦେଖାଯିବ।</string>
     <string name="swiper_file_type_category_images">ଚିତ୍ରଗୁଡ଼ିକ</string>

--- a/app-tool-swiper/src/main/res/values-pa-rIN/strings.xml
+++ b/app-tool-swiper/src/main/res/values-pa-rIN/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">ਰੱਖਣ ਜਾਂ ਮਿਟਾਉਣ ਦੇ ਫੈਸਲੇ ਲੈਂਦੇ ਸਮੇਂ ਵਾਈਬ੍ਰੇਟ ਕਰੋ।</string>
     <string name="swiper_discard_session_confirmation_title">ਸੈਸ਼ਨ ਰੱਦ ਕਰਨਾ ਹੈ?</string>
     <string name="swiper_discard_session_confirmation_message">ਸਾਰੇ ਫੈਸਲੇ ਗੁੰਮ ਹੋ ਜਾਣਗੇ। ਕੀ ਤੁਸੀਂ ਪੱਕੇ ਹੋ?</string>
-    <string name="swiper_no_preview_available">ਪ੍ਰੀਵਿਊ ਉਪਲਬਧ ਨਹੀਂ</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d ਦਿਨ ਪਹਿਲਾਂ ਦੇ ਸੈਸ਼ਨ ਨੂੰ ਜਾਰੀ ਰੱਖੋ (%2$d%% ਮੁਕੰਮਲ)</item>
         <item quantity="other">%1$d ਦਿਨ ਪਹਿਲਾਂ ਦੇ ਸੈਸ਼ਨ ਨੂੰ ਜਾਰੀ ਰੱਖੋ (%2$d%% ਮੁਕੰਮਲ)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">ਪਿੱਛੇ!</string>
     <string name="swiper_stamp_undo_3">ਉਫ਼!</string>
     <string name="swiper_stamp_undo_4">ਰੁਕੋ!</string>
-    <string name="swiper_gesture_overlay_dismiss">ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਕਿਤੇ ਵੀ ਟੈਪ ਕਰੋ</string>
-    <string name="swiper_gesture_overlay_left_delete">← ਮਿਟਾਓ</string>
-    <string name="swiper_gesture_overlay_right_keep">ਰੱਖੋ →</string>
-    <string name="swiper_gesture_overlay_left_keep">← ਰੱਖੋ</string>
-    <string name="swiper_gesture_overlay_right_delete">ਮਿਟਾਓ →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ ਛੱਡੋ</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ ਵਾਪਸ</string>
     <string name="swiper_help_title">ਸਵਾਈਪਰ ਕਿਵੇਂ ਕੰਮ ਕਰਦਾ ਹੈ</string>
     <string name="swiper_help_message">ਫੈਸਲਾ ਲੈਣ ਲਈ ਹਰ ਫਾਈਲ ਸਵਾਈਪ ਕਰੋ:\n\n← ਖੱਬੇ ਸਵਾਈਪ: %1$s\n→ ਸੱਜੇ ਸਵਾਈਪ: %2$s\n↑ ਉੱਪਰ ਸਵਾਈਪ: ਛੱਡੋ\n↓ ਹੇਠਾਂ ਸਵਾਈਪ: ਵਾਪਸ (ਪਹਿਲੇ ਸਵਾਈਪ ਤੋਂ ਬਾਅਦ)\n\nਤੁਸੀਂ ਹੇਠਾਂ ਦਿੱਤੇ ਬਟਨ ਵੀ ਵਰਤ ਸਕਦੇ ਹੋ।\n\nਜਦੋਂ ਤੁਸੀਂ ਮੁਕੰਮਲ ਕਰ ਲਵੋ, ਆਪਣੇ ਸਾਰੇ ਫੈਸਲੇ ਦੇਖਣ ਲਈ \"ਸਮੀਖਿਆ\" \'ਤੇ ਟੈਪ ਕਰੋ। ਜਦੋਂ ਤੱਕ ਤੁਸੀਂ ਸਮੀਖਿਆ ਸਕ੍ਰੀਨ \'ਤੇ ਪੁਸ਼ਟੀ ਨਹੀਂ ਕਰਦੇ ਕੁਝ ਵੀ ਮਿਟਾਇਆ ਨਹੀਂ ਜਾਂਦਾ।</string>
-    <string name="swiper_gesture_overlay_dismiss_action">ਸਮਝ ਗਿਆਂ/ ਗਈ</string>
     <string name="swiper_file_type_filter_title">ਸਿਰਫ਼ ਇਹ ਫ਼ਾਈਲ ਕਿਸਮਾਂ ਦਿਖਾਓ</string>
     <string name="swiper_file_type_filter_hint">ਉਹ ਕਿਸਮਾਂ ਚੁਣੋ ਜੋ ਤੁਸੀਂ ਦੇਖਣਾ ਚਾਹੁੰਦੇ ਹੋ। ਜੇ ਕੋਈ ਨਹੀਂ ਚੁਣੀ, ਸਾਰੀਆਂ ਫ਼ਾਈਲਾਂ ਦਿਖਾਈਆਂ ਜਾਂਦੀਆਂ ਹਨ।</string>
     <string name="swiper_file_type_category_images">ਤਸਵੀਰਾਂ</string>

--- a/app-tool-swiper/src/main/res/values-pl/strings.xml
+++ b/app-tool-swiper/src/main/res/values-pl/strings.xml
@@ -68,7 +68,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Wibracja sygnalizuje decyzję o zachowaniu lub usunięciu.</string>
     <string name="swiper_discard_session_confirmation_title">Anulować sesję?</string>
     <string name="swiper_discard_session_confirmation_message">Wszystkie decyzje zostaną utracone. Jesteś pewien?</string>
-    <string name="swiper_no_preview_available">Podgląd niedostępny</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Kontynuuj sesję sprzed %1$d dnia (zakończono %2$d%%)</item>
         <item quantity="few">Kontynuuj sesję sprzed %1$d dni (zakończono %2$d%%)</item>
@@ -167,16 +166,8 @@
     <string name="swiper_stamp_undo_2">Wstecz!</string>
     <string name="swiper_stamp_undo_3">Ups!</string>
     <string name="swiper_stamp_undo_4">Czekaj!</string>
-    <string name="swiper_gesture_overlay_dismiss">Dotknij w dowolnym miejscu, aby rozpocząć</string>
-    <string name="swiper_gesture_overlay_left_delete">← Usuń</string>
-    <string name="swiper_gesture_overlay_right_keep">Zachowaj →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Zachowaj</string>
-    <string name="swiper_gesture_overlay_right_delete">Usuń →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Pomiń</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Cofnij</string>
     <string name="swiper_help_title">Jak działa Przesuwacz</string>
     <string name="swiper_help_message">Przesuń każdy plik, aby podjąć decyzję:\n\n← Przesuń w lewo: %1$s\n→ Przesuń w prawo: %2$s\n↑ Przesuń w górę: Pomiń\n↓ Przesuń w dół: Cofnij (po pierwszym przesunięciu)\n\nMożesz również użyć przycisków na dole.\n\nPo zakończeniu dotknij „Przejrzyj”, aby zobaczyć wszystkie swoje decyzje. Nic nie zostanie usunięte, dopóki nie potwierdzisz na ekranie przeglądu.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Rozumiem</string>
     <string name="swiper_file_type_filter_title">Pokaż tylko te typy plików</string>
     <string name="swiper_file_type_filter_hint">Zaznacz typy, które chcesz zobaczyć. Jeśli żaden nie jest zaznaczony, wyświetlone zostaną wszystkie pliki.</string>
     <string name="swiper_file_type_category_images">Obrazy</string>

--- a/app-tool-swiper/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tool-swiper/src/main/res/values-pt-rBR/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrar ao tomar decisões de manter ou excluir.</string>
     <string name="swiper_discard_session_confirmation_title">Descartar sessão?</string>
     <string name="swiper_discard_session_confirmation_message">Todas as decisões serão perdidas. Tem certeza?</string>
-    <string name="swiper_no_preview_available">Nenhuma pré-visualização disponível</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Continuar sessão de %1$d dia atrás (%2$d%% concluído)</item>
         <item quantity="other">Continuar sessão de %1$d dias atrás (%2$d%% concluído)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Voltar!</string>
     <string name="swiper_stamp_undo_3">Ops!</string>
     <string name="swiper_stamp_undo_4">Espere!</string>
-    <string name="swiper_gesture_overlay_dismiss">Toque em qualquer lugar para iniciar</string>
-    <string name="swiper_gesture_overlay_left_delete">← Excluir</string>
-    <string name="swiper_gesture_overlay_right_keep">Manter →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Manter</string>
-    <string name="swiper_gesture_overlay_right_delete">Excluir →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Ignorar</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Desfazer</string>
     <string name="swiper_help_title">Como o deslizar funciona</string>
     <string name="swiper_help_message">Deslize cada arquivo para tomar uma decisão:\n\n← Deslize para a esquerda: %1$s\n→ Deslize para a direita: %2$s\n↑ Deslize para cima: Ignorar\n↓ Deslize para baixo: Desfazer (após o primeiro deslize)\n\nVocê também pode usar os botões na parte inferior.\n\nQuando terminar, toque em \"Revisar\" para ver todas as suas decisões. Nada será excluído até que você confirme na tela de revisão.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Entendi</string>
     <string name="swiper_file_type_filter_title">Mostrar apenas estes tipos de arquivo</string>
     <string name="swiper_file_type_filter_hint">Marque os tipos que você deseja ver. Se nenhum estiver marcado, todos os arquivos serão mostrados.</string>
     <string name="swiper_file_type_category_images">Imagens</string>

--- a/app-tool-swiper/src/main/res/values-pt/strings.xml
+++ b/app-tool-swiper/src/main/res/values-pt/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrar ao tomar decisões de manter ou eliminar.</string>
     <string name="swiper_discard_session_confirmation_title">Descartar sessão?</string>
     <string name="swiper_discard_session_confirmation_message">Todas as decisões serão perdidas. Tem a certeza?</string>
-    <string name="swiper_no_preview_available">Sem pré-visualização disponível</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Continuar a sessão de há %1$d dia (%2$d%% concluída)</item>
         <item quantity="other">Continuar a sessão de há %1$d dias (%2$d%% concluída)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Voltar!</string>
     <string name="swiper_stamp_undo_3">Ops!</string>
     <string name="swiper_stamp_undo_4">Aguarde!</string>
-    <string name="swiper_gesture_overlay_dismiss">Toque em qualquer lugar para começar</string>
-    <string name="swiper_gesture_overlay_left_delete">← Eliminar</string>
-    <string name="swiper_gesture_overlay_right_keep">Manter →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Manter</string>
-    <string name="swiper_gesture_overlay_right_delete">Eliminar →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Ignorar</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Desfazer</string>
     <string name="swiper_help_title">Como funciona o Swiper</string>
     <string name="swiper_help_message">Deslize cada ficheiro para tomar uma decisão:\n\n← Deslizar para a esquerda: %1$s\n→ Deslizar para a direita: %2$s\n↑ Deslizar para cima: Ignorar\n↓ Deslizar para baixo: Desfazer (após o primeiro deslize)\n\nTambém pode usar os botões na parte inferior.\n\nQuando terminar, toque em \"Rever\" para ver todas as suas decisões. Nada é eliminado até confirmar no ecrã de revisão.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Entendido</string>
     <string name="swiper_file_type_filter_title">Mostrar apenas estes tipos de ficheiro</string>
     <string name="swiper_file_type_filter_hint">Selecione os tipos que pretende ver. Se nenhum estiver selecionado, todos os ficheiros são mostrados.</string>
     <string name="swiper_file_type_category_images">Imagens</string>

--- a/app-tool-swiper/src/main/res/values-ro/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ro/strings.xml
@@ -62,7 +62,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrați atunci când luați decizii de păstrare sau ștergere.</string>
     <string name="swiper_discard_session_confirmation_title">Renunțați la sesiune?</string>
     <string name="swiper_discard_session_confirmation_message">Toate deciziile vor fi pierdute. Sunteți sigur?</string>
-    <string name="swiper_no_preview_available">Nu există previzualizare disponibilă</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Continuați sesiunea de acum %1$d zi (%2$d%% finalizat)</item>
         <item quantity="few">Continuați sesiunea de acum %1$d zile (%2$d%% finalizat)</item>
@@ -150,16 +149,8 @@
     <string name="swiper_stamp_undo_2">Înapoi!</string>
     <string name="swiper_stamp_undo_3">Ups!</string>
     <string name="swiper_stamp_undo_4">Așteaptă!</string>
-    <string name="swiper_gesture_overlay_dismiss">Atingeți oriunde pentru a începe</string>
-    <string name="swiper_gesture_overlay_left_delete">← Șterge</string>
-    <string name="swiper_gesture_overlay_right_keep">Păstrează →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Păstrează</string>
-    <string name="swiper_gesture_overlay_right_delete">Șterge →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Sari</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Anulare</string>
     <string name="swiper_help_title">Cum funcționează Swiper</string>
     <string name="swiper_help_message">Glisați fiecare fișier pentru a lua o decizie:\n\n← Glisați la stânga: %1$s\n→ Glisați la dreapta: %2$s\n↑ Glisați în sus: Sari\n↓ Glisați în jos: Anulare (după prima glisare)\n\nPuteți utiliza și butoanele de jos.\n\nCând ați terminat, atingeți \"Revizuire\" pentru a vedea toate deciziile. Nimic nu este șters până nu confirmați pe ecranul de revizuire.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Am înțeles</string>
     <string name="swiper_file_type_filter_title">Afișează doar aceste tipuri de fișiere</string>
     <string name="swiper_file_type_filter_hint">Bifează tipurile pe care dorești să le vezi. Dacă niciuna nu este bifată, toate fișierele sunt afișate.</string>
     <string name="swiper_file_type_category_images">Imagini</string>

--- a/app-tool-swiper/src/main/res/values-ru/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ru/strings.xml
@@ -68,7 +68,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Вибрация при принятии или удалении решений.</string>
     <string name="swiper_discard_session_confirmation_title">Отменить сессию?</string>
     <string name="swiper_discard_session_confirmation_message">Все решения будут потеряны. Вы уверены?</string>
-    <string name="swiper_no_preview_available">Предпросмотр недоступен</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Продолжить сессию, начатую %1$d день назад (%2$d%% завершено)</item>
         <item quantity="few">Продолжить сессию, начатую %1$d дн. назад (%2$d%% завершено)</item>
@@ -167,16 +166,8 @@
     <string name="swiper_stamp_undo_2">Назад!</string>
     <string name="swiper_stamp_undo_3">Ой!</string>
     <string name="swiper_stamp_undo_4">Одну минуточку!</string>
-    <string name="swiper_gesture_overlay_dismiss">Коснитесь экрана, чтобы начать</string>
-    <string name="swiper_gesture_overlay_left_delete">← Удалить</string>
-    <string name="swiper_gesture_overlay_right_keep">Сохранить →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Сохранить</string>
-    <string name="swiper_gesture_overlay_right_delete">Удалить →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Пропустить</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Отменить</string>
     <string name="swiper_help_title">Как работает Свайпер</string>
     <string name="swiper_help_message">Проведите по каждому файу, чтобы принять решение:\n\n← Проведите влево: %1$s\n→ Проведите вправо: %2$s\n↑ Проведите вверх: Пропустить\n↓ Проведите вниз: Отменить (после первого свайпа)\n\nТакже Вы можете использовать кнопки внизу.\n\nКогда Вы закончите, нажмите \"Обзор\" чтобы просмотреть все Ваши решения. Ничего не удалится, пока Вы не подтвердите это на экране обзора.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Понятно</string>
     <string name="swiper_file_type_filter_title">Показывать только эти типы файлов</string>
     <string name="swiper_file_type_filter_hint">Отметьте типы, которые хотите видеть. Если ничего не отмечено, отображаются все файлы.</string>
     <string name="swiper_file_type_category_images">Изображения</string>

--- a/app-tool-swiper/src/main/res/values-sc-rIT/strings.xml
+++ b/app-tool-swiper/src/main/res/values-sc-rIT/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibra cando si leat detzisiones de mantènnere o cantzellare.</string>
     <string name="swiper_discard_session_confirmation_title">Iscartare sa sessione?</string>
     <string name="swiper_discard_session_confirmation_message">Totu is detzisiones ant a èssere pèrdidas. Ses seguru?</string>
-    <string name="swiper_no_preview_available">Peruna anteprima disponìbile</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Sighit sa sessione de %1$d die a como (%2$d%% acabadu)</item>
         <item quantity="other">Sighit sa sessione de %1$d dies a como (%2$d%% acabadu)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Agoa!</string>
     <string name="swiper_stamp_undo_3">Ops!</string>
     <string name="swiper_stamp_undo_4">Firma!</string>
-    <string name="swiper_gesture_overlay_dismiss">Toca in cale si siat logu pro cumintzare</string>
-    <string name="swiper_gesture_overlay_left_delete">← Cantzella</string>
-    <string name="swiper_gesture_overlay_right_keep">Mantèni →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Mantèni</string>
-    <string name="swiper_gesture_overlay_right_delete">Cantzella →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Brinca</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Annulla</string>
     <string name="swiper_help_title">Comente funtzionat Swiper</string>
     <string name="swiper_help_message">Iscorre cada archìviu pro leare una detzisione:\n\n← Iscorre a manu manca: %1$s\n→ Iscorre a manu dereta: %2$s\n↑ Iscorre a susu: Brinca\n↓ Iscorre a josso: Annulla (a pustis de su primu iscorrimentu)\n\nPodes fintzas impreare is butones in bàsciu.\n\nCando as acabadu, toca \"Revisione\" pro bìdere totu is detzisiones tuas. No si cantzellat nudda fintzas a cando non lu cunfirmas in sa pàgina de revisione.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Apat cumprèndiu</string>
     <string name="swiper_file_type_filter_title">Ammustra sos tipos de archiviu solu</string>
     <string name="swiper_file_type_filter_hint">Controlla sos tipos chi boles bidere. Si nisciunu est controlladu, totos sos archivios sun ammustratos.</string>
     <string name="swiper_file_type_category_images">Immàgines</string>

--- a/app-tool-swiper/src/main/res/values-si-rLK/strings.xml
+++ b/app-tool-swiper/src/main/res/values-si-rLK/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">තබා ගැනීම හෝ මැකීම තීරණ ගන්නා විට කම්පනය.</string>
     <string name="swiper_discard_session_confirmation_title">සැසිය ඉවත ලන්නද?</string>
     <string name="swiper_discard_session_confirmation_message">සියලු තීරණ නැති වනු ඇත. ඔබට විශ්වාසද?</string>
-    <string name="swiper_no_preview_available">පෙරදසුනක් නැත</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">දින %1$d කට පෙර සැසිය දිගටම (%2$d%% අවසන්)</item>
         <item quantity="other">දින %1$d කට පෙර සැසිය දිගටම (%2$d%% අවසන්)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">ආපසු!</string>
     <string name="swiper_stamp_undo_3">අපොයි!</string>
     <string name="swiper_stamp_undo_4">ඉන්න!</string>
-    <string name="swiper_gesture_overlay_dismiss">ආරම්භ කිරීමට ඕනෑම තැනක තට්ටු කරන්න</string>
-    <string name="swiper_gesture_overlay_left_delete">← මකන්න</string>
-    <string name="swiper_gesture_overlay_right_keep">තබාගන්න →</string>
-    <string name="swiper_gesture_overlay_left_keep">← තබාගන්න</string>
-    <string name="swiper_gesture_overlay_right_delete">මකන්න →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ මඟ හරින්න</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ අස් කරන්න</string>
     <string name="swiper_help_title">ස්වයිපර් ක්‍රියා කරන ආකාරය</string>
     <string name="swiper_help_message">තීරණයක් ගැනීමට සෑම ගොනුවක්ම ස්වයිප් කරන්න:\n\n← වමට ස්වයිප්: %1$s\n→ දකුණට ස්වයිප්: %2$s\n↑ ඉහළට ස්වයිප්: මඟ හරින්න\n↓ පහළට ස්වයිප්: අස් කරන්න (පළමු ස්වයිප් එකෙන් පසු)\n\nඔබට පහළ බොත්තම් ද භාවිත කළ හැක.\n\nඔබ අවසන් වූ විට, ඔබේ සියලු තීරණ බැලීමට \"සමාලෝචනය\" තට්ටු කරන්න. සමාලෝචන තිරයේ තහවුරු කරන තුරු කිසිවක් මකා නොදමයි.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">තේරුණා</string>
     <string name="swiper_file_type_filter_title">මෙම ගොනු වර්ග පමණක් පෙන්වන්න</string>
     <string name="swiper_file_type_filter_hint">ඔබ දැකීමට කැමති වර්ග සලකුණු කරන්න. කිසිවක් සලකුණු නොකළ හොත්, සියළු ගොනු පෙන්වනු ලැබේ.</string>
     <string name="swiper_file_type_category_images">රූප</string>

--- a/app-tool-swiper/src/main/res/values-sk/strings.xml
+++ b/app-tool-swiper/src/main/res/values-sk/strings.xml
@@ -68,7 +68,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrovať pri rozhodnutí ponechať alebo odstrániť.</string>
     <string name="swiper_discard_session_confirmation_title">Zahodiť reláciu?</string>
     <string name="swiper_discard_session_confirmation_message">Všetky rozhodnutia budú stratené. Ste si istí?</string>
-    <string name="swiper_no_preview_available">Náhľad nie je k dispozícii</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Pokračovať v relácii spred %1$d dňa (%2$d%% dokončených)</item>
         <item quantity="few">Pokračovať v relácii spred %1$d dní (%2$d%% dokončených)</item>
@@ -167,16 +166,8 @@
     <string name="swiper_stamp_undo_2">Naspäť!</string>
     <string name="swiper_stamp_undo_3">Ups!</string>
     <string name="swiper_stamp_undo_4">Počkať!</string>
-    <string name="swiper_gesture_overlay_dismiss">Klepnutím kdekoľvek začnite</string>
-    <string name="swiper_gesture_overlay_left_delete">← Odstrániť</string>
-    <string name="swiper_gesture_overlay_right_keep">Ponechať →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Ponechať</string>
-    <string name="swiper_gesture_overlay_right_delete">Odstrániť →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Preskočiť</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Späť</string>
     <string name="swiper_help_title">Ako funguje Swiper</string>
     <string name="swiper_help_message">Potiahnutím každého súboru urobte rozhodnutie:\n\n← Potiahnite doľava: %1$s\n→ Potiahnite doprava: %2$s\n↑ Potiahnite hore: Preskočiť\n↓ Potiahnite dole: Späť (po prvom potiahnutí)\n\nMôžete tiež použiť tlačidlá v spodnej časti.\n\nKeď skončíte, klepnite na „Skontrolovať\" pre zobrazenie všetkých rozhodnutí. Nič sa neodstráni, kým to nepotvrdíte na obrazovke kontroly.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Rozumiem</string>
     <string name="swiper_file_type_filter_title">Zobraziť iba tieto typy súborov</string>
     <string name="swiper_file_type_filter_hint">Zaškrtnite typy, ktoré chcete vidieť. Ak nie je zaškrtnutý žiadny, zobrazia sa všetky súbory.</string>
     <string name="swiper_file_type_category_images">Obrázky</string>

--- a/app-tool-swiper/src/main/res/values-sl/strings.xml
+++ b/app-tool-swiper/src/main/res/values-sl/strings.xml
@@ -68,7 +68,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibriraj pri odločitvah za ohranitev ali izbris.</string>
     <string name="swiper_discard_session_confirmation_title">Zavrzi sejo?</string>
     <string name="swiper_discard_session_confirmation_message">Vse odločitve bodo izgubljene. Ste prepričani?</string>
-    <string name="swiper_no_preview_available">Predogled ni na voljo</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Nadaljuj sejo izpred %1$d-ega dneva (%2$d%% končano)</item>
         <item quantity="two">Nadaljuj sejo izpred %1$d-h dni (%2$d%% končano)</item>
@@ -167,16 +166,8 @@
     <string name="swiper_stamp_undo_2">Nazaj!</string>
     <string name="swiper_stamp_undo_3">Ups!</string>
     <string name="swiper_stamp_undo_4">Počakaj!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tapnite kjerkoli za začetek</string>
-    <string name="swiper_gesture_overlay_left_delete">← Izbriši</string>
-    <string name="swiper_gesture_overlay_right_keep">Obdrži→</string>
-    <string name="swiper_gesture_overlay_left_keep">← Obdrži</string>
-    <string name="swiper_gesture_overlay_right_delete">Izbriši →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Preskoči</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Razveljavi</string>
     <string name="swiper_help_title">Kako deluje Drsnik</string>
     <string name="swiper_help_message">Povlecite vsako datoteko, da sprejmete odločitev:\n\n← Povlek levo: %1$s\n→ Povlek desno: %2$s\n↑ Povlek navzgor: Preskoči\n↓ Povlek navzdol: Razveljavi (po prvem povleku)\n\nUporabite lahko tudi gumbe na dnu.\n\nKo končate, se dotaknite \"Pregled\", da pokažete vse odločitve.  Nič ne bo izbrisano, dokler dejanj ne potrdite na zaslonu za pregled.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Razumem!</string>
     <string name="swiper_file_type_filter_title">Prikaži samo te vrste datotek</string>
     <string name="swiper_file_type_filter_hint">Označite vrste, ki jih želite videti.  Če ni označena nobena, se bodo prikazale vse datoteke.</string>
     <string name="swiper_file_type_category_images">Slike</string>

--- a/app-tool-swiper/src/main/res/values-sq-rAL/strings.xml
+++ b/app-tool-swiper/src/main/res/values-sq-rAL/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Dridhu kur merrni vendime për mbajtje ose fshirje.</string>
     <string name="swiper_discard_session_confirmation_title">Hidhni sesionin?</string>
     <string name="swiper_discard_session_confirmation_message">Të gjitha vendimet do të humbasin. Jeni të sigurt?</string>
-    <string name="swiper_no_preview_available">Nuk ka pamje paraprake</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Vazhdo sesionin nga %1$d ditë më parë (%2$d%% e përfunduar)</item>
         <item quantity="other">Vazhdo sesionin nga %1$d ditë më parë (%2$d%% e përfunduar)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Prapa!</string>
     <string name="swiper_stamp_undo_3">Ups!</string>
     <string name="swiper_stamp_undo_4">Prit!</string>
-    <string name="swiper_gesture_overlay_dismiss">Prekni kudo për të filluar</string>
-    <string name="swiper_gesture_overlay_left_delete">← Fshi</string>
-    <string name="swiper_gesture_overlay_right_keep">Mbaj →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Mbaj</string>
-    <string name="swiper_gesture_overlay_right_delete">Fshi →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Kapërce</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Zhbëj</string>
     <string name="swiper_help_title">Si funksionon Swiper</string>
     <string name="swiper_help_message">Rrëshqitni çdo skedar për të marrë një vendim:\n\n← Rrëshqitni majtas: %1$s\n→ Rrëshqitni djathtas: %2$s\n↑ Rrëshqitni lart: Kapërce\n↓ Rrëshqitni poshtë: Zhbëj (pas rrëshqitjes së parë)\n\nMund të përdorni gjithashtu butonat në fund.\n\nKur të keni mbaruar, prekni \"Rishiko\" për të parë të gjitha vendimet tuaja. Asgjë nuk fshihet derisa të konfirmoni në ekranin e rishikimit.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">E kuptova</string>
     <string name="swiper_file_type_filter_title">Shfaq vetëm këto lloje skedarësh</string>
     <string name="swiper_file_type_filter_hint">Kontrolloni llojet që dëshironi të shikoni. Nëse asnjë nuk është zgjedhur, të gjithë skedarët shfaqen.</string>
     <string name="swiper_file_type_category_images">Imazhe</string>

--- a/app-tool-swiper/src/main/res/values-sr/strings.xml
+++ b/app-tool-swiper/src/main/res/values-sr/strings.xml
@@ -62,7 +62,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Вибрирај при доношењу одлука о задржавању или брисању.</string>
     <string name="swiper_discard_session_confirmation_title">Одбацити сесију?</string>
     <string name="swiper_discard_session_confirmation_message">Све одлуке ће бити изгубљене. Да ли сте сигурни?</string>
-    <string name="swiper_no_preview_available">Преглед није доступан</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Настави сесију од пре %1$d дана (%2$d%% завршено)</item>
         <item quantity="few">Настави сесију од пре %1$d дана (%2$d%% завршено)</item>
@@ -150,16 +149,8 @@
     <string name="swiper_stamp_undo_2">Назад!</string>
     <string name="swiper_stamp_undo_3">Упс!</string>
     <string name="swiper_stamp_undo_4">Стани!</string>
-    <string name="swiper_gesture_overlay_dismiss">Додирните било где да започнете</string>
-    <string name="swiper_gesture_overlay_left_delete">← Обриши</string>
-    <string name="swiper_gesture_overlay_right_keep">Задржи →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Задржи</string>
-    <string name="swiper_gesture_overlay_right_delete">Обриши →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Прескочи</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Поништи</string>
     <string name="swiper_help_title">Како ради Swiper</string>
     <string name="swiper_help_message">Превуците сваки фајл да донесете одлуку:\n\n← Превуците лево: %1$s\n→ Превуците десно: %2$s\n↑ Превуците горе: Прескочи\n↓ Превуците доле: Поништи (после првог превлачења)\n\nМожете користити и дугмад на дну.\n\nКада завршите, додирните \"Преглед\" да видите све своје одлуке. Ништа се не брише док не потврдите на екрану за преглед.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Разумем</string>
     <string name="swiper_file_type_filter_title">Прикажи само ове типове датотека</string>
     <string name="swiper_file_type_filter_hint">Означите типове које желите да видите. Ако ниједан није означен, приказују се све датотеке.</string>
     <string name="swiper_file_type_category_images">Слике</string>

--- a/app-tool-swiper/src/main/res/values-sv/strings.xml
+++ b/app-tool-swiper/src/main/res/values-sv/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrera vid behåll- eller ta bort-beslut.</string>
     <string name="swiper_discard_session_confirmation_title">Förkasta session?</string>
     <string name="swiper_discard_session_confirmation_message">Alla beslut kommer gå förlorade. Är du säker?</string>
-    <string name="swiper_no_preview_available">Ingen förhandsvisning tillgänglig</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Fortsätt session från %1$d dag sedan (%2$d%% klart)</item>
         <item quantity="other">Fortsätt session från %1$d dagar sedan (%2$d%% klart)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Tillbaka!</string>
     <string name="swiper_stamp_undo_3">Oj!</string>
     <string name="swiper_stamp_undo_4">Vänta!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tryck var som helst för att börja</string>
-    <string name="swiper_gesture_overlay_left_delete">← Ta bort</string>
-    <string name="swiper_gesture_overlay_right_keep">Behåll →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Behåll</string>
-    <string name="swiper_gesture_overlay_right_delete">Ta bort →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Hoppa över</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Ångra</string>
     <string name="swiper_help_title">Hur Swiper fungerar</string>
     <string name="swiper_help_message">Svep varje fil för att fatta ett beslut:\n\n← Svep vänster: %1$s\n→ Svep höger: %2$s\n↑ Svep uppåt: Hoppa över\n↓ Svep nedåt: Ångra (efter första svepet)\n\nDu kan också använda knapparna längst ned.\n\nNär du är klar, tryck på \"Granska\" för att se alla dina beslut. Inget raderas förrän du bekräftar på granskningsskärmen.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Jag fattar</string>
     <string name="swiper_file_type_filter_title">Visa bara dessa filtyper</string>
     <string name="swiper_file_type_filter_hint">Markera de typer du vill se. Om inga är markerade visas alla filer.</string>
     <string name="swiper_file_type_category_images">Bilder</string>

--- a/app-tool-swiper/src/main/res/values-sw/strings.xml
+++ b/app-tool-swiper/src/main/res/values-sw/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Tetema unapofanya maamuzi ya kuhifadhi au kufuta.</string>
     <string name="swiper_discard_session_confirmation_title">Tupa kipindi?</string>
     <string name="swiper_discard_session_confirmation_message">Maamuzi yote yatapotea. Una uhakika?</string>
-    <string name="swiper_no_preview_available">Hakikisho haipatikani</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Endelea na kipindi kutoka siku %1$d iliyopita (%2$d%% imekamilika)</item>
         <item quantity="other">Endelea na kipindi kutoka siku %1$d zilizopita (%2$d%% imekamilika)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Rudi!</string>
     <string name="swiper_stamp_undo_3">Lo!</string>
     <string name="swiper_stamp_undo_4">Ngoja!</string>
-    <string name="swiper_gesture_overlay_dismiss">Gusa popote ili kuanza</string>
-    <string name="swiper_gesture_overlay_left_delete">← Futa</string>
-    <string name="swiper_gesture_overlay_right_keep">Weka →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Weka</string>
-    <string name="swiper_gesture_overlay_right_delete">Futa →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Ruka</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Tendua</string>
     <string name="swiper_help_title">Jinsi Swiper inavyofanya kazi</string>
     <string name="swiper_help_message">Piga swaipu kwa kila faili ili kufanya uamuzi:\n\n← Piga swaipu kushoto: %1$s\n→ Piga swaipu kulia: %2$s\n↑ Piga swaipu juu: Ruka\n↓ Piga swaipu chini: Tendua (baada ya swaipu ya kwanza)\n\nUnaweza pia kutumia vitufe vilivyo chini.\n\nUkimaliza, gusa \"Kagua\" ili kuona maamuzi yako yote. Hakuna kinachofutwa hadi utakapothibitisha kwenye skrini ya ukaguzi.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Nimeelewa</string>
     <string name="swiper_file_type_filter_title">Onyesha aina hizi za faili peke yake</string>
     <string name="swiper_file_type_filter_hint">Angalia aina unazotaka kuona. Ikiwa hakuna iliyochaguliwa, faili zote zinaonyeshwa.</string>
     <string name="swiper_file_type_category_images">Picha</string>

--- a/app-tool-swiper/src/main/res/values-ta-rIN/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ta-rIN/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">வைத்திருக்க அல்லது நீக்க முடிவு செய்யும் போது அதிர்வு.</string>
     <string name="swiper_discard_session_confirmation_title">அமர்வை நிராகரிக்கவா?</string>
     <string name="swiper_discard_session_confirmation_message">அனைத்து முடிவுகளும் இழக்கப்படும். உறுதியாக இருக்கிறீர்களா?</string>
-    <string name="swiper_no_preview_available">முன்னோட்டம் கிடைக்கவில்லை</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d நாளுக்கு முன் அமர்வைத் தொடரவும் (%2$d%% முடிந்தது)</item>
         <item quantity="other">%1$d நாட்களுக்கு முன் அமர்வைத் தொடரவும் (%2$d%% முடிந்தது)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">பின்!</string>
     <string name="swiper_stamp_undo_3">அச்சோ!</string>
     <string name="swiper_stamp_undo_4">நில்!</string>
-    <string name="swiper_gesture_overlay_dismiss">தொடங்க எங்கு வேண்டுமானாலும் தட்டவும்</string>
-    <string name="swiper_gesture_overlay_left_delete">← நீக்கு</string>
-    <string name="swiper_gesture_overlay_right_keep">வைத்திரு →</string>
-    <string name="swiper_gesture_overlay_left_keep">← வைத்திரு</string>
-    <string name="swiper_gesture_overlay_right_delete">நீக்கு →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ தவிர்</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ மீட்டமை</string>
     <string name="swiper_help_title">Swiper எவ்வாறு செயல்படுகிறது</string>
     <string name="swiper_help_message">முடிவெடுக்க ஒவ்வொரு கோப்பையும் ஸ்வைப் செய்யவும்:\n\n← இடதுபக்கம் ஸ்வைப்: %1$s\n→ வலதுபக்கம் ஸ்வைப்: %2$s\n↑ மேலே ஸ்வைப்: தவிர்\n↓ கீழே ஸ்வைப்: மீட்டமை (முதல் ஸ்வைப்பிற்குப் பிறகு)\n\nகீழே உள்ள பொத்தான்களையும் பயன்படுத்தலாம்.\n\nமுடிந்ததும், உங்கள் அனைத்து முடிவுகளையும் காண \"மதிப்பாய்வு\" என்பதைத் தட்டவும். மதிப்பாய்வுத் திரையில் உறுதிப்படுத்தும் வரை எதுவும் நீக்கப்படாது.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">புரிந்தது</string>
     <string name="swiper_file_type_filter_title">இந்த கோப்பு வகைகளை மட்டும் காட்டு</string>
     <string name="swiper_file_type_filter_hint">நீங்கள் பார்க்க விரும்பும் வகைகளை தேர்வு செய்யுங்கள். எதுவும் தேர்வு செய்யப்படவில்லை என்றால், அனைத்து கோப்புகளும் காட்டப்படும்.</string>
     <string name="swiper_file_type_category_images">படங்கள்</string>

--- a/app-tool-swiper/src/main/res/values-te-rIN/strings.xml
+++ b/app-tool-swiper/src/main/res/values-te-rIN/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">ఉంచు లేదా తొలగించు నిర్ణయాలు తీసుకునేటప్పుడు వైబ్రేట్ చేయి.</string>
     <string name="swiper_discard_session_confirmation_title">సెషన్ విస్మరించాలా?</string>
     <string name="swiper_discard_session_confirmation_message">అన్ని నిర్ణయాలు కోల్పోతాయి. మీరు ఖచ్చితంగా కోరుకుంటున్నారా?</string>
-    <string name="swiper_no_preview_available">ప్రివ్యూ అందుబాటులో లేదు</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d రోజు క్రితం నుండి సెషన్ కొనసాగించు (%2$d%% పూర్తయింది)</item>
         <item quantity="other">%1$d రోజుల క్రితం నుండి సెషన్ కొనసాగించు (%2$d%% పూర్తయింది)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">వెనక్కి!</string>
     <string name="swiper_stamp_undo_3">అయ్యో!</string>
     <string name="swiper_stamp_undo_4">ఆగు!</string>
-    <string name="swiper_gesture_overlay_dismiss">ప్రారంభించడానికి ఎక్కడైనా నొక్కండి</string>
-    <string name="swiper_gesture_overlay_left_delete">← తొలగించు</string>
-    <string name="swiper_gesture_overlay_right_keep">ఉంచు →</string>
-    <string name="swiper_gesture_overlay_left_keep">← ఉంచు</string>
-    <string name="swiper_gesture_overlay_right_delete">తొలగించు →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ దాటవేయి</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ రద్దు</string>
     <string name="swiper_help_title">Swiper ఎలా పని చేస్తుంది</string>
     <string name="swiper_help_message">నిర్ణయం తీసుకోవడానికి ప్రతి ఫైల్‌ను స్వైప్ చేయండి:\n\n← ఎడమకు స్వైప్: %1$s\n→ కుడికి స్వైప్: %2$s\n↑ పైకి స్వైప్: దాటవేయి\n↓ క్రిందికి స్వైప్: రద్దు (మొదటి స్వైప్ తర్వాత)\n\nమీరు దిగువన ఉన్న బటన్‌లను కూడా ఉపయోగించవచ్చు.\n\nమీరు పూర్తి చేసిన తర్వాత, మీ అన్ని నిర్ణయాలను చూడటానికి \"సమీక్ష\" నొక్కండి. సమీక్ష స్క్రీన్‌లో మీరు నిర్ధారించే వరకు ఏదీ తొలగించబడదు.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">అర్థమైంది</string>
     <string name="swiper_file_type_filter_title">ఈ ఫైల్ రకాలను మాత్రమే చూపించు</string>
     <string name="swiper_file_type_filter_hint">మీరు చూడాలనుకునే రకాలను ఎంచుకోండి. ఏదీ ఎంచుకోకపోతే, అన్ని ఫైల్స్ చూపించబడతాయి.</string>
     <string name="swiper_file_type_category_images">చిత్రాలు</string>

--- a/app-tool-swiper/src/main/res/values-th/strings.xml
+++ b/app-tool-swiper/src/main/res/values-th/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">สั่นเมื่อตัดสินใจเก็บหรือลบ</string>
     <string name="swiper_discard_session_confirmation_title">ยกเลิกเซสชัน?</string>
     <string name="swiper_discard_session_confirmation_message">การตัดสินใจทั้งหมดจะสูญหาย คุณแน่ใจหรือไม่?</string>
-    <string name="swiper_no_preview_available">ไม่มีตัวอย่าง</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">ดำเนินเซสชันต่อจาก %1$d วันที่แล้ว (เสร็จ %2$d%%)</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">กลับ!</string>
     <string name="swiper_stamp_undo_3">อุ๊ย!</string>
     <string name="swiper_stamp_undo_4">เดี๋ยว!</string>
-    <string name="swiper_gesture_overlay_dismiss">แตะที่ใดก็ได้เพื่อเริ่ม</string>
-    <string name="swiper_gesture_overlay_left_delete">← ลบ</string>
-    <string name="swiper_gesture_overlay_right_keep">เก็บ →</string>
-    <string name="swiper_gesture_overlay_left_keep">← เก็บ</string>
-    <string name="swiper_gesture_overlay_right_delete">ลบ →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ ข้าม</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ เลิกทำ</string>
     <string name="swiper_help_title">วิธีใช้ Swiper</string>
     <string name="swiper_help_message">ปัดไฟล์แต่ละรายการเพื่อตัดสินใจ:\n\n← ปัดซ้าย: %1$s\n→ ปัดขวา: %2$s\n↑ ปัดขึ้น: ข้าม\n↓ ปัดลง: เลิกทำ (หลังจากปัดครั้งแรก)\n\nคุณยังสามารถใช้ปุ่มด้านล่างได้\n\nเมื่อเสร็จแล้ว แตะ \"ตรวจสอบ\" เพื่อดูการตัดสินใจทั้งหมดของคุณ จะไม่มีอะไรถูกลบจนกว่าคุณจะยืนยันในหน้าตรวจสอบ</string>
-    <string name="swiper_gesture_overlay_dismiss_action">เข้าใจแล้ว</string>
     <string name="swiper_file_type_filter_title">แสดงเฉพาะประเภทไฟล์เหล่านี้</string>
     <string name="swiper_file_type_filter_hint">เลือกประเภทที่ต้องการดู หากไม่ได้เลือกประเภทใด จะแสดงไฟล์ทั้งหมด</string>
     <string name="swiper_file_type_category_images">รูปภาพ</string>

--- a/app-tool-swiper/src/main/res/values-tr/strings.xml
+++ b/app-tool-swiper/src/main/res/values-tr/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Saklama veya silme kararları verirken titreşim.</string>
     <string name="swiper_discard_session_confirmation_title">Oturum iptal edilsin mi?</string>
     <string name="swiper_discard_session_confirmation_message">Tüm kararlar kaybolacak. Emin misiniz?</string>
-    <string name="swiper_no_preview_available">Önizleme mevcut değil</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d gün önceki oturuma devam et (%2$d%% tamamlandı)</item>
         <item quantity="other">%1$d gün önceki oturuma devam et (%2$d%% tamamlandı)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Geri!</string>
     <string name="swiper_stamp_undo_3">Hay aksi!</string>
     <string name="swiper_stamp_undo_4">Dur!</string>
-    <string name="swiper_gesture_overlay_dismiss">Başlamak için herhangi bir yere dokunun</string>
-    <string name="swiper_gesture_overlay_left_delete">← Sil</string>
-    <string name="swiper_gesture_overlay_right_keep">Sakla →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Sakla</string>
-    <string name="swiper_gesture_overlay_right_delete">Sil →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Atla</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Geri al</string>
     <string name="swiper_help_title">Swiper nasıl çalışır</string>
     <string name="swiper_help_message">Her dosyayı kaydırarak bir karar verin:\n\n← Sola kaydırma: %1$s\n→ Sağa kaydırma: %2$s\n↑ Yukarı kaydırma: Atla\n↓ Aşağı kaydırma: Geri al (ilk kaydırmadan sonra)\n\nAlttaki düğmeleri de kullanabilirsiniz.\n\nİşiniz bittiğinde, tüm kararlarınızı görmek için \"İncele\"ye dokunun. İnceleme ekranında onaylayana kadar hiçbir şey silinmez.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Anladım</string>
     <string name="swiper_file_type_filter_title">Yalnızca bu dosya türlerini göster</string>
     <string name="swiper_file_type_filter_hint">Görmek istediğiniz türleri işaretleyin. Hiçbiri işaretlenmemişse tüm dosyalar gösterilir.</string>
     <string name="swiper_file_type_category_images">Görseller</string>

--- a/app-tool-swiper/src/main/res/values-uk/strings.xml
+++ b/app-tool-swiper/src/main/res/values-uk/strings.xml
@@ -68,7 +68,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Вібрувати при прийнятті рішень про збереження або видалення.</string>
     <string name="swiper_discard_session_confirmation_title">Скасувати сесію?</string>
     <string name="swiper_discard_session_confirmation_message">Всі рішення будуть втрачені. Ви впевнені?</string>
-    <string name="swiper_no_preview_available">Попередній перегляд недоступний</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Продовжити сесію %1$d день тому (%2$d%% завершено)</item>
         <item quantity="few">Продовжити сесію %1$d дні тому (%2$d%% завершено)</item>
@@ -167,16 +166,8 @@
     <string name="swiper_stamp_undo_2">Назад!</string>
     <string name="swiper_stamp_undo_3">Ой!</string>
     <string name="swiper_stamp_undo_4">Зачекайте!</string>
-    <string name="swiper_gesture_overlay_dismiss">Натисніть будь-де, щоб почати</string>
-    <string name="swiper_gesture_overlay_left_delete">← Видалити</string>
-    <string name="swiper_gesture_overlay_right_keep">Зберегти →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Зберегти</string>
-    <string name="swiper_gesture_overlay_right_delete">Видалити →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Пропустити</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Скасувати</string>
     <string name="swiper_help_title">Як працює Swiper</string>
     <string name="swiper_help_message">Проведіть по кожному файлу, щоб прийняти рішення:\n\n← Проведіть вліво: %1$s\n→ Проведіть вправо: %2$s\n↑ Проведіть вгору: Пропустити\n↓ Проведіть вниз: Скасувати (після першого свайпу)\n\nВи також можете використовувати кнопки внизу.\n\nКоли закінчите, натисніть \"Огляд\", щоб переглянути всі рішення. Нічого не видаляється, поки ви не підтвердите на екрані перегляду.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Зрозуміло</string>
     <string name="swiper_file_type_filter_title">Показувати лише ці типи файлів</string>
     <string name="swiper_file_type_filter_hint">Позначте типи, які хочете бачити. Якщо жодного не позначено, відображаються всі файли.</string>
     <string name="swiper_file_type_category_images">Зображення</string>

--- a/app-tool-swiper/src/main/res/values-ur-rIN/strings.xml
+++ b/app-tool-swiper/src/main/res/values-ur-rIN/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">رکھنے یا حذف کے فیصلوں پر وائبریٹ کریں۔</string>
     <string name="swiper_discard_session_confirmation_title">سیشن رد کریں؟</string>
     <string name="swiper_discard_session_confirmation_message">تمام فیصلے ضائع ہو جائیں گے۔ کیا آپ کو یقین ہے؟</string>
-    <string name="swiper_no_preview_available">کوئی پیش نظارہ دستیاب نہیں</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d دن پہلے کا سیشن جاری رکھیں (%2$d%% مکمل)</item>
         <item quantity="other">%1$d دن پہلے کا سیشن جاری رکھیں (%2$d%% مکمل)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">پیچھے!</string>
     <string name="swiper_stamp_undo_3">اوہو!</string>
     <string name="swiper_stamp_undo_4">رکیں!</string>
-    <string name="swiper_gesture_overlay_dismiss">شروع کرنے کے لیے کہیں بھی ٹیپ کریں</string>
-    <string name="swiper_gesture_overlay_left_delete">← حذف</string>
-    <string name="swiper_gesture_overlay_right_keep">رکھیں →</string>
-    <string name="swiper_gesture_overlay_left_keep">← رکھیں</string>
-    <string name="swiper_gesture_overlay_right_delete">حذف →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ چھوڑیں</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ واپس</string>
     <string name="swiper_help_title">Swiper کیسے کام کرتا ہے</string>
     <string name="swiper_help_message">فیصلہ کرنے کے لیے ہر فائل سوائپ کریں:\n\n← بائیں سوائپ کریں: %1$s\n→ دائیں سوائپ کریں: %2$s\n↑ اوپر سوائپ کریں: چھوڑیں\n↓ نیچے سوائپ کریں: واپس (پہلے سوائپ کے بعد)\n\nآپ نیچے کے بٹن بھی استعمال کر سکتے ہیں۔\n\nجب آپ مکمل کر لیں، اپنے تمام فیصلے دیکھنے کے لیے \"جائزہ\" پر ٹیپ کریں۔ جائزہ اسکرین پر تصدیق کرنے تک کچھ بھی حذف نہیں ہوتا۔</string>
-    <string name="swiper_gesture_overlay_dismiss_action">سمجھ گیا</string>
     <string name="swiper_file_type_filter_title">صرف یہ فائل کی اقسام دکھائیں</string>
     <string name="swiper_file_type_filter_hint">وہ اقسام چیک کریں جو آپ دیکھنا چاہتے ہیں۔ اگر کوئی چیک نہیں ہے، تمام فائلیں دکھائی جاتی ہیں۔</string>
     <string name="swiper_file_type_category_images">تصاویر</string>

--- a/app-tool-swiper/src/main/res/values-uz/strings.xml
+++ b/app-tool-swiper/src/main/res/values-uz/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Saqlash yoki o\'chirish qarorlari qabul qilinganda tebratish.</string>
     <string name="swiper_discard_session_confirmation_title">Sessiyani rad etish kerakmi?</string>
     <string name="swiper_discard_session_confirmation_message">Barcha qarorlar yo\'qoladi. Ishonchingiz komilmi?</string>
-    <string name="swiper_no_preview_available">Oldindan ko\'rish mavjud emas</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">%1$d kun oldingi sessiyani davom ettirish (%2$d%% tugallangan)</item>
         <item quantity="other">%1$d kun oldingi sessiyani davom ettirish (%2$d%% tugallangan)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Orqaga!</string>
     <string name="swiper_stamp_undo_3">Voy!</string>
     <string name="swiper_stamp_undo_4">Kuting!</string>
-    <string name="swiper_gesture_overlay_dismiss">Boshlash uchun istalgan joyga bosing</string>
-    <string name="swiper_gesture_overlay_left_delete">← O\'chirish</string>
-    <string name="swiper_gesture_overlay_right_keep">Saqlash →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Saqlash</string>
-    <string name="swiper_gesture_overlay_right_delete">O\'chirish →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ O\'tkazish</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Qaytarish</string>
     <string name="swiper_help_title">Swiper qanday ishlaydi</string>
     <string name="swiper_help_message">Qaror qabul qilish uchun har bir faylni suring:\n\n← Chapga suring: %1$s\n→ O\'ngga suring: %2$s\n↑ Yuqoriga suring: O\'tkazish\n↓ Pastga suring: Qaytarish (birinchi surishdan keyin)\n\nSiz pastdagi tugmalardan ham foydalanishingiz mumkin.\n\nTugatganingizda, barcha qarorlaringizni ko\'rish uchun \"Ko\'rib chiqish\" ni bosing. Ko\'rib chiqish ekranida tasdiqlaguningizcha hech narsa o\'chirilmaydi.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Tushundim</string>
     <string name="swiper_file_type_filter_title">Faqat shu fayl turlarini ko\'rsatish</string>
     <string name="swiper_file_type_filter_hint">Ko\'rmoqchi bo\'lgan turlarni belgilang. Hech biri belgilanmagan bo\'lsa, barcha fayllar ko\'rsatiladi.</string>
     <string name="swiper_file_type_category_images">Rasmlar</string>

--- a/app-tool-swiper/src/main/res/values-vi/strings.xml
+++ b/app-tool-swiper/src/main/res/values-vi/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Rung khi ra quyết định giữ hoặc xóa.</string>
     <string name="swiper_discard_session_confirmation_title">Hủy bỏ phiên làm việc?</string>
     <string name="swiper_discard_session_confirmation_message">Tất cả quyết định sẽ bị mất hết. Bạn có chắc không?</string>
-    <string name="swiper_no_preview_available">Không có bản xem trước</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">Tiếp tục phiên từ %1$d ngày trước (%2$d%% đã hoàn thành)</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">Trở lại!</string>
     <string name="swiper_stamp_undo_3">Rất tiếc!</string>
     <string name="swiper_stamp_undo_4">Chờ chút!</string>
-    <string name="swiper_gesture_overlay_dismiss">Chạm bất kỳ đâu để bắt đầu</string>
-    <string name="swiper_gesture_overlay_left_delete">← Xóa</string>
-    <string name="swiper_gesture_overlay_right_keep">Giữ lại →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Giữ lại</string>
-    <string name="swiper_gesture_overlay_right_delete">Xóa →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Bỏ qua</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Hoàn tác</string>
     <string name="swiper_help_title">Cách Swiper hoạt động</string>
     <string name="swiper_help_message">Vuốt từng tệp để đưa ra quyết định:\n\n← Vuốt sang trái: %1$s\n→ Vuốt sang phải: %2$s\n↑ Vuốt lên: Bỏ qua\n↓ Vuốt xuống: Hoàn tác (sau lần vuốt đầu tiên)\n\nBạn cũng có thể sử dụng các nút ở phía dưới.\n\nKhi hoàn tất, nhấn \"Xem lại\" để xem tất cả quyết định của bạn. Không có gì bị xóa cho đến khi bạn xác nhận trên màn hình xem lại.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Đã hiểu</string>
     <string name="swiper_file_type_filter_title">Chỉ hiển thị các loại tệp này</string>
     <string name="swiper_file_type_filter_hint">Chọn các loại bạn muốn xem. Nếu không có loại nào được chọn, tất cả các tệp sẽ được hiển thị.</string>
     <string name="swiper_file_type_category_images">Hình ảnh</string>

--- a/app-tool-swiper/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tool-swiper/src/main/res/values-zh-rCN/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">做出保留或删除决定时振动。</string>
     <string name="swiper_discard_session_confirmation_title">丢弃会话？</string>
     <string name="swiper_discard_session_confirmation_message">所有决定将会丢失。您确定吗？</string>
-    <string name="swiper_no_preview_available">没有可用的预览</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">继续 %1$d 天前的会话（已完成 %2$d%%）</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">返回！</string>
     <string name="swiper_stamp_undo_3">糟糕！</string>
     <string name="swiper_stamp_undo_4">等等！</string>
-    <string name="swiper_gesture_overlay_dismiss">点击任意位置开始</string>
-    <string name="swiper_gesture_overlay_left_delete">← 删除</string>
-    <string name="swiper_gesture_overlay_right_keep">保留 →</string>
-    <string name="swiper_gesture_overlay_left_keep">← 保留</string>
-    <string name="swiper_gesture_overlay_right_delete">删除 →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ 跳过</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ 撤销</string>
     <string name="swiper_help_title">Swiper 使用方法</string>
     <string name="swiper_help_message">滑动每个文件来做出决定：\n\n← 向左滑动：%1$s\n→ 向右滑动：%2$s\n↑ 向上滑动：跳过\n↓ 向下滑动：撤销（首次滑动后）\n\n您也可以使用底部的按钮。\n\n完成后，点击\"审查\"查看所有决定。在审查页面确认之前不会删除任何内容。</string>
-    <string name="swiper_gesture_overlay_dismiss_action">明白</string>
     <string name="swiper_file_type_filter_title">仅显示这些文件类型</string>
     <string name="swiper_file_type_filter_hint">勾选您想查看的类型。如果未勾选任何类型，则显示所有文件。</string>
     <string name="swiper_file_type_category_images">图片</string>

--- a/app-tool-swiper/src/main/res/values-zh-rHK/strings.xml
+++ b/app-tool-swiper/src/main/res/values-zh-rHK/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">做出保留或刪除決定時震動。</string>
     <string name="swiper_discard_session_confirmation_title">捨棄工作階段？</string>
     <string name="swiper_discard_session_confirmation_message">所有決定將會遺失。確定嗎？</string>
-    <string name="swiper_no_preview_available">無法預覽</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">繼續 %1$d 天前的工作階段（已完成 %2$d%%）</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">返回！</string>
     <string name="swiper_stamp_undo_3">哎呀！</string>
     <string name="swiper_stamp_undo_4">等等！</string>
-    <string name="swiper_gesture_overlay_dismiss">輕觸任何位置開始</string>
-    <string name="swiper_gesture_overlay_left_delete">← 刪除</string>
-    <string name="swiper_gesture_overlay_right_keep">保留 →</string>
-    <string name="swiper_gesture_overlay_left_keep">← 保留</string>
-    <string name="swiper_gesture_overlay_right_delete">刪除 →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ 跳過</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ 復原</string>
     <string name="swiper_help_title">Swiper 使用方法</string>
     <string name="swiper_help_message">滑動每個檔案作出決定：\n\n← 向左滑動：%1$s\n→ 向右滑動：%2$s\n↑ 向上滑動：跳過\n↓ 向下滑動：復原（首次滑動後）\n\n你也可以使用底部的按鈕。\n\n完成後，輕觸「檢視」查看所有決定。在確認畫面上確認之前，不會刪除任何內容。</string>
-    <string name="swiper_gesture_overlay_dismiss_action">瞭解了</string>
     <string name="swiper_file_type_filter_title">只顯示這些檔案類型</string>
     <string name="swiper_file_type_filter_hint">勾選您想查看的類型。如果未勾選任何類型，則顯示所有檔案。</string>
     <string name="swiper_file_type_category_images">圖片</string>

--- a/app-tool-swiper/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tool-swiper/src/main/res/values-zh-rTW/strings.xml
@@ -50,7 +50,6 @@
     <string name="swiper_settings_haptic_feedback_summary">做出保留或刪除決定時震動。</string>
     <string name="swiper_discard_session_confirmation_title">捨棄工作階段？</string>
     <string name="swiper_discard_session_confirmation_message">所有決定將會遺失。您確定嗎？</string>
-    <string name="swiper_no_preview_available">沒有可用的預覽</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="other">繼續 %1$d 天前的工作階段（已完成 %2$d%%）</item>
     </plurals>
@@ -116,16 +115,8 @@
     <string name="swiper_stamp_undo_2">返回！</string>
     <string name="swiper_stamp_undo_3">糟糕！</string>
     <string name="swiper_stamp_undo_4">等等！</string>
-    <string name="swiper_gesture_overlay_dismiss">點擊任意位置開始</string>
-    <string name="swiper_gesture_overlay_left_delete">← 刪除</string>
-    <string name="swiper_gesture_overlay_right_keep">保留 →</string>
-    <string name="swiper_gesture_overlay_left_keep">← 保留</string>
-    <string name="swiper_gesture_overlay_right_delete">刪除 →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ 跳過</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ 復原</string>
     <string name="swiper_help_title">Swiper 使用方式</string>
     <string name="swiper_help_message">滑動每個檔案來做決定：\n\n← 向左滑動：%1$s\n→ 向右滑動：%2$s\n↑ 向上滑動：跳過\n↓ 向下滑動：復原（第一次滑動後）\n\n您也可以使用底部的按鈕。\n\n完成後，點擊「檢閱」查看所有決定。在檢閱畫面確認之前，不會刪除任何內容。</string>
-    <string name="swiper_gesture_overlay_dismiss_action">瞭解了</string>
     <string name="swiper_file_type_filter_title">只顯示這些檔案類型</string>
     <string name="swiper_file_type_filter_hint">勾選您想查看的類型。若未勾選任何類型，將顯示所有檔案。</string>
     <string name="swiper_file_type_category_images">圖片</string>

--- a/app-tool-swiper/src/main/res/values-zu/strings.xml
+++ b/app-tool-swiper/src/main/res/values-zu/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Dlidlizela lapho wenza izinqumo zokugcina noma zokususa.</string>
     <string name="swiper_discard_session_confirmation_title">Lahla iseshini?</string>
     <string name="swiper_discard_session_confirmation_message">Zonke izinqumo zizolahleka. Uqinisekile?</string>
-    <string name="swiper_no_preview_available">Akukho imboniso yangaphambili etholakalayo</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Qhubeka neseshini yosuku olungu-%1$d oludlule (%2$d%% kuqediwe)</item>
         <item quantity="other">Qhubeka neseshini yezinsuku ezingu-%1$d ezedlule (%2$d%% kuqediwe)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Emuva!</string>
     <string name="swiper_stamp_undo_3">Hawu!</string>
     <string name="swiper_stamp_undo_4">Linda!</string>
-    <string name="swiper_gesture_overlay_dismiss">Thepha noma kuphi ukuze uqale</string>
-    <string name="swiper_gesture_overlay_left_delete">← Susa</string>
-    <string name="swiper_gesture_overlay_right_keep">Gcina →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Gcina</string>
-    <string name="swiper_gesture_overlay_right_delete">Susa →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Yeqa</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Hlehlisa</string>
     <string name="swiper_help_title">Indlela i-Swiper esebenza ngayo</string>
     <string name="swiper_help_message">Swayipha ifayela ngalinye ukuze uthathe isinqumo:\n\n← Swayipha kwesokunxele: %1$s\n→ Swayipha kwesokudla: %2$s\n↑ Swayipha phezulu: Yeqa\n↓ Swayipha phansi: Hlehlisa (ngemva kokuswayipha kokuqala)\n\nUngasebenzisa nezinkinobho ezingezansi.\n\nUma uqedile, thepha \"Buyekeza\" ukuze ubone zonke izinqumo zakho. Akukho okususwayo kuze kube uqinisekisa kusikrini sokubuyekeza.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Ngiyaqonda</string>
     <string name="swiper_file_type_filter_title">Bonisa kuphela lezi zinhlobo zamafayela</string>
     <string name="swiper_file_type_filter_hint">Hlola izinhlobo ofuna ukuzibona. Uma kungekho ezihlolwe, wonke amafayela azoboniswa.</string>
     <string name="swiper_file_type_category_images">Izithombe</string>

--- a/app-tool-swiper/src/main/res/values/strings.xml
+++ b/app-tool-swiper/src/main/res/values/strings.xml
@@ -56,7 +56,6 @@
     <string name="swiper_settings_haptic_feedback_summary">Vibrate when making keep or delete decisions.</string>
     <string name="swiper_discard_session_confirmation_title">Discard session?</string>
     <string name="swiper_discard_session_confirmation_message">All decisions will be lost. Are you sure?</string>
-    <string name="swiper_no_preview_available">No preview available</string>
     <plurals name="swiper_dashcard_session_context">
         <item quantity="one">Continue session from %1$d day ago (%2$d%% finished)</item>
         <item quantity="other">Continue session from %1$d days ago (%2$d%% finished)</item>
@@ -133,16 +132,8 @@
     <string name="swiper_stamp_undo_2">Back!</string>
     <string name="swiper_stamp_undo_3">Oops!</string>
     <string name="swiper_stamp_undo_4">Wait!</string>
-    <string name="swiper_gesture_overlay_dismiss">Tap anywhere to start</string>
-    <string name="swiper_gesture_overlay_left_delete">← Delete</string>
-    <string name="swiper_gesture_overlay_right_keep">Keep →</string>
-    <string name="swiper_gesture_overlay_left_keep">← Keep</string>
-    <string name="swiper_gesture_overlay_right_delete">Delete →</string>
-    <string name="swiper_gesture_overlay_up_skip">↑ Skip</string>
-    <string name="swiper_gesture_overlay_down_undo">↓ Undo</string>
     <string name="swiper_help_title">How Swiper works</string>
     <string name="swiper_help_message">Swipe each file to make a decision:\n\n← Swipe left: %1$s\n→ Swipe right: %2$s\n↑ Swipe up: Skip\n↓ Swipe down: Undo (after first swipe)\n\nYou can also use the buttons at the bottom.\n\nWhen you\'re done, tap \"Review\" to see all your decisions. Nothing is deleted until you confirm on the review screen.</string>
-    <string name="swiper_gesture_overlay_dismiss_action">Got it</string>
     <string name="swiper_file_type_filter_title">Only show these file types</string>
     <string name="swiper_file_type_filter_hint">Check the types you want to see. If none are checked, all files are shown.</string>
     <string name="swiper_file_type_category_images">Images</string>


### PR DESCRIPTION
## What changed

Removes nine pieces of text from Swiper that no screen shows any more. Eight of them are the old first-run tutorial that appeared over the swipe screen; it was replaced by the help dialog, which explains the same gestures. The ninth is a leftover "No preview available" line. Nothing changes for people using the app.

The practical effect is for translators: these had to be translated into every language, and none of that work could reach a user.

## Technical Context

- All nine were verified unreferenced repo-wide by identifier, not just by an `R.string.` pattern (that pattern misses plurals, so it is not sufficient on its own): the eight `swiper_gesture_overlay_*` entries plus `swiper_no_preview_available`.
- The replacement is visible in the base file: `swiper_help_title` and `swiper_help_message` sit inside the same block and cover the same four directions, with the left/right actions as placeholders so they track the swap-directions setting rather than being hardcoded.
- Base and locale files are deleted together, 693 elements across 80 files. A base-only deletion leaves locales with translations whose base string is gone, which lint reports as `ExtraTranslation`, escalated to `fatal` for non-beta builds in `app/build.gradle.kts:101`.
- 693 rather than 720 because several locales had not translated the full set yet. The bulk of the diff is 79 near-identical locale deletions; the base file is the only one worth reading closely.
- Found while writing translator context for this file on Crowdin: the annotator could locate a call site for every other string in the module but not these. The remaining 104 Swiper strings now have context and 11 character limits on Crowdin; these nine were deliberately left without context rather than given guessed placement.