### PR TITLE
General: Remove leftover text that no screen shows

### DIFF
--- a/app-common-stats/src/main/res/values-af-rZA/strings.xml
+++ b/app-common-stats/src/main/res/values-af-rZA/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s in %2$s</string>
     <string name="stats_space_history_upgrade_title">Volledige geskiedenis is \'n Pro-funksie</string>
-    <string name="stats_space_history_upgrade_body">Opgradeer om die volledige 90-dag-tendensaansig vir elke bergingstoestel te ontsluit.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Upgrade na premium om die volledige 90-daagse oorsig vir elke bergingstoestel te ontsluit, en kry \'n waarskuwing voordat jy sonder ruimte raak.</string>
     <string name="stats_space_history_marker_freed">Vrygestel %1$s</string>
     <string name="stats_storage_type_primary">Primêre berging</string>

--- a/app-common-stats/src/main/res/values-am/strings.xml
+++ b/app-common-stats/src/main/res/values-am/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">ለውጥ</string>
     <string name="stats_space_history_delta_in_x">%1$s በ%2$s</string>
     <string name="stats_space_history_upgrade_title">ሙሉ ታሪክ የPro ባህሪ ነው</string>
-    <string name="stats_space_history_upgrade_body">ለእያንዳንዱ የማከማቻ መሳሪያ ሙሉ የ90-ቀን አዝማሚያ እይታ ለማግኘት ያሻሽሉ።</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">ለእያንዳንዱ የማከማቻ መሣሪያ ሙሉውን የ90 ቀናት አዝማሚያ እይታ ለመክፈት እና ቦታ ከማለቁ በፊት ማስጠንቀቂያ ለማግኘት ያሻሽሉ።</string>
     <string name="stats_space_history_marker_freed">%1$s ነጻ ሆነ</string>
     <string name="stats_storage_type_primary">ዋና ማጠራቀሚያ</string>

--- a/app-common-stats/src/main/res/values-ar/strings.xml
+++ b/app-common-stats/src/main/res/values-ar/strings.xml
@@ -77,9 +77,6 @@
     <string name="stats_space_history_delta_label">الفارق</string>
     <string name="stats_space_history_delta_in_x">%1$s في %2$s</string>
     <string name="stats_space_history_upgrade_title">السجل الكامل ميزة Pro</string>
-    <string name="stats_space_history_upgrade_body">قم بالترقية لإلغاء قفل عرض الاتجاه الكامل لـ 90 يومًا لكل جهاز تخزين.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">قم بالترقية لفتح عرض الاتجاه الكامل لمدة 90 يومًا لكل جهاز تخزين، والحصول على تنبيه قبل نفاد المساحة.</string>
     <string name="stats_space_history_marker_freed">تم تحرير %1$s</string>
     <string name="stats_storage_type_primary">التخزين الأساسي</string>

--- a/app-common-stats/src/main/res/values-az/strings.xml
+++ b/app-common-stats/src/main/res/values-az/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s, %2$s ərzində</string>
     <string name="stats_space_history_upgrade_title">Tam tarixçə Pro xüsusiyyətidir</string>
-    <string name="stats_space_history_upgrade_body">Hər saxlama qurğusu üçün tam 90 günlük trend görünüşünün kilidini açmaq üçün təkmilləşdirin.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Hər yaddaş cihazı üçün tam 90 günlük tendensiya görünüşünü açmaq və yerin bitməzdən əvvəl xəbərdarlıq almaq üçün yüksəlt.</string>
     <string name="stats_space_history_marker_freed">%1$s azaldıldı</string>
     <string name="stats_storage_type_primary">Əsas yaddaş</string>

--- a/app-common-stats/src/main/res/values-be/strings.xml
+++ b/app-common-stats/src/main/res/values-be/strings.xml
@@ -65,9 +65,6 @@
     <string name="stats_space_history_delta_label">Дэльта</string>
     <string name="stats_space_history_delta_in_x">%1$s за %2$s</string>
     <string name="stats_space_history_upgrade_title">Поўная гісторыя — гэта функцыя Pro</string>
-    <string name="stats_space_history_upgrade_body">Абновіцеся, каб атрымаць доступ да поўнага 90-дзённага прагляду трэнду для кожнай прылады захоўвання.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Абнавіць, каб разблакіраваць поўны прагляд тэндэнцый за 90 дзён для кожнага ўстройства сховішча, і атрымаць папярэджанне перш, чым месца скончыцца.</string>
     <string name="stats_space_history_marker_freed">Вызвалена %1$s</string>
     <string name="stats_storage_type_primary">Асноўнае сховішча</string>

--- a/app-common-stats/src/main/res/values-bg/strings.xml
+++ b/app-common-stats/src/main/res/values-bg/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Делта</string>
     <string name="stats_space_history_delta_in_x">%1$s за %2$s</string>
     <string name="stats_space_history_upgrade_title">Пълната история е функция Pro</string>
-    <string name="stats_space_history_upgrade_body">Надградете, за да отключите пълния 90-дневен преглед на тенденциите за всяко устройство за съхранение.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Надгради, за да отключиш пълния 90-дневен изглед на тенденциите за всяко устройство за съхранение и да получаваш предупреждение, преди мястото да свърши.</string>
     <string name="stats_space_history_marker_freed">Освободено %1$s</string>
     <string name="stats_storage_type_primary">Основно хранилище</string>

--- a/app-common-stats/src/main/res/values-bn-rBD/strings.xml
+++ b/app-common-stats/src/main/res/values-bn-rBD/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">পরিবর্তন</string>
     <string name="stats_space_history_delta_in_x">%2$s এ %1$s</string>
     <string name="stats_space_history_upgrade_title">সম্পূর্ণ ইতিহাস একটি Pro বৈশিষ্ট্য</string>
-    <string name="stats_space_history_upgrade_body">প্রতিটি স্টোরেজ ডিভাইসের জন্য সম্পূর্ণ ৯০-দিনের প্রবণতা দৃশ্য আনলক করতে আপগ্রেড করুন।</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">প্রতিটি স্টোরেজ ডিভাইসের জন্য সম্পূর্ণ ৯০-দিনের ট্রেন্ড ভিউ আনলক করতে এবং স্থান শেষ হওয়ার আগে একটি সতর্কতা পেতে আপগ্রেড করুন।</string>
     <string name="stats_space_history_marker_freed">%1$s মুক্ত করা হয়েছে</string>
     <string name="stats_storage_type_primary">প্রাথমিক স্টোরেজ</string>

--- a/app-common-stats/src/main/res/values-ca/strings.xml
+++ b/app-common-stats/src/main/res/values-ca/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s en %2$s</string>
     <string name="stats_space_history_upgrade_title">L’historial complet és una funció Pro</string>
-    <string name="stats_space_history_upgrade_body">Actualitza per desbloquejar la vista de tendència completa de 90 dies per a cada dispositiu d’emmagatzematge.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Milloreu per desbloquejar la vista completa de tendències de 90 dies per a cada dispositiu d\'emmagatzematge i rebeu un avís abans que us quedeu sense espai.</string>
     <string name="stats_space_history_marker_freed">Alliberat %1$s</string>
     <string name="stats_storage_type_primary">Emmagatzematge primari</string>

--- a/app-common-stats/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-common-stats/src/main/res/values-ckb-rIR/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">دێڵتا</string>
     <string name="stats_space_history_delta_in_x">%1$s لە %2$s</string>
     <string name="stats_space_history_upgrade_title">مێژووی تەواو تایبەتمەندییەکی Pro ە</string>
-    <string name="stats_space_history_upgrade_body">Pro بکە بۆ کردنەوەی دیمەنی ڕووتری ٩٠ ڕۆژی بۆ هەر ئامێرێکی ئەنبار.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">بەرزکردنەوە بکە بۆ کردنەوەی بینینی تەواوی ڕەوتی ٩٠ ڕۆژ بۆ هەر ئامێرێکی بیرگە، و ئاگاداری وەربگرە پێش ئەوەی بۆشاییت تەواو بێت.</string>
     <string name="stats_space_history_marker_freed">%1$s ئازادکراوە</string>
     <string name="stats_storage_type_primary">ئەنبارێکی سەرەکی</string>

--- a/app-common-stats/src/main/res/values-cs/strings.xml
+++ b/app-common-stats/src/main/res/values-cs/strings.xml
@@ -65,9 +65,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s za %2$s</string>
     <string name="stats_space_history_upgrade_title">Celá historie je funkce Pro</string>
-    <string name="stats_space_history_upgrade_body">Upgradujte pro odemknutí plného 90denního trendu pro každé paměťové zařízení.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Přejdi na vyšší verzi a odemkni si kompletní 90denní zobrazení trendu pro každé úložné zařízení a získej upozornění dřív, než dojde místo.</string>
     <string name="stats_space_history_marker_freed">Uvolněno %1$s</string>
     <string name="stats_storage_type_primary">Primární úložiště</string>

--- a/app-common-stats/src/main/res/values-da/strings.xml
+++ b/app-common-stats/src/main/res/values-da/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s på %2$s</string>
     <string name="stats_space_history_upgrade_title">Fuld historik er en Pro-funktion</string>
-    <string name="stats_space_history_upgrade_body">Opgrader for at låse op for den fulde 90-dages trendvisning for hver lagerenhed.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Opgrader for at låse op for den fulde 90-dages trendvisning for hver lagerenhed, og få en advarsel, før du løber tør for plads.</string>
     <string name="stats_space_history_marker_freed">Frigjort %1$s</string>
     <string name="stats_storage_type_primary">Primær lager</string>

--- a/app-common-stats/src/main/res/values-de/strings.xml
+++ b/app-common-stats/src/main/res/values-de/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s in %2$s</string>
     <string name="stats_space_history_upgrade_title">Vollständiger Verlauf ist eine Pro-Funktion</string>
-    <string name="stats_space_history_upgrade_body">Upgrade durchführen, um die vollständige 90-Tage-Trendansicht für jedes Speichergerät freizuschalten.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Hol dir das Upgrade, um die vollständige 90-Tage-Trendansicht für jedes Speichergerät freizuschalten und eine Warnung zu erhalten, bevor dein Speicher voll ist.</string>
     <string name="stats_space_history_marker_freed">%1$s freigegeben</string>
     <string name="stats_storage_type_primary">Primärspeicher</string>

--- a/app-common-stats/src/main/res/values-el/strings.xml
+++ b/app-common-stats/src/main/res/values-el/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Δέλτα</string>
     <string name="stats_space_history_delta_in_x">%1$s σε %2$s</string>
     <string name="stats_space_history_upgrade_title">Το πλήρες ιστορικό είναι λειτουργία Pro</string>
-    <string name="stats_space_history_upgrade_body">Αναβαθμίστε για να ξεκλειδώσετε την πλήρη προβολή τάσης 90 ημερών για κάθε συσκευή αποθήκευσης.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Αναβάθμισε για να ξεκλειδώσεις την πλήρη προβολή τάσης 90 ημερών για κάθε συσκευή αποθήκευσης, και λάβε προειδοποίηση προτού εξαντληθεί ο χώρος σου.</string>
     <string name="stats_space_history_marker_freed">Ελευθερώθηκε %1$s</string>
     <string name="stats_storage_type_primary">Πρωτεύων αποθηκευτικός χώρος</string>

--- a/app-common-stats/src/main/res/values-es-rAR/strings.xml
+++ b/app-common-stats/src/main/res/values-es-rAR/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s en %2$s</string>
     <string name="stats_space_history_upgrade_title">El historial completo es una función Pro</string>
-    <string name="stats_space_history_upgrade_body">Actualizá para desbloquear la vista de tendencia completa de 90 días para cada dispositivo de almacenamiento.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Actualizá para desbloquear la vista completa de tendencias de 90 días para cada dispositivo de almacenamiento, y recibí un aviso antes de quedarte sin espacio.</string>
     <string name="stats_space_history_marker_freed">Liberado %1$s</string>
     <string name="stats_storage_type_primary">Almacenamiento Primario</string>

--- a/app-common-stats/src/main/res/values-es-rMX/strings.xml
+++ b/app-common-stats/src/main/res/values-es-rMX/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s en %2$s</string>
     <string name="stats_space_history_upgrade_title">El historial completo es una función Pro</string>
-    <string name="stats_space_history_upgrade_body">Actualiza para desbloquear la vista de tendencia completa de 90 días para cada dispositivo de almacenamiento.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Actualiza para desbloquear la vista de tendencia completa de 90 días para cada dispositivo de almacenamiento y recibir una advertencia antes de quedarte sin espacio.</string>
     <string name="stats_space_history_marker_freed">Liberado %1$s</string>
     <string name="stats_storage_type_primary">Almacenamiento principal</string>

--- a/app-common-stats/src/main/res/values-es/strings.xml
+++ b/app-common-stats/src/main/res/values-es/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s en %2$s</string>
     <string name="stats_space_history_upgrade_title">El historial completo es una función Pro</string>
-    <string name="stats_space_history_upgrade_body">Actualiza para desbloquear la vista completa de tendencias de 90 días para cada dispositivo de almacenamiento.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Actualiza para desbloquear la vista completa de tendencias de 90 días para cada dispositivo de almacenamiento, y recibe un aviso antes de quedarte sin espacio.</string>
     <string name="stats_space_history_marker_freed">Liberado %1$s</string>
     <string name="stats_storage_type_primary">Almacenamiento principal</string>

--- a/app-common-stats/src/main/res/values-et-rEE/strings.xml
+++ b/app-common-stats/src/main/res/values-et-rEE/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s %2$s pärast</string>
     <string name="stats_space_history_upgrade_title">Kogu ajalugu on tasuline</string>
-    <string name="stats_space_history_upgrade_body">Iga hoiustamisseadme kogu 90 päevase trendi kuvamiseks ostke võimsam pakett.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Uuenda, et avada iga mäluseadme täielik 90 päeva pikkune trendivaade ja saada hoiatus enne ruumi otsalõppemist.</string>
     <string name="stats_space_history_marker_freed">Vabanes %1$s</string>
     <string name="stats_storage_type_primary">Peamine hoiustamisruum</string>

--- a/app-common-stats/src/main/res/values-eu-rES/strings.xml
+++ b/app-common-stats/src/main/res/values-eu-rES/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s %2$s-tan</string>
     <string name="stats_space_history_upgrade_title">Historia osoa Pro ezaugarria da</string>
-    <string name="stats_space_history_upgrade_body">Eguneratu biltegiratze-gailu bakoitzeko 90 eguneko joeraren ikuspegi osoa desblokeatzeko.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Eguneratu biltegi-gailu bakoitzerako 90 eguneko joeraren bista osoa desblokeatzeko, eta jaso abisu bat lekua agortzen baino lehen.</string>
     <string name="stats_space_history_marker_freed">Askatuta %1$s</string>
     <string name="stats_storage_type_primary">Lehen mailako biltegiratzea</string>

--- a/app-common-stats/src/main/res/values-fa/strings.xml
+++ b/app-common-stats/src/main/res/values-fa/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">تفاضل</string>
     <string name="stats_space_history_delta_in_x">%1$s در %2$s</string>
     <string name="stats_space_history_upgrade_title">تاریخچه کامل یک ویژگی Pro است</string>
-    <string name="stats_space_history_upgrade_body">برای مشاهده روند کامل ۹۰ روزه هر دستگاه ذخیره‌سازی، ارتقاء دهید.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">ارتقا دهید تا نمای کامل روند ۹۰ روزه هر دستگاه ذخیره‌سازی را باز کنید و پیش از اتمام فضا هشدار دریافت کنید.</string>
     <string name="stats_space_history_marker_freed">آزاد شده %1$s</string>
     <string name="stats_storage_type_primary">حافظه اصلی</string>

--- a/app-common-stats/src/main/res/values-fi/strings.xml
+++ b/app-common-stats/src/main/res/values-fi/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Muutos</string>
     <string name="stats_space_history_delta_in_x">%1$s kohteessa %2$s</string>
     <string name="stats_space_history_upgrade_title">Täysi historia on Pro-ominaisuus</string>
-    <string name="stats_space_history_upgrade_body">Päivitä avataksesi täyden 90 päivän trendinäkymän kullekin tallennuslaitteelle.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Päivitä, niin saat täyden 90 päivän trendinäkymän jokaiselle tallennuslaitteelle sekä varoituksen ennen kuin tila loppuu.</string>
     <string name="stats_space_history_marker_freed">Vapautettu %1$s</string>
     <string name="stats_storage_type_primary">Sisäinen tallennustila</string>

--- a/app-common-stats/src/main/res/values-fil/strings.xml
+++ b/app-common-stats/src/main/res/values-fil/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s sa loob ng %2$s</string>
     <string name="stats_space_history_upgrade_title">Ang buong kasaysayan ay isang Pro na tampok</string>
-    <string name="stats_space_history_upgrade_body">I-upgrade upang ma-unlock ang buong 90-araw na trend view para sa bawat storage device.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">I-upgrade upang i-unlock ang 90-day trend view para sa bawat storage device, at makatanggap ng babala bago maubos ang puwang.</string>
     <string name="stats_space_history_marker_freed">Na-free ang %1$s</string>
     <string name="stats_storage_type_primary">Pangunahing imbakan</string>

--- a/app-common-stats/src/main/res/values-fr/strings.xml
+++ b/app-common-stats/src/main/res/values-fr/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s en %2$s</string>
     <string name="stats_space_history_upgrade_title">L’historique complet est une fonctionnalité Pro</string>
-    <string name="stats_space_history_upgrade_body">Passez à la version Pro pour accéder à la vue complète des tendances sur 90 jours pour chaque périphérique de stockage.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Mets à niveau pour déverrouiller la vue de tendance complète de 90 jours pour chaque appareil de stockage, et obtiens un avertissement avant de manquer d\'espace.</string>
     <string name="stats_space_history_marker_freed">Espace libéré %1$s</string>
     <string name="stats_storage_type_primary">Mémoire principale</string>

--- a/app-common-stats/src/main/res/values-gl-rES/strings.xml
+++ b/app-common-stats/src/main/res/values-gl-rES/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s en %2$s</string>
     <string name="stats_space_history_upgrade_title">O historial completo é unha función Pro</string>
-    <string name="stats_space_history_upgrade_body">Mellora para desbloquear a vista de tendencia completa de 90 días para cada dispositivo de almacenamento.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Actualiza para desbloquear a vista de tendencia completa de 90 días para cada dispositivo de almacenamento e recibe un aviso antes de quedares sen espazo.</string>
     <string name="stats_space_history_marker_freed">Liberado %1$s</string>
     <string name="stats_storage_type_primary">Almacenamento principal</string>

--- a/app-common-stats/src/main/res/values-hi-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-hi-rIN/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">डेल्टा</string>
     <string name="stats_space_history_delta_in_x">%1$s में %2$s</string>
     <string name="stats_space_history_upgrade_title">पूर्ण इतिहास एक Pro सुविधा है</string>
-    <string name="stats_space_history_upgrade_body">प्रत्येक स्टोरेज डिवाइस के लिए पूर्ण 90-दिन का ट्रेंड व्यू अनलॉक करने के लिए अपग्रेड करें।</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">प्रत्येक स्टोरेज डिवाइस के लिए संपूर्ण 90-दिन का ट्रेंड दृश्य अनलॉक करने के लिए अपग्रेड करें, और अपनी जगह खत्म होने से पहले एक चेतावनी प्राप्त करें।</string>
     <string name="stats_space_history_marker_freed">%1$s मुक्त किया</string>
     <string name="stats_storage_type_primary">प्रारंभिक संग्रहण</string>

--- a/app-common-stats/src/main/res/values-hr/strings.xml
+++ b/app-common-stats/src/main/res/values-hr/strings.xml
@@ -59,9 +59,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s u %2$s</string>
     <string name="stats_space_history_upgrade_title">Potpuna povijest je Pro značajka</string>
-    <string name="stats_space_history_upgrade_body">Nadogradite za otključavanje prikaza trenda od 90 dana za svaki uređaj za pohranu.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Nadogradi za otključavanje potpunog prikaza trenda od 90 dana za svaki uređaj za pohranu, te upozorenje prije nego što ti ponestane prostora.</string>
     <string name="stats_space_history_marker_freed">Oslobođeno %1$s</string>
     <string name="stats_storage_type_primary">Primarna pohrana</string>

--- a/app-common-stats/src/main/res/values-hu/strings.xml
+++ b/app-common-stats/src/main/res/values-hu/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s %2$s alatt</string>
     <string name="stats_space_history_upgrade_title">A teljes előzmény Pro funkció</string>
-    <string name="stats_space_history_upgrade_body">Frissíts a teljes 90 napos trendnézet feloldásához minden tárolóeszközön.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Frissítsd, hogy a teljes 90 napos trendet lásd minden tárhelyhez, és figyelmeztetést kapj, mielőtt kifogyóban lenne a tárhely.</string>
     <string name="stats_space_history_marker_freed">Felszabadítva: %1$s</string>
     <string name="stats_storage_type_primary">Elsődleges tároló</string>

--- a/app-common-stats/src/main/res/values-in/strings.xml
+++ b/app-common-stats/src/main/res/values-in/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s dalam %2$s</string>
     <string name="stats_space_history_upgrade_title">Riwayat lengkap adalah fitur Pro</string>
-    <string name="stats_space_history_upgrade_body">Tingkatkan untuk membuka tampilan tren 90 hari penuh untuk setiap perangkat penyimpanan.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Tingkatkan untuk membuka tampilan tren penuh 90 hari untuk setiap perangkat penyimpanan, dan dapatkan peringatan sebelum ruangmu habis.</string>
     <string name="stats_space_history_marker_freed">Dibebaskan %1$s</string>
     <string name="stats_storage_type_primary">Penyimpanan utama</string>

--- a/app-common-stats/src/main/res/values-is/strings.xml
+++ b/app-common-stats/src/main/res/values-is/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Mismunur</string>
     <string name="stats_space_history_delta_in_x">%1$s í %2$s</string>
     <string name="stats_space_history_upgrade_title">Full saga er Pro eiginleiki</string>
-    <string name="stats_space_history_upgrade_body">Uppfærstu til að opna fulla 90 daga þróunarsýð fyrir hverja geymslueiningu.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Uppfærðu til að fá aðgang að fullri 90 daga þróunarsýn fyrir hvert geymslutæki, og fáðu viðvörun áður en plássið klárast.</string>
     <string name="stats_space_history_marker_freed">Frelsadði %1$s</string>
     <string name="stats_storage_type_primary">Aðalgeymsla</string>

--- a/app-common-stats/src/main/res/values-it/strings.xml
+++ b/app-common-stats/src/main/res/values-it/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s in %2$s</string>
     <string name="stats_space_history_upgrade_title">La cronologia completa è una funzionalità Pro</string>
-    <string name="stats_space_history_upgrade_body">Aggiorna per sbloccare la visualizzazione completa delle tendenze a 90 giorni per ogni dispositivo di archiviazione.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Effettua l\'upgrade per sbloccare la visualizzazione completa delle tendenze di 90 giorni per ogni dispositivo di archiviazione e ricevi un avviso prima di esaurire lo spazio.</string>
     <string name="stats_space_history_marker_freed">Liberati %1$s</string>
     <string name="stats_storage_type_primary">Archivio principale</string>

--- a/app-common-stats/src/main/res/values-iw/strings.xml
+++ b/app-common-stats/src/main/res/values-iw/strings.xml
@@ -65,9 +65,6 @@
     <string name="stats_space_history_delta_label">דלתא</string>
     <string name="stats_space_history_delta_in_x">%1$s ב-%2$s</string>
     <string name="stats_space_history_upgrade_title">היסטוריה מלאה היא תכונת Pro</string>
-    <string name="stats_space_history_upgrade_body">שדרג כדי לפתח את תצוגת המגמה המלאה של 90 יום עבור כל התקן אחסון.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">שדרג כדי לפתוח את תצוגת המגמה המלאה של 90 ימים לכל מכשיר אחסון, וקבל אזהרה לפני שיגמר לך המקום.</string>
     <string name="stats_space_history_marker_freed">שוחרר %1$s</string>
     <string name="stats_storage_type_primary">אחסון ראשי</string>

--- a/app-common-stats/src/main/res/values-ja/strings.xml
+++ b/app-common-stats/src/main/res/values-ja/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">差分</string>
     <string name="stats_space_history_delta_in_x">%2$s間の%1$s</string>
     <string name="stats_space_history_upgrade_title">全履歴はプロ機能です</string>
-    <string name="stats_space_history_upgrade_body">アップグレードすると、各ストレージデバイスの90日間の全トレンドビューがロック解除されます。</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">アップグレードすると、各ストレージデバイスの90日間の完全な推移表示が利用でき、容量不足になる前に警告を受け取れます。</string>
     <string name="stats_space_history_marker_freed">%1$s解放</string>
     <string name="stats_storage_type_primary">プライマリストレージ</string>

--- a/app-common-stats/src/main/res/values-ka-rGE/strings.xml
+++ b/app-common-stats/src/main/res/values-ka-rGE/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">დელტა</string>
     <string name="stats_space_history_delta_in_x">%1$s %2$s-ში</string>
     <string name="stats_space_history_upgrade_title">სრული ისტორია Pro ფუნქციაა</string>
-    <string name="stats_space_history_upgrade_body">განახლდით, რომ განბლოკოთ სრული 90-დღიანი ტენდენციის ხედი თითოეული მეხსიერების მოწყობილობისთვის.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">განახლდი, რომ თითოეული საცავი მოწყობილობისთვის სრული 90-დღიანი ტენდენციის ხედი განბლოკო და მიიღო გაფრთხილება, სანამ სივრცე ამოიწურება.</string>
     <string name="stats_space_history_marker_freed">გათავისუფლდა %1$s</string>
     <string name="stats_storage_type_primary">ძირითადი მეხსიერება</string>

--- a/app-common-stats/src/main/res/values-kaa/strings.xml
+++ b/app-common-stats/src/main/res/values-kaa/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Дельта</string>
     <string name="stats_space_history_delta_in_x">%1$s ишинде %2$s</string>
     <string name="stats_space_history_upgrade_title">Толық тарийх Pro функциясы болып табылады</string>
-    <string name="stats_space_history_upgrade_body">Ҳәр бир сақлау қурылмасы ушын толық 90 күнлик тренд көринисин ашыў ушын жаңартың.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Her saqlaw\'iğı 90-kün kep körüw\'ün açıp, saqlaw tamam bolmastan burın olbertiwge yo\'l altıp, o\'nnama tarifke o\'tüñ.</string>
     <string name="stats_space_history_marker_freed">Босатылды %1$s</string>
     <string name="stats_storage_type_primary">Тийкарғы сақлау орны</string>

--- a/app-common-stats/src/main/res/values-km-rKH/strings.xml
+++ b/app-common-stats/src/main/res/values-km-rKH/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">ភាពខុសគ្នា</string>
     <string name="stats_space_history_delta_in_x">%1$s ក្នុង %2$s</string>
     <string name="stats_space_history_upgrade_title">ប្រវត្តិពេញលេញជាមុខងារ Pro</string>
-    <string name="stats_space_history_upgrade_body">លើកកំរិតដើម្បីដោះសោការមើលនិន្នាការ 90 ថ្ងៃពេញលេញសម្រាប់ឧបករណ៍ផ្ទុករាល់ពួក។</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">អាប់ក្រេតដើម្បីដោះសោទិដ្ឋភាពនិន្នាការពេញ 90 ថ្ងៃសម្រាប់ឧបករណ៍ផ្ទុកនីមួយៗ ព្រមទាំងទទួលបានការជូនដំណឹងមុនពេលទំហំផ្ទុករបស់អ្នកអស់។</string>
     <string name="stats_space_history_marker_freed">បានដោះលែង %1$s</string>
     <string name="stats_storage_type_primary">ឧបករណ៍ផ្ទុកចម្បង</string>

--- a/app-common-stats/src/main/res/values-ko/strings.xml
+++ b/app-common-stats/src/main/res/values-ko/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">변화량</string>
     <string name="stats_space_history_delta_in_x">%2$s 동안 %1$s</string>
     <string name="stats_space_history_upgrade_title">전체 기록은 Pro 기능입니다</string>
-    <string name="stats_space_history_upgrade_body">각 저장 기기에 대한 전체 90일 추세 보기를 잠금 해제하려면 업그레이드하세요.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">업그레이드하면 각 저장 장치의 90일 전체 추이 보기를 이용할 수 있고, 저장공간이 부족해지기 전에 경고도 받을 수 있어요.</string>
     <string name="stats_space_history_marker_freed">%1$s 해제됨</string>
     <string name="stats_storage_type_primary">주 저장소</string>

--- a/app-common-stats/src/main/res/values-lo-rLA/strings.xml
+++ b/app-common-stats/src/main/res/values-lo-rLA/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">ການປ່ຽນແປງ</string>
     <string name="stats_space_history_delta_in_x">%1$s ໃນ %2$s</string>
     <string name="stats_space_history_upgrade_title">ປະຫວັດທັງໝົດເປັນຄຸນສົມບັດ Pro</string>
-    <string name="stats_space_history_upgrade_body">ອັບເກຣດເພື່ອປົດລັອກມຸມມອງແນວໂນ້ມ 90 ວັນເຕັມສຳລັບແຕ່ລະອຸປະກອນເກັບຂໍ້ມູນ.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">ອັບເກຣດເພື່ອປົດລັອກມຸມມອງແນວໂນ້ມເຕັມ 90 ວັນສຳລັບອຸປະກອນຈັດເກັບແຕ່ລະອັນ, ແລະຮັບການແຈ້ງເຕືອນກ່ອນທີ່ພື້ນທີ່ຈະໝົດ.</string>
     <string name="stats_space_history_marker_freed">ປົດປ່ອຍ %1$s</string>
     <string name="stats_storage_type_primary">ບ່ອນເກັບຂໍ້ມູນຫຼັກ</string>

--- a/app-common-stats/src/main/res/values-lt/strings.xml
+++ b/app-common-stats/src/main/res/values-lt/strings.xml
@@ -65,9 +65,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s per %2$s</string>
     <string name="stats_space_history_upgrade_title">Visa istorija yra Pro funkcija</string>
-    <string name="stats_space_history_upgrade_body">Atnaujinkite, kad atrakintumėte visą 90 dienų tendencijų rodinį kiekvienam saugojimo įrenginiui.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Atnaujink, kad atrakintum visą 90 dienų tendencijų peržiūrą kiekvienam saugyklos įrenginiui ir gautum įspėjimą prieš baigiantis vietai.</string>
     <string name="stats_space_history_marker_freed">Atlaisvinta %1$s</string>
     <string name="stats_storage_type_primary">Pagrindinė saugykla</string>

--- a/app-common-stats/src/main/res/values-lv/strings.xml
+++ b/app-common-stats/src/main/res/values-lv/strings.xml
@@ -59,9 +59,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s laikā %2$s</string>
     <string name="stats_space_history_upgrade_title">Pilna vēsture ir Pro funkcija</string>
-    <string name="stats_space_history_upgrade_body">Jauniniet, lai atbloķētu pilno 90 dienu tendences skatu katrai krātuves ierīcei.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Uzlabo, lai atbloķētu pilnu 90 dienu tendenču skatu katrai krātuves ierīcei un saņemtu brīdinājumu, pirms vieta beidzas.</string>
     <string name="stats_space_history_marker_freed">Atbrīvots %1$s</string>
     <string name="stats_storage_type_primary">Primārā krātuve</string>

--- a/app-common-stats/src/main/res/values-mk-rMK/strings.xml
+++ b/app-common-stats/src/main/res/values-mk-rMK/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Делта</string>
     <string name="stats_space_history_delta_in_x">%1$s за %2$s</string>
     <string name="stats_space_history_upgrade_title">Целосната историја е Про функција</string>
-    <string name="stats_space_history_upgrade_body">Надградете за да го отклучите целосниот 90-дневен приказ на тренд за секој уред за складирање.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Надградете за да го отклучите целосниот 90-дневен преглед за секој уред за складиште, и за да добиете известување пред да останете без простор.</string>
     <string name="stats_space_history_marker_freed">Ослободено %1$s</string>
     <string name="stats_storage_type_primary">Примарно складиште</string>

--- a/app-common-stats/src/main/res/values-ml-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-ml-rIN/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">ഡെൽറ്റ</string>
     <string name="stats_space_history_delta_in_x">%2$s-ൽ %1$s</string>
     <string name="stats_space_history_upgrade_title">പൂർണ്ണ ചരിത്രം ഒരു Pro ഫീച്ചറാണ്</string>
-    <string name="stats_space_history_upgrade_body">ഓരോ സ്റ്റോറേജ് ഉപകരണത്തിനും 90-ദിവസ ട്രെൻഡ് വ്യൂ അൺലോക്ക് ചെയ്യാൻ അപ്ഗ്രേഡ് ചെയ്യുക.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">ഓരോ സ്റ്റോറേജ് ഉപകരണത്തിനും 90 ദിവസത്തെ പൂർണ്ണ ട്രെൻഡ് കാഴ്ച അൺലോക്ക് ചെയ്യാനും, സ്ഥലം തീരുന്നതിന് മുമ്പ് ഒരു മുന്നറിയിപ്പ് ലഭിക്കാനും അപ്ഗ്രേഡ് ചെയ്യുക.</string>
     <string name="stats_space_history_marker_freed">%1$s മോചിപ്പിച്ചു</string>
     <string name="stats_storage_type_primary">പ്രാഥമിക സ്റ്റോറേജ്</string>

--- a/app-common-stats/src/main/res/values-mn-rMN/strings.xml
+++ b/app-common-stats/src/main/res/values-mn-rMN/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Зөрүү</string>
     <string name="stats_space_history_delta_in_x">%1$s, %2$s хугацаанд</string>
     <string name="stats_space_history_upgrade_title">Бүрэн түүх нь Pro онцлог</string>
-    <string name="stats_space_history_upgrade_body">Хадгалалтын төхөөрөмж бүрийн 90 хоногийн бүрэн чиг хандлагыг харахын тулд шинэчлэх.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Санах ойн төхөөрөмж болгонд 90 хоногийн бүрэн чиг хандлагаа үзэх, санах ой шавхагдахаас өмнө анхааруулга авахын тулд сайжруулж аваарай.</string>
     <string name="stats_space_history_marker_freed">%1$s чөлөөлсөн</string>
     <string name="stats_storage_type_primary">Үндсэн хадгалалт</string>

--- a/app-common-stats/src/main/res/values-ms/strings.xml
+++ b/app-common-stats/src/main/res/values-ms/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s dalam %2$s</string>
     <string name="stats_space_history_upgrade_title">Sejarah penuh adalah ciri Pro</string>
-    <string name="stats_space_history_upgrade_body">Naik taraf untuk membuka kunci paparan trend 90 hari penuh untuk setiap peranti storan.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Naik taraf untuk membuka paparan trend penuh 90 hari untuk setiap peranti storan, dan dapatkan amaran sebelum kamu kehabisan ruang.</string>
     <string name="stats_space_history_marker_freed">Dibebaskan %1$s</string>
     <string name="stats_storage_type_primary">Storan utama</string>

--- a/app-common-stats/src/main/res/values-my-rMM/strings.xml
+++ b/app-common-stats/src/main/res/values-my-rMM/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">ကွာခြားချက်</string>
     <string name="stats_space_history_delta_in_x">%2$s အတွင်း %1$s</string>
     <string name="stats_space_history_upgrade_title">မှတ်တမ်းအပြည့်အစုံသည် Pro အင်္ဂါရပ်ဖြစ်သည်</string>
-    <string name="stats_space_history_upgrade_body">သိုလှောင်ကိရိယာတစ်ခုချင်းစီ၏ ၉၀ ရက် လမ်းကြောင်းမြင်ကွင်းအပြည့်ကို ဖွင့်ရန် အဆင့်မြှင့်ပါ။</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">သိုလှောင်ခန်းစက်တစ်ခုစီအတွက် ၉၀ ရက်စာ လမ်းကြောင်းပြသမှု အပြည့်အဝကို ဖွင့်ရန်နှင့် နေရာလွတ်မကုန်ခင် သတိပေးချက်ရယူရန် အဆင့်မြှင့်ပါ။</string>
     <string name="stats_space_history_marker_freed">%1$s လွတ်မြောက်ခဲ့သည်</string>
     <string name="stats_storage_type_primary">မူလသိုလှောင်မှု</string>

--- a/app-common-stats/src/main/res/values-nb/strings.xml
+++ b/app-common-stats/src/main/res/values-nb/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s på %2$s</string>
     <string name="stats_space_history_upgrade_title">Full historikk er en Pro-funksjon</string>
-    <string name="stats_space_history_upgrade_body">Oppgrader for å låse opp full 90-dagers trendvisning for hver lagringsenhet.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Oppgrader for å låse opp full 90-dagers trendvisning for hver lagringsenhet, og få et varsel før lagringsplassen tar slutt.</string>
     <string name="stats_space_history_marker_freed">Frigjort %1$s</string>
     <string name="stats_storage_type_primary">Primærlagring</string>

--- a/app-common-stats/src/main/res/values-ne-rNP/strings.xml
+++ b/app-common-stats/src/main/res/values-ne-rNP/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">परिवर्तन</string>
     <string name="stats_space_history_delta_in_x">%1$s %2$s मा</string>
     <string name="stats_space_history_upgrade_title">पूर्ण इतिहास Pro सुविधा हो</string>
-    <string name="stats_space_history_upgrade_body">प्रत्येक भण्डारण उपकरणको पूर्ण ९०-दिने प्रवृत्ति दृश्य अनलक गर्न अपग्रेड गर्नुहोस्।</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">प्रत्येक भण्डारण डिभाइसको लागि पूर्ण ९०-दिनको प्रवृत्ति दृश्य अनलक गर्न अपग्रेड गर्नुहोस्, र तिम्रो ठाउँ समाप्त हुनु अघि एक चेतावनी पाउनुहोस्।</string>
     <string name="stats_space_history_marker_freed">%1$s मुक्त गरियो</string>
     <string name="stats_storage_type_primary">प्राथमिक भण्डारण</string>

--- a/app-common-stats/src/main/res/values-nl/strings.xml
+++ b/app-common-stats/src/main/res/values-nl/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s in %2$s</string>
     <string name="stats_space_history_upgrade_title">Volledige geschiedenis is een Pro-functie</string>
-    <string name="stats_space_history_upgrade_body">Upgrade om de volledige 90-daagse trendweergave voor elk opslagapparaat te ontgrendelen.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Upgrade om het volledige trendoverzicht van 90 dagen voor elk opslagapparaat te bekijken en ontvang een waarschuwing voordat uw opslagruimte vol is.</string>
     <string name="stats_space_history_marker_freed">%1$s vrijgemaakt</string>
     <string name="stats_storage_type_primary">Primaire opslag</string>

--- a/app-common-stats/src/main/res/values-or-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-or-rIN/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">ଡେଲ୍ଟା</string>
     <string name="stats_space_history_delta_in_x">%1$s %2$s ମଧ୍ୟରେ</string>
     <string name="stats_space_history_upgrade_title">ସମ୍ପୂର୍ଣ୍ଣ ଇତିହାସ ଏକ Pro ବୈଶିଷ୍ଟ୍ୟ</string>
-    <string name="stats_space_history_upgrade_body">ପ୍ରତ୍ୟେକ ଷ୍ଟୋରେଜ ଡିଭାଇସ ପାଇଁ ସମ୍ପୂର୍ଣ୍ଣ ୯୦-ଦିନ ଟ୍ରେଣ୍ଡ ଭ୍ୟୁ ଅନ୍ଲକ କରିବାକୁ ଅପଗ୍ରେଡ କରନ୍ତୁ।</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">ପ୍ରତ୍ୟେକ ସଂରକ୍ଷଣ ଡିଭାଇସ୍ ପାଇଁ ସମ୍ପୂର୍ଣ୍ଣ 90-ଦିନର ଟ୍ରେଣ୍ଡ୍ ଦୃଶ୍ୟ ଅନ୍ତର୍ଭୁକ୍ତ କରିବାକୁ ଅପଗ୍ରେଡ୍ କରନ୍ତୁ, ଏବଂ ଆପଣ ସ୍ଥାନ ଶେଷ ହେବାର ଆଗରୁ ଏକ ସତର୍କତା ପାଇନ୍ତୁ।</string>
     <string name="stats_space_history_marker_freed">%1$s ମୁକ୍ତ ହୋଇଛି</string>
     <string name="stats_storage_type_primary">ପ୍ରାଥମିକ ଷ୍ଟୋରେଜ୍</string>

--- a/app-common-stats/src/main/res/values-pa-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-pa-rIN/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">ਡੈਲਟਾ</string>
     <string name="stats_space_history_delta_in_x">%1$s %2$s ਵਿੱਚ</string>
     <string name="stats_space_history_upgrade_title">ਪੂਰਾ ਇਤਿਹਾਸ ਇੱਕ Pro ਵਿਸ਼ੇਸ਼ਤਾ ਹੈ</string>
-    <string name="stats_space_history_upgrade_body">ਹਰ ਸਟੋਰੇਜ ਡਿਵਾਈਸ ਲਈ ਪੂਰਾ 90-ਦਿਨ ਰੁਝਾਨ ਦ੍ਰਿਸ਼ ਅਨਲਾਕ ਕਰਨ ਲਈ ਅੱਪਗ੍ਰੇਡ ਕਰੋ।</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">ਅਪਗ੍ਰੇਡ ਕਰੋ ਤਾਂ ਜੋ ਹਰ ਸਟੋਰੇਜ ਲਈ ਪੂਰੀ 90-ਦਿਨਾਂ ਦਾ ਦ੍ਰਿਸ਼ ਦੇਖ ਸਕੋ ਅਤੇ ਸਥਾਨ ਖਤਮ ਹੋਣ ਤੋਂ ਪਹਿਲਾਂ ਚੇਤਾਵਨੀ ਪਾਓ।</string>
     <string name="stats_space_history_marker_freed">%1$s ਮੁਕਤ ਕੀਤਾ</string>
     <string name="stats_storage_type_primary">ਮੁੱਖ ਸਟੋਰੇਜ</string>

--- a/app-common-stats/src/main/res/values-pl/strings.xml
+++ b/app-common-stats/src/main/res/values-pl/strings.xml
@@ -65,9 +65,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s w %2$s</string>
     <string name="stats_space_history_upgrade_title">Pełna historia jest funkcją Pro</string>
-    <string name="stats_space_history_upgrade_body">Uaktualnij, aby odblokować pełny 90-dniowy widok trendu dla każdego urządzenia pamięci.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Zaktualizuj, aby odblokować pełny 90-dniowy widok trendów dla każdego urządzenia pamięci masowej i otrzymać ostrzeżenie przed wyczerpaniem miejsca.</string>
     <string name="stats_space_history_marker_freed">Zwolniono %1$s</string>
     <string name="stats_storage_type_primary">Pamięć podstawowa</string>

--- a/app-common-stats/src/main/res/values-pt-rBR/strings.xml
+++ b/app-common-stats/src/main/res/values-pt-rBR/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s em %2$s</string>
     <string name="stats_space_history_upgrade_title">Histórico completo é um recurso Pro</string>
-    <string name="stats_space_history_upgrade_body">Atualize para desbloquear a visualização completa de tendência de 90 dias para cada dispositivo de armazenamento.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Atualize para desbloquear a visualização completa de tendência de 90 dias para cada dispositivo de armazenamento e receba um aviso antes de ficar sem espaço.</string>
     <string name="stats_space_history_marker_freed">Liberado %1$s</string>
     <string name="stats_storage_type_primary">Armazenamento primário</string>

--- a/app-common-stats/src/main/res/values-pt/strings.xml
+++ b/app-common-stats/src/main/res/values-pt/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s em %2$s</string>
     <string name="stats_space_history_upgrade_title">O histórico completo é uma funcionalidade Pro</string>
-    <string name="stats_space_history_upgrade_body">Atualize para desbloquear a visualização completa de tendência de 90 dias para cada dispositivo de armazenamento.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Atualiza para desbloquear a vista completa de tendências de 90 dias para cada dispositivo de armazenamento e receber um aviso antes de ficares sem espaço.</string>
     <string name="stats_space_history_marker_freed">Libertado %1$s</string>
     <string name="stats_storage_type_primary">Armazenamento primário</string>

--- a/app-common-stats/src/main/res/values-ro/strings.xml
+++ b/app-common-stats/src/main/res/values-ro/strings.xml
@@ -59,9 +59,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s în %2$s</string>
     <string name="stats_space_history_upgrade_title">Istoricul complet este o funcție Pro</string>
-    <string name="stats_space_history_upgrade_body">Faceți upgrade pentru a debloca vizualizarea completă a tendințelor pe 90 de zile pentru fiecare dispozitiv de stocare.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Fă upgrade pentru a debloca vizualizarea completă a tendinței pe 90 de zile pentru fiecare dispozitiv de stocare și pentru a primi un avertisment înainte să rămâi fără spațiu.</string>
     <string name="stats_space_history_marker_freed">Eliberat %1$s</string>
     <string name="stats_storage_type_primary">Stocare principală</string>

--- a/app-common-stats/src/main/res/values-ru/strings.xml
+++ b/app-common-stats/src/main/res/values-ru/strings.xml
@@ -65,9 +65,6 @@
     <string name="stats_space_history_delta_label">Дельта</string>
     <string name="stats_space_history_delta_in_x">%1$s за %2$s</string>
     <string name="stats_space_history_upgrade_title">Полная история — функция Pro</string>
-    <string name="stats_space_history_upgrade_body">Обновитесь, чтобы разблокировать полный 90-дневный обзор тренда для каждого устройства хранения.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Оформите подписку, чтобы открыть полный график изменений за 90 дней для каждого накопителя и получать предупреждение о нехватке места.</string>
     <string name="stats_space_history_marker_freed">Освобождено %1$s</string>
     <string name="stats_storage_type_primary">Основное хранилище</string>

--- a/app-common-stats/src/main/res/values-sc-rIT/strings.xml
+++ b/app-common-stats/src/main/res/values-sc-rIT/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s in %2$s</string>
     <string name="stats_space_history_upgrade_title">Sa cronologia cumpleta est una funtzionalidade Pro</string>
-    <string name="stats_space_history_upgrade_body">Aggiunna pro isviluppare sa visualizatzione de sa tendèntzia de 90 dies pro ogni dispositiu de memorizamentu.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Agiorna pro isblocare sa visualizatzione cumpleta de is 90 dies pro dispositivu de archiviatzione, e retzi un\'avisu prima de acabbare s\'ispàtziu.</string>
     <string name="stats_space_history_marker_freed">Liberadu %1$s</string>
     <string name="stats_storage_type_primary">Archìviu primàriu</string>

--- a/app-common-stats/src/main/res/values-si-rLK/strings.xml
+++ b/app-common-stats/src/main/res/values-si-rLK/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">වෙනස</string>
     <string name="stats_space_history_delta_in_x">%1$s, %2$s හිදී</string>
     <string name="stats_space_history_upgrade_title">සම්පූර්ණ ඉතිහාසය Pro විශේෂාංගයකි</string>
-    <string name="stats_space_history_upgrade_body">සෑම ගබඩා උපාංගයක් සඳහාම සම්පූර්ණ 90-දින ප්‍රවණතා දසුන අගුළු ඇරීමට උත්සාහ කරන්න.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">සෑම ගබඩා උපාංගයක් සඳහාම සම්පූර්ණ දින 90 ප්‍රවණතා දසුන අගුළු හැරීමට සහ ඉඩ අවසන් වීමට පෙර අනතුරු ඇඟවීමක් ලබා ගැනීමට උත්ශ්‍රේණි කරන්න.</string>
     <string name="stats_space_history_marker_freed">නිදහස් කළ %1$s</string>
     <string name="stats_storage_type_primary">මුලික ආචයනය</string>

--- a/app-common-stats/src/main/res/values-sk/strings.xml
+++ b/app-common-stats/src/main/res/values-sk/strings.xml
@@ -65,9 +65,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s za %2$s</string>
     <string name="stats_space_history_upgrade_title">Plná história je funkcia Pro</string>
-    <string name="stats_space_history_upgrade_body">Inovujte na odomknutie úplého 90-dňového prehľadu trendu pre každé úložné zariadenie.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Upgraduj, aby si odomkol úplný 90-dňový pohľad na trend pre každé úložné zariadenie a dostal upozornenie skôr, ako ti dôjde miesto.</string>
     <string name="stats_space_history_marker_freed">Uvoľnené %1$s</string>
     <string name="stats_storage_type_primary">Primárne úložisko</string>

--- a/app-common-stats/src/main/res/values-sl/strings.xml
+++ b/app-common-stats/src/main/res/values-sl/strings.xml
@@ -65,9 +65,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s v %2$s</string>
     <string name="stats_space_history_upgrade_title">Polna zgodovina je funkcija Pro</string>
-    <string name="stats_space_history_upgrade_body">Nadgradite za odklep celotnega 90-dnevnega prikaza trenda za vsako pomnilniško napravo.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Nadgradi se, da odblokiraš polni pogled trendov 90 dni za vsako napravo za shranjevanje in preješ opozorilo, preden ti zmanjka prostora.</string>
     <string name="stats_space_history_marker_freed">Sproščeno %1$s</string>
     <string name="stats_storage_type_primary">Primarna pomnilniška naprava</string>

--- a/app-common-stats/src/main/res/values-sq-rAL/strings.xml
+++ b/app-common-stats/src/main/res/values-sq-rAL/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s në %2$s</string>
     <string name="stats_space_history_upgrade_title">Historia e plotë është një veçori Pro</string>
-    <string name="stats_space_history_upgrade_body">Përmirso për të zhbllokuar pamjen e plotë të trendit 90-ditor për çdo pajisje magazinimi.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Përmirëso planin për të shkyçur pamjen e plotë të tendencës 90-ditore për çdo pajisje ruajtëse, dhe merr një paralajmërim para se të mbarosësh hapësirën.</string>
     <string name="stats_space_history_marker_freed">U lirua %1$s</string>
     <string name="stats_storage_type_primary">Magazina primare</string>

--- a/app-common-stats/src/main/res/values-sr/strings.xml
+++ b/app-common-stats/src/main/res/values-sr/strings.xml
@@ -59,9 +59,6 @@
     <string name="stats_space_history_delta_label">Делта</string>
     <string name="stats_space_history_delta_in_x">%1$s у %2$s</string>
     <string name="stats_space_history_upgrade_title">Пуна историја је Pro функција</string>
-    <string name="stats_space_history_upgrade_body">Надоградите да откључате приказ тренда за пуних 90 дана за сваки уређај за складиштење.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Унапреди да откључаш приказ трендова од 90 дана за сваки уређај складишта, и добијеш упозорење пре него што останеш без простора.</string>
     <string name="stats_space_history_marker_freed">Ослобођено %1$s</string>
     <string name="stats_storage_type_primary">Примарно складиште</string>

--- a/app-common-stats/src/main/res/values-sv/strings.xml
+++ b/app-common-stats/src/main/res/values-sv/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s på %2$s</string>
     <string name="stats_space_history_upgrade_title">Fullständig historik är en Pro-funktion</string>
-    <string name="stats_space_history_upgrade_body">Uppgradera för att låsa upp den fullständiga 90-dagarstrenden för varje lagringsenhet.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Uppgradera för att låsa upp den fullständiga 90-dagars trendvyn för varje lagringsenhet, och få en varning innan utrymmet tar slut.</string>
     <string name="stats_space_history_marker_freed">Frigjorde %1$s</string>
     <string name="stats_storage_type_primary">Primär lagring</string>

--- a/app-common-stats/src/main/res/values-sw/strings.xml
+++ b/app-common-stats/src/main/res/values-sw/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Tofauti</string>
     <string name="stats_space_history_delta_in_x">%1$s katika %2$s</string>
     <string name="stats_space_history_upgrade_title">Historia kamili ni kipengele cha Pro</string>
-    <string name="stats_space_history_upgrade_body">Boresha ili kufungua mwonekano kamili wa mwenendo wa siku 90 kwa kila kifaa cha hifadhi.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Boresha ili ufungue mwonekano kamili wa mwenendo wa siku 90 kwa kila kifaa cha hifadhi, na upate onyo kabla nafasi yako haijaisha.</string>
     <string name="stats_space_history_marker_freed">Iliyoachiliwa %1$s</string>
     <string name="stats_storage_type_primary">Hifadhi ya msingi</string>

--- a/app-common-stats/src/main/res/values-ta-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-ta-rIN/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">வேறுபாடு</string>
     <string name="stats_space_history_delta_in_x">%2$s இல் %1$s</string>
     <string name="stats_space_history_upgrade_title">முழு வரலாறும் Pro அம்சம்</string>
-    <string name="stats_space_history_upgrade_body">ஒவ்வொரு சேமிப்பக சாதனத்திற்கும் முழு 90-நாள் போக்கு காட்சியை திறக்க மேம்படுத்தவும்.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">ஒவ்வொரு சேமிப்பக சாதனத்திற்கும் முழு 90-நாள் போக்குக் காட்சியைத் திறக்கவும், இடம் தீர்வதற்கு முன் எச்சரிக்கையும் பெறவும் மேம்படுத்துங்கள்.</string>
     <string name="stats_space_history_marker_freed">%1$s விடுவிக்கப்பட்டது</string>
     <string name="stats_storage_type_primary">முதன்மை சேமிப்பு</string>

--- a/app-common-stats/src/main/res/values-te-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-te-rIN/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">తేడా</string>
     <string name="stats_space_history_delta_in_x">%2$sలో %1$s</string>
     <string name="stats_space_history_upgrade_title">పూర్తి చరిత్ర ఒక Pro ఫీచర్</string>
-    <string name="stats_space_history_upgrade_body">ప్రతి స్టోరేజ్ పరికరానికి పూర్తి 90-రోజుల ట్రెండ్ వీక్షణను అన్‌లాక్ చేయడానికి అప్‌గ్రేడ్ చేయండి.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">ప్రతి నిల్వ పరికరానికి పూర్తి 90-రోజుల ట్రెండ్ వీక్షణను అన్‌లాక్ చేయడానికి మరియు స్థలం అయిపోయే ముందు హెచ్చరిక పొందడానికి అప్‌గ్రేడ్ చేయండి.</string>
     <string name="stats_space_history_marker_freed">%1$s విడుదల చేయబడింది</string>
     <string name="stats_storage_type_primary">ముఖ్య స్టోరేజీ</string>

--- a/app-common-stats/src/main/res/values-th/strings.xml
+++ b/app-common-stats/src/main/res/values-th/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">เดลต้า</string>
     <string name="stats_space_history_delta_in_x">%1$s ใน %2$s</string>
     <string name="stats_space_history_upgrade_title">ประวัติทั้งหมดเป็นฟีเจอร์ Pro</string>
-    <string name="stats_space_history_upgrade_body">อัปเกรดเพื่อปลดล็อกมุมมองแนวโน้ม 90 วันแบบเต็มสำหรับแต่ละอุปกรณ์จัดเก็บข้อมูล</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">อัปเกรดเพื่อปลดล็อกมุมมองแนวโน้มแบบเต็ม 90 วันสำหรับอุปกรณ์จัดเก็บแต่ละตัว และรับคำเตือนก่อนพื้นที่จะหมด</string>
     <string name="stats_space_history_marker_freed">เพิ่มพื้นที่ว่าง %1$s</string>
     <string name="stats_storage_type_primary">พื้นที่จัดเก็บหลัก</string>

--- a/app-common-stats/src/main/res/values-tr/strings.xml
+++ b/app-common-stats/src/main/res/values-tr/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s / %2$s</string>
     <string name="stats_space_history_upgrade_title">Tam geçmiş bir Pro özelliğidir</string>
-    <string name="stats_space_history_upgrade_body">Her depolama aygıtı için tam 90 günlük trend görünümünü açmak üzere yükseltin.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Yükselt ve her depolama cihazı için tam 90 günlük trend görünümünü aç, depolama tükenmeden uyarı al.</string>
     <string name="stats_space_history_marker_freed">%1$s boşaltıldı</string>
     <string name="stats_storage_type_primary">Birincil depolama</string>

--- a/app-common-stats/src/main/res/values-uk/strings.xml
+++ b/app-common-stats/src/main/res/values-uk/strings.xml
@@ -65,9 +65,6 @@
     <string name="stats_space_history_delta_label">Дельта</string>
     <string name="stats_space_history_delta_in_x">%1$s у %2$s</string>
     <string name="stats_space_history_upgrade_title">Повна історія — це функція версії Pro</string>
-    <string name="stats_space_history_upgrade_body">Оновіть версію, щоб отримати доступ до повного 90-денного огляду тенденцій для кожного пристрою зберігання даних.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Оновіть, щоб розблокувати повний 90-денний перегляд тренду для кожного сховища, і отримуйте попередження до того, як вам закінчиться місце.</string>
     <string name="stats_space_history_marker_freed">Звільнено %1$s</string>
     <string name="stats_storage_type_primary">Основне сховище</string>

--- a/app-common-stats/src/main/res/values-ur-rIN/strings.xml
+++ b/app-common-stats/src/main/res/values-ur-rIN/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">ڈیلٹا</string>
     <string name="stats_space_history_delta_in_x">%1$s میں %2$s</string>
     <string name="stats_space_history_upgrade_title">مکمل تاریخ ایک پرو فیچر ہے</string>
-    <string name="stats_space_history_upgrade_body">ہر اسٹوریج ڈیوائس کے لیے مکمل ۹۰ دن کا ٹرینڈ ویو کھولنے کے لیے اپ گریڈ کریں۔</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">ہر اسٹوریج ڈیوائس کے لیے مکمل 90 دن کا رجحان دیکھنے کے لیے اپ گریڈ کریں، اور جگہ ختم ہونے سے پہلے وارننگ حاصل کریں۔</string>
     <string name="stats_space_history_marker_freed">%1$s آزاد کیا گیا</string>
     <string name="stats_storage_type_primary">بنیادی اسٹوریج</string>

--- a/app-common-stats/src/main/res/values-uz/strings.xml
+++ b/app-common-stats/src/main/res/values-uz/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s, %2$s ichida</string>
     <string name="stats_space_history_upgrade_title">To\'liq tarix Pro funksiyasidir</string>
-    <string name="stats_space_history_upgrade_body">Har bir saqlash qurilmasi uchun to\'liq 90 kunlik trend ko\'rinishini ochish uchun yangilang.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Har bir xotira qurilmasi uchun to‘liq 90 kunlik tendentsiya ko‘rinishini ochish va joy tugashidan oldin ogohlantirish olish uchun yangilang.</string>
     <string name="stats_space_history_marker_freed">%1$s bo\'shatildi</string>
     <string name="stats_storage_type_primary">Asosiy xotira</string>

--- a/app-common-stats/src/main/res/values-vi/strings.xml
+++ b/app-common-stats/src/main/res/values-vi/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">Biến động</string>
     <string name="stats_space_history_delta_in_x">%1$s trong %2$s</string>
     <string name="stats_space_history_upgrade_title">Lịch sử đầy đủ là tính năng Pro</string>
-    <string name="stats_space_history_upgrade_body">Nâng cấp để mở khóa chế độ xem xu hướng 90 ngày đầy đủ cho mỗi thiết bị lưu trữ.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Nâng cấp để mở khóa chế độ xem xu hướng đầy đủ 90 ngày cho mỗi thiết bị lưu trữ, và nhận cảnh báo trước khi bạn hết chỗ trống.</string>
     <string name="stats_space_history_marker_freed">Đã giải phóng %1$s</string>
     <string name="stats_storage_type_primary">Bộ nhớ chính</string>

--- a/app-common-stats/src/main/res/values-zh-rCN/strings.xml
+++ b/app-common-stats/src/main/res/values-zh-rCN/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">变化量</string>
     <string name="stats_space_history_delta_in_x">%2$s 内 %1$s</string>
     <string name="stats_space_history_upgrade_title">完整历史记录是专业版功能</string>
-    <string name="stats_space_history_upgrade_body">升级以解锁每个存储设备的完整90天趋势视图。</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">升级以解锁每个存储设备的完整 90 天趋势视图，并在空间耗尽前获得警告。</string>
     <string name="stats_space_history_marker_freed">已释放 %1$s</string>
     <string name="stats_storage_type_primary">内部存储</string>

--- a/app-common-stats/src/main/res/values-zh-rHK/strings.xml
+++ b/app-common-stats/src/main/res/values-zh-rHK/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">差異</string>
     <string name="stats_space_history_delta_in_x">%1$s（%2$s 內）</string>
     <string name="stats_space_history_upgrade_title">完整歷史記錄是 Pro 功能</string>
-    <string name="stats_space_history_upgrade_body">升級以解鎖每個儲存裝置的完整 90 天趨勢視圖。</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">升級即可解鎖各儲存裝置完整的90天趨勢圖，並在儲存空間耗盡前收到警告。</string>
     <string name="stats_space_history_marker_freed">已釋放 %1$s</string>
     <string name="stats_storage_type_primary">主要儲存空間</string>

--- a/app-common-stats/src/main/res/values-zh-rTW/strings.xml
+++ b/app-common-stats/src/main/res/values-zh-rTW/strings.xml
@@ -47,9 +47,6 @@
     <string name="stats_space_history_delta_label">差異值</string>
     <string name="stats_space_history_delta_in_x">%1$s 於 %2$s 內</string>
     <string name="stats_space_history_upgrade_title">完整歷史記錄是 Pro 功能</string>
-    <string name="stats_space_history_upgrade_body">升級以解鎖每個儲存裝置的完整 90 天趨勢檢視。</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">升級即可解鎖每個儲存裝置的完整 90 天趨勢檢視，並在儲存空間用盡前收到警告。</string>
     <string name="stats_space_history_marker_freed">已釋放 %1$s</string>
     <string name="stats_storage_type_primary">主要儲存空間</string>

--- a/app-common-stats/src/main/res/values-zu/strings.xml
+++ b/app-common-stats/src/main/res/values-zu/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Umehluko</string>
     <string name="stats_space_history_delta_in_x">%1$s ku-%2$s</string>
     <string name="stats_space_history_upgrade_title">Umlando ophelele iwuchiphile we-Pro</string>
-    <string name="stats_space_history_upgrade_body">Thuthukela ukuvula ukubuka ukulandelela okugcwele kwezinsuku eziyi-90 kwaleso naleso sifiso sesitoreji.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Thuthukisa ukuze avule umbukeli we-trend wezinsuku ezingama-90 ozuphelele ubaba yonke idivayisi yesikholo, futhi uthole isexwayiso ngaphambi kokuba isikholo sakho siyophela.</string>
     <string name="stats_space_history_marker_freed">Kukhishiwe %1$s</string>
     <string name="stats_storage_type_primary">Isitoreji esiyinhloko</string>

--- a/app-common-stats/src/main/res/values/strings.xml
+++ b/app-common-stats/src/main/res/values/strings.xml
@@ -53,9 +53,6 @@
     <string name="stats_space_history_delta_label">Delta</string>
     <string name="stats_space_history_delta_in_x">%1$s in %2$s</string>
     <string name="stats_space_history_upgrade_title">Full history is a Pro feature</string>
-    <string name="stats_space_history_upgrade_body">Upgrade to unlock the full 90-day trend view for each storage device.</string>
-    <!-- Replaces stats_space_history_upgrade_body. The old key is translated into 74 locales and is
-         left untouched so those locales don't keep showing the old copy until Crowdin catches up. -->
     <string name="stats_space_history_upgrade_body_v2">Upgrade to unlock the full 90-day trend view for each storage device, and get a warning before you run out of space.</string>
     <string name="stats_space_history_marker_freed">Freed %1$s</string>
     <string name="stats_storage_type_primary">Primary storage</string>

--- a/app-tool-deduplicator/src/main/res/values-af-rZA/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-af-rZA/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s word deur duplikate beset</item>
         <item quantity="other">%s word deur duplikate beset</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Lêer grootte</string>
     <string name="deduplicator_average_size_label">Gemiddelde grootte</string>
     <string name="deduplicator_cluster_x_label">Groep %s</string>
     <string name="deduplicator_delete_confirmation_message">Skrap alles behalwe een kopie in alle stelle van duplikaat lêers?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Duplikaatstel voorskouing</string>
     <string name="deduplicator_selection_keep_one_required">Ten minste een lêer per duplikaatstel moet oorbly. Aktiveer \"Maak \'Verwyder alles\' moontlik\" in instellings om dit te oorskryf.</string>
     <string name="deduplicator_progress_comparing_files">Vergelyk lêers</string>
-    <string name="deduplicator_details_cluster_title">Stel van duplikate</string>
     <string name="deduplicator_matches_exact_label">Presiese kopieë</string>
     <string name="deduplicator_matches_similar_label">Soortgelyke lêers</string>
     <string name="deduplicator_arbiter_title">Uitveestrategie</string>

--- a/app-tool-deduplicator/src/main/res/values-am/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-am/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s በተመሳሳዮች ተይዟል</item>
         <item quantity="other">%s በተመሳሳዮች ተይዘዋል</item>
     </plurals>
-    <string name="deduplicator_file_size_label">የፋይል መጠን</string>
     <string name="deduplicator_average_size_label">አማካይ መጠን</string>
     <string name="deduplicator_cluster_x_label">ክስተር %s</string>
     <string name="deduplicator_delete_confirmation_message">በሁሉም የተመሳሳይ ፋይሎች ስብስቦች ውስጥ ከአንድ ኮፒ በስተቀር ሁሉንም ይሰረዙ?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">ተደጋጋሚ ስብስብ ቅድመ እይታ</string>
     <string name="deduplicator_selection_keep_one_required">ከእያንዳንዱ ተመሳሳይ ስብስብ ቢያንስ አንድ ፋይል ሊቆይ ይገባል። ለመሸነፍ በቅንብሮች ውስጥ ሁሉንም ሰርዝ ይቻላል ያንቁ።</string>
     <string name="deduplicator_progress_comparing_files">ፋይሎችን በማወዳደር ላይ</string>
-    <string name="deduplicator_details_cluster_title">የተመሳሳዮች ስብስብ</string>
     <string name="deduplicator_matches_exact_label">ትክክለኛ ኮፒዎች</string>
     <string name="deduplicator_matches_similar_label">ተመሳሳይ ፋይሎች</string>
     <string name="deduplicator_arbiter_title">የመሰረዝ ስትራቴጂ</string>

--- a/app-tool-deduplicator/src/main/res/values-ar/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ar/strings.xml
@@ -44,7 +44,6 @@
         <item quantity="many">%s مشغولة بالنسخ المكررة</item>
         <item quantity="other">%s مشغولة بالنسخ المكررة</item>
     </plurals>
-    <string name="deduplicator_file_size_label">حجم الملف</string>
     <string name="deduplicator_average_size_label">متوسط الحجم</string>
     <string name="deduplicator_cluster_x_label">المجموعة %s</string>
     <string name="deduplicator_delete_confirmation_message">حذف جميع النسخ باستثناء نسخة واحدة في جميع مجموعات الملفات المكررة؟</string>
@@ -68,7 +67,6 @@
     <string name="deduplicator_cluster_preview_image">معاينة مجموعة النسخ المكررة</string>
     <string name="deduplicator_selection_keep_one_required">يجب أن يبقى ملف واحد على الأقل لكل مجموعة نسخ مكررة. فعّل \"اجعل \'حذف الكل\' ممكناً\" في الإعدادات للتجاوز.</string>
     <string name="deduplicator_progress_comparing_files">مقارنة الملفات</string>
-    <string name="deduplicator_details_cluster_title">مجموعة من النُسخة المتكررة</string>
     <string name="deduplicator_matches_exact_label">نُسخة طبق الاصل</string>
     <string name="deduplicator_matches_similar_label">ملفات متطابقة</string>
     <string name="deduplicator_arbiter_title">استراتيجية الحذف</string>

--- a/app-tool-deduplicator/src/main/res/values-az/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-az/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s dublikatlar tərəfindən tutulub</item>
         <item quantity="other">%s dublikatlar tərəfindən tutulub</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Fayl ölçüsü</string>
     <string name="deduplicator_average_size_label">Orta ölçü</string>
     <string name="deduplicator_cluster_x_label">Klaster %s</string>
     <string name="deduplicator_delete_confirmation_message">Bütün dublikat fayl dəstlərində bir nüsxədən başqa hamısını silinsinmi?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Dublika dəstinin önizləməsi</string>
     <string name="deduplicator_selection_keep_one_required">Hər bir dublikat dəsti üçün ən azı bir fayl qalmalıdır. Parametrlərdə \"Hamısını Silməyi Mümkün Et\" seçimini aktivləşdirərək bu məhdudiyyəti ləğv edə bilərsiniz.</string>
     <string name="deduplicator_progress_comparing_files">Fayllar müqayisə edilir</string>
-    <string name="deduplicator_details_cluster_title">Dublikatlar dəsti</string>
     <string name="deduplicator_matches_exact_label">Dəqiq nüsxələr</string>
     <string name="deduplicator_matches_similar_label">Oxşar fayllar</string>
     <string name="deduplicator_arbiter_title">Silmə strategiyası</string>

--- a/app-tool-deduplicator/src/main/res/values-be/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-be/strings.xml
@@ -38,7 +38,6 @@
         <item quantity="many">%s занята дублікатамі</item>
         <item quantity="other">%s занята дублікатамі</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Памер файла</string>
     <string name="deduplicator_average_size_label">Сярэдні памер</string>
     <string name="deduplicator_cluster_x_label">Кластар %s</string>
     <string name="deduplicator_delete_confirmation_message">Выдаліць усе копіі ўсіх пар дублікатаў, акрамя адной?</string>
@@ -60,7 +59,6 @@
     <string name="deduplicator_cluster_preview_image">Папярэдні прагляд набору дублікатаў</string>
     <string name="deduplicator_selection_keep_one_required">У кожным наборы дублікатаў павінен застацца прынамсі адзін файл. Каб абыйсці гэта абмежаванне, ўключыце ў наладах опцыю «Дазволіць \'Delete all\'».</string>
     <string name="deduplicator_progress_comparing_files">Параўнанне файлаў</string>
-    <string name="deduplicator_details_cluster_title">Пара дублікатаў</string>
     <string name="deduplicator_matches_exact_label">Дакладныя копіі</string>
     <string name="deduplicator_matches_similar_label">Падобныя файлы</string>
     <string name="deduplicator_arbiter_title">Стратэгія выдалення</string>

--- a/app-tool-deduplicator/src/main/res/values-bg/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-bg/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s е заето от дубликати</item>
         <item quantity="other">%s са заети от дубликати</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Размер на файл</string>
     <string name="deduplicator_average_size_label">Средн размер</string>
     <string name="deduplicator_cluster_x_label">Клъстер %s</string>
     <string name="deduplicator_delete_confirmation_message">Изтриване на всички освен едно копие във всички комплекти дублирани файлове?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Преглед на набор дубликати</string>
     <string name="deduplicator_selection_keep_one_required">Поне един файл в набор дубликати трябва да остане. Активирайте „Make \'Delete all\' possible“ в настройките, за да отмените това.</string>
     <string name="deduplicator_progress_comparing_files">Сравняване на файлове</string>
-    <string name="deduplicator_details_cluster_title">Комплект дубликати</string>
     <string name="deduplicator_matches_exact_label">Точни копия</string>
     <string name="deduplicator_matches_similar_label">Подобни файлове</string>
     <string name="deduplicator_arbiter_title">Стратегия за изтриване</string>

--- a/app-tool-deduplicator/src/main/res/values-bn-rBD/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-bn-rBD/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s ডুপ্লিকেট দ্বারা দখল করা আছে</item>
         <item quantity="other">%s ডুপ্লিকেট দ্বারা দখল করা আছে</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ফাইলের আকার</string>
     <string name="deduplicator_average_size_label">গড় আকার</string>
     <string name="deduplicator_cluster_x_label">ক্লাস্টার %s</string>
     <string name="deduplicator_delete_confirmation_message">সদৃশ ফাইলের সমস্ত সেটে একটি কপি ছাড়া সব মুছে ফেলবেন?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">ডুপ্লিকেট সেট পূর্বরূপ</string>
     <string name="deduplicator_selection_keep_one_required">প্রতিটি ডুপ্লিকেট সেটে কমপক্ষে একটি ফাইল অবশ্যই থাকতে হবে। এটি বাতিল করতে সেটিংসে \"সব মুছে ফেলা সম্ভব করুন\" সক্ষম করুন।</string>
     <string name="deduplicator_progress_comparing_files">ফাইল তুলনা করা হচ্ছে</string>
-    <string name="deduplicator_details_cluster_title">সদৃশ সেট</string>
     <string name="deduplicator_matches_exact_label">হুবহু কপি</string>
     <string name="deduplicator_matches_similar_label">অনুরূপ ফাইল</string>
     <string name="deduplicator_arbiter_title">মুছে ফেলার কৌশল</string>

--- a/app-tool-deduplicator/src/main/res/values-ca/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ca/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s està ocupat per duplicats</item>
         <item quantity="other">%s estan ocupats per duplicats</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Mida del fitxer</string>
     <string name="deduplicator_average_size_label">Mida mitjana</string>
     <string name="deduplicator_cluster_x_label">Clúster %s</string>
     <string name="deduplicator_delete_confirmation_message">Voleu suprimir totes les còpies menys una de tots els conjunts de fitxers duplicats?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Previsualització del conjunt de duplicats</string>
     <string name="deduplicator_selection_keep_one_required">Almenys un fitxer per conjunt de duplicats ha de romandre. Habilita «Permet ‘Eliminar-ho tot’» a la configuració per anul·lar-ho.</string>
     <string name="deduplicator_progress_comparing_files">Comparació de fitxers</string>
-    <string name="deduplicator_details_cluster_title">Conjunt de duplicats</string>
     <string name="deduplicator_matches_exact_label">Còpies exactes</string>
     <string name="deduplicator_matches_similar_label">Fitxers similars</string>
     <string name="deduplicator_arbiter_title">Estratègia d\'eliminació</string>

--- a/app-tool-deduplicator/src/main/res/values-ckb-rIR/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ckb-rIR/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s لەلایەن دووبارەکانەوە پڕکراوە</item>
         <item quantity="other">%s لەلایەن دووبارەکانەوە پڕکراون</item>
     </plurals>
-    <string name="deduplicator_file_size_label">فایل size</string>
     <string name="deduplicator_average_size_label">قەبارەی مامناوەند</string>
     <string name="deduplicator_cluster_x_label">کلاستەر %s</string>
     <string name="deduplicator_delete_confirmation_message">سڕینەوە all but one copy in all sets of duplicate files?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">پێشبینینی کۆمەڵەی دووپلیکەت</string>
     <string name="deduplicator_selection_keep_one_required">بەندی کەم یەک فایل لە هەرێک کۆمەڵەی دووپلیکەت پێویستە بمێنێتەوە. \"سڕینەوەی هەموو ئەمکان بکە\" لە رێکخستندا چالاک بکە بۆ زاڵداکردنەوە.</string>
     <string name="deduplicator_progress_comparing_files">Comparing فایلs</string>
-    <string name="deduplicator_details_cluster_title">کۆمەلی دووبارەکان</string>
     <string name="deduplicator_matches_exact_label">کۆپیەکانی تەواو</string>
     <string name="deduplicator_matches_similar_label">Similar فایلs</string>
     <string name="deduplicator_arbiter_title">ستراتیژی سڕینەوە</string>

--- a/app-tool-deduplicator/src/main/res/values-cs/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-cs/strings.xml
@@ -38,7 +38,6 @@
         <item quantity="many">Obsazeno duplikáty je %s</item>
         <item quantity="other">Obsazeno duplikáty je %s</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Velikost souboru</string>
     <string name="deduplicator_average_size_label">Průměrná velikost</string>
     <string name="deduplicator_cluster_x_label">Cluster %s</string>
     <string name="deduplicator_delete_confirmation_message">Smazat všechno ve všech sadách duplicitních souborů kromě jedné kopie?</string>
@@ -60,7 +59,6 @@
     <string name="deduplicator_cluster_preview_image">Náhled sady duplikátů</string>
     <string name="deduplicator_selection_keep_one_required">V každé sadě duplikátů musí zůstat alespoň jeden soubor. Povolte v nastavení „Umožnit smazat vše“ pro obejítí.</string>
     <string name="deduplicator_progress_comparing_files">Porovnávání souborů</string>
-    <string name="deduplicator_details_cluster_title">Sady duplikátů</string>
     <string name="deduplicator_matches_exact_label">Přesné kopie</string>
     <string name="deduplicator_matches_similar_label">Podobné soubory</string>
     <string name="deduplicator_arbiter_title">Strategie mazání</string>

--- a/app-tool-deduplicator/src/main/res/values-cy/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-cy/strings.xml
@@ -14,7 +14,6 @@
     <string name="deduplicator_detection_method_checksum_summary">Pennu dyblygu trwy gyfrifo symiau gwirio ar gyfer ffeiliau. Mae gan ffeiliau gyda symiau gwirio cyfatebol yr union yr un cynnwys.</string>
     <string name="deduplicator_detection_method_phash_title">Hash canfyddiadol</string>
     <string name="deduplicator_detection_method_phash_summary">Dod o hyd i ffeiliau tebyg trwy ddadansoddi nodweddion cynnwys a chymharu gwerthoedd hash canfyddiadol.</string>
-    <string name="deduplicator_file_size_label">Maint ffeil</string>
     <string name="deduplicator_average_size_label">Maint cyfartalog</string>
     <string name="deduplicator_cluster_x_label">Clwstwr %s</string>
     <string name="deduplicator_delete_confirmation_message">Dileu pob copi ond un ym mhob set o ffeiliau dyblyg?</string>
@@ -24,7 +23,6 @@
     <string name="deduplicator_delete_multiple_sets_keep_none_confirmation_message">Dileu\'r holl ffeiliau ym mhob set a ddewiswyd o ffeiliau dyblyg? Ni fydd ffeil ar ôl!</string>
     <string name="deduplicator_delete_all_toggle_msg">Dileu pob copi. Ni fydd ffeil ar ôl!</string>
     <string name="deduplicator_progress_comparing_files">Cymharu ffeiliau</string>
-    <string name="deduplicator_details_cluster_title">Set o ddyblygu</string>
     <string name="deduplicator_matches_exact_label">Copïau union</string>
     <string name="deduplicator_matches_similar_label">Ffeiliau tebyg</string>
     <plurals name="deduplicator_result_x_clusters_processed">

--- a/app-tool-deduplicator/src/main/res/values-da/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-da/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s er optaget af duplikater</item>
         <item quantity="other">%s er optaget af duplikater</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Filstørrelse</string>
     <string name="deduplicator_average_size_label">Gennemsnitlig størrelse</string>
     <string name="deduplicator_cluster_x_label">Klynge %s</string>
     <string name="deduplicator_delete_confirmation_message">Slet alle kopier undtagen én i alle sæt af duplikerede filer?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Forhåndsvisning af duplikat-sæt</string>
     <string name="deduplicator_selection_keep_one_required">Mindst én fil per duplikatgruppe skal forblive. Aktivér \'Gør \'Slet alt\' muligt\' i indstillinger for at tilsidesætte.</string>
     <string name="deduplicator_progress_comparing_files">Sammenligner filer</string>
-    <string name="deduplicator_details_cluster_title">Sæt af duplikater</string>
     <string name="deduplicator_matches_exact_label">Præcise kopier</string>
     <string name="deduplicator_matches_similar_label">Lignende filer</string>
     <string name="deduplicator_arbiter_title">Sletningsstrategi</string>

--- a/app-tool-deduplicator/src/main/res/values-de/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-de/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s ist von Duplikaten belegt</item>
         <item quantity="other">%s sind von Duplikaten belegt</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Dateigröße</string>
     <string name="deduplicator_average_size_label">Durchschnittliche Größe</string>
     <string name="deduplicator_cluster_x_label">Cluster %s</string>
     <string name="deduplicator_delete_confirmation_message">In diesem Satz doppelter Dateien alle bis auf eine Kopie löschen?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Duplikatgruppen-Vorschau</string>
     <string name="deduplicator_selection_keep_one_required">Mindestens eine Datei pro Duplikatgruppe muss erhalten bleiben. Aktiviere „Alles löschen ermöglichen“ in den Einstellungen, um diese Einschränkung zu umgehen.</string>
     <string name="deduplicator_progress_comparing_files">Dateien vergleichen</string>
-    <string name="deduplicator_details_cluster_title">Satz Duplikate</string>
     <string name="deduplicator_matches_exact_label">Exakte Kopien</string>
     <string name="deduplicator_matches_similar_label">Ähnliche Dateien</string>
     <string name="deduplicator_arbiter_title">Löschstrategie</string>

--- a/app-tool-deduplicator/src/main/res/values-el/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-el/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s καταλαμβάνεται από διπλότυπα</item>
         <item quantity="other">%s καταλαμβάνονται από διπλότυπα</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Μέγεθος αρχείου</string>
     <string name="deduplicator_average_size_label">Μέσο μέγεθος</string>
     <string name="deduplicator_cluster_x_label">Σύμπλεγμα %s</string>
     <string name="deduplicator_delete_confirmation_message">Να διαγραφούν όλα τα αντίγραφα εκτός από ένα σε όλα τα σύνολα διπλότυπων αρχείων;</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Προεπισκόπηση συνόλου διπλοτύπων</string>
     <string name="deduplicator_selection_keep_one_required">Τουλάχιστον ένα αρχείο ανά σύνολο διπλοτύπων πρέπει να παραμείνει. Ενεργοποιήστε το «Επιτρέψτε τη \'Διαγραφή όλων\'» στις ρυθμίσεις για να παρακάμψετε.</string>
     <string name="deduplicator_progress_comparing_files">Σύγκριση αρχείων</string>
-    <string name="deduplicator_details_cluster_title">Σύνολο διπλότυπων</string>
     <string name="deduplicator_matches_exact_label">Ακριβή αντίγραφα</string>
     <string name="deduplicator_matches_similar_label">Παρόμοια αρχεία</string>
     <string name="deduplicator_arbiter_title">Στρατηγική διαγραφής</string>

--- a/app-tool-deduplicator/src/main/res/values-eo/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-eo/strings.xml
@@ -14,7 +14,6 @@
     <string name="deduplicator_detection_method_checksum_summary">Determini duoblaĵojn kalkulante kontrolsumojn por dosieroj. Dosieroj kun kongruaj kontrolsumoj havas precize la saman enhavon.</string>
     <string name="deduplicator_detection_method_phash_title">Percepta hakaĵo</string>
     <string name="deduplicator_detection_method_phash_summary">Trovi similajn dosierojn analizante enhavajn trajtojn kaj komparante perceptajn hakaĵajn valorojn.</string>
-    <string name="deduplicator_file_size_label">Dosiera grandeco</string>
     <string name="deduplicator_average_size_label">Averaĝa grandeco</string>
     <string name="deduplicator_cluster_x_label">Fasko %s</string>
     <string name="deduplicator_delete_confirmation_message">Ĉu forigi ĉiujn krom unu kopio en ĉiuj aroj de duoblaj dosieroj?</string>
@@ -24,7 +23,6 @@
     <string name="deduplicator_delete_multiple_sets_keep_none_confirmation_message">Ĉu forigi ĉiujn dosierojn en ĉiu elektita aro de duoblaj dosieroj? Neniu dosiero restas!</string>
     <string name="deduplicator_delete_all_toggle_msg">Forigi ĉiujn kopiojn. Neniu dosiero restas!</string>
     <string name="deduplicator_progress_comparing_files">Komparante dosierojn</string>
-    <string name="deduplicator_details_cluster_title">Aro de duoblaĵoj</string>
     <string name="deduplicator_matches_exact_label">Precizaj kopioj</string>
     <string name="deduplicator_matches_similar_label">Similaj dosieroj</string>
     <plurals name="deduplicator_result_x_clusters_processed">

--- a/app-tool-deduplicator/src/main/res/values-es-rAR/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-es-rAR/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s está ocupado por duplicados</item>
         <item quantity="other">%s están ocupados por duplicados</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Tamaño del archivo</string>
     <string name="deduplicator_average_size_label">Tamaño promedio</string>
     <string name="deduplicator_cluster_x_label">Agrupar %s</string>
     <string name="deduplicator_delete_confirmation_message">¿Borrar todas las copias menos una en todos los archivos duplicados?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Vista previa del conjunto de duplicados</string>
     <string name="deduplicator_selection_keep_one_required">Debe permanecer al menos un archivo por conjunto de duplicados. Habilitá \"Hacer \'Eliminar todo\' posible\" en la configuración para anular esto.</string>
     <string name="deduplicator_progress_comparing_files">Comparando archivos</string>
-    <string name="deduplicator_details_cluster_title">Conjunto de duplicados</string>
     <string name="deduplicator_matches_exact_label">Copias exactas</string>
     <string name="deduplicator_matches_similar_label">Archivos similares</string>
     <string name="deduplicator_arbiter_title">Estrategia de eliminación</string>

--- a/app-tool-deduplicator/src/main/res/values-es-rMX/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-es-rMX/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s está ocupado por duplicados</item>
         <item quantity="other">%s están ocupados por duplicados</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Tamaño del archivo</string>
     <string name="deduplicator_average_size_label">Tamaño promedio</string>
     <string name="deduplicator_cluster_x_label">Grupo %s</string>
     <string name="deduplicator_delete_confirmation_message">¿Eliminar todas menos una copia en todos los conjuntos de archivos duplicados?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Vista previa del conjunto de duplicados</string>
     <string name="deduplicator_selection_keep_one_required">Debe permanecer al menos un archivo de cada conjunto de duplicados. Habilita \'Permitir \"Eliminar todo\"\' en la configuración para anular esto.</string>
     <string name="deduplicator_progress_comparing_files">Comparando archivos</string>
-    <string name="deduplicator_details_cluster_title">Conjunto de duplicados</string>
     <string name="deduplicator_matches_exact_label">Copias exactas</string>
     <string name="deduplicator_matches_similar_label">Archivos similares</string>
     <string name="deduplicator_arbiter_title">Estrategia de eliminación</string>

--- a/app-tool-deduplicator/src/main/res/values-es/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-es/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s está ocupado por duplicados</item>
         <item quantity="other">%s están ocupadas por duplicados</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Tamaño del archivo</string>
     <string name="deduplicator_average_size_label">Tamaño medio</string>
     <string name="deduplicator_cluster_x_label">Agrupar %s</string>
     <string name="deduplicator_delete_confirmation_message">¿Borrar todas las copias menos una en todos los archivos duplicados?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Vista previa del conjunto de duplicados</string>
     <string name="deduplicator_selection_keep_one_required">Debe permanecer al menos un archivo por cada conjunto de duplicados. Activa \"Permitir eliminar todos\" en la configuración para anular esto.</string>
     <string name="deduplicator_progress_comparing_files">Comparar los archivos</string>
-    <string name="deduplicator_details_cluster_title">Conjunto de duplicados</string>
     <string name="deduplicator_matches_exact_label">Copias iguales</string>
     <string name="deduplicator_matches_similar_label">Archivos parecidos</string>
     <string name="deduplicator_arbiter_title">Estrategia de eliminación</string>

--- a/app-tool-deduplicator/src/main/res/values-et-rEE/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-et-rEE/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s kasutab koopiad</item>
         <item quantity="other">%s kasutavad koopiad</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Faili maht</string>
     <string name="deduplicator_average_size_label">Keskmine maht</string>
     <string name="deduplicator_cluster_x_label">Klaster %s</string>
     <string name="deduplicator_delete_confirmation_message">Kustutada faili koopiad, nii et alles jääb vaid üks neist?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Koopiate kogumi eelvaade</string>
     <string name="deduplicator_selection_keep_one_required">Iga koopia kogumi kohta peab jääma vähemalt üks fail. Seadetes lülitage sisse „Luba kustutada kõik“, et alistada.</string>
     <string name="deduplicator_progress_comparing_files">Failide võrdlemine</string>
-    <string name="deduplicator_details_cluster_title">Koopiate pakett</string>
     <string name="deduplicator_matches_exact_label">Samad koopiad</string>
     <string name="deduplicator_matches_similar_label">Sarnased failid</string>
     <string name="deduplicator_arbiter_title">Kustutamisstrateegia</string>

--- a/app-tool-deduplicator/src/main/res/values-eu-rES/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-eu-rES/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s bikoiztuek hartuta dago</item>
         <item quantity="other">%s bikoiztuek hartuta daude</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Fitxategiaren tamaina</string>
     <string name="deduplicator_average_size_label">Batez besteko tamaina</string>
     <string name="deduplicator_cluster_x_label">Klusterra %s</string>
     <string name="deduplicator_delete_confirmation_message">Ezabatu kopia bat izan ezik bikoiztuen multzo guztietan?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Bikoiza multzoaren aurreikuspena</string>
     <string name="deduplicator_selection_keep_one_required">Gutxienez fitxategi bat geratzen jarraitu behar du bikoizta-multzo bakoitzean. Gaitu \'Guztiak ezabatzea ahalgarri egitea\' ezarpenetan murriztapena gainditzeko.</string>
     <string name="deduplicator_progress_comparing_files">Fitxategiak alderatzen</string>
-    <string name="deduplicator_details_cluster_title">Bikoiztuen multzoa</string>
     <string name="deduplicator_matches_exact_label">Kopia exactuak</string>
     <string name="deduplicator_matches_similar_label">Antzeko fitxategiak</string>
     <string name="deduplicator_arbiter_title">Ezabatze-estrategia</string>

--- a/app-tool-deduplicator/src/main/res/values-fa/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fa/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s توسط فایل‌های تکراری اشغال شده</item>
         <item quantity="other">%s توسط فایل‌های تکراری اشغال شده</item>
     </plurals>
-    <string name="deduplicator_file_size_label">اندازه فایل</string>
     <string name="deduplicator_average_size_label">اندازه میانگین</string>
     <string name="deduplicator_cluster_x_label">خوشه %s</string>
     <string name="deduplicator_delete_confirmation_message">حذف همه بجز یک نسخه در تمام مجموعه‌های فایل‌های تکراری؟</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">پیش‌نمایش مجموعه تکراری</string>
     <string name="deduplicator_selection_keep_one_required">حداقل یک فایل از هر مجموعه تکراری باید باقی بماند. گزینه «امکان حذف همه» را در تنظیمات فعال کنید تا این محدودیت را نادیده بگیرید.</string>
     <string name="deduplicator_progress_comparing_files">مقایسه فایل‌ها</string>
-    <string name="deduplicator_details_cluster_title">مجموعه‌ای از فایل‌های تکراری</string>
     <string name="deduplicator_matches_exact_label">نسخه‌های دقیقا مشابه</string>
     <string name="deduplicator_matches_similar_label">فایل های مشابه</string>
     <string name="deduplicator_arbiter_title">استراتژی حذف</string>

--- a/app-tool-deduplicator/src/main/res/values-fi/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fi/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s on kaksoiskappaleiden käyttämää</item>
         <item quantity="other">%s on kaksoiskappaleiden käyttämää</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Tiedoston koko</string>
     <string name="deduplicator_average_size_label">Keskimääräinen koko</string>
     <string name="deduplicator_cluster_x_label">Klusteri %s</string>
     <string name="deduplicator_delete_confirmation_message">Poista kaikki paitsi yksi kopio kaikista kaksoistiedostojen sarjoista?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Kopioiden joukon esikatselu</string>
     <string name="deduplicator_selection_keep_one_required">Jokaisessa kaksoiskappalejoukossa on säilytettävä vähintään yksi tiedosto. Ota asetuksista käyttöön ”Tee \'Poista kaikki\' mahdolliseksi” ohittaaksesi tämän rajoituksen.</string>
     <string name="deduplicator_progress_comparing_files">Vertaillaan tiedostoja</string>
-    <string name="deduplicator_details_cluster_title">Kaksoiskappaleiden sarja</string>
     <string name="deduplicator_matches_exact_label">Tarkat kopiot</string>
     <string name="deduplicator_matches_similar_label">Samankaltaiset tiedostot</string>
     <string name="deduplicator_arbiter_title">Poistamisstrategia</string>

--- a/app-tool-deduplicator/src/main/res/values-fil/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fil/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s ay ginagamit ng mga duplicate</item>
         <item quantity="other">%s ay ginagamit ng mga duplicate</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Laki ng file</string>
     <string name="deduplicator_average_size_label">Average na laki</string>
     <string name="deduplicator_cluster_x_label">Cluster %s</string>
     <string name="deduplicator_delete_confirmation_message">Burahin ang lahat maliban sa isang kopya sa lahat ng set ng mga doble na file?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Paunang tingnan ng duplicate set</string>
     <string name="deduplicator_selection_keep_one_required">Dapat na manatili ang kahit isang file sa bawat duplicate set. I-enable ang \"Make \'Delete all\' possible\" sa settings upang ma-override.</string>
     <string name="deduplicator_progress_comparing_files">Naghahambing ng mga file</string>
-    <string name="deduplicator_details_cluster_title">Set ng mga doble</string>
     <string name="deduplicator_matches_exact_label">Eksaktong mga kopya</string>
     <string name="deduplicator_matches_similar_label">Mga katulad na file</string>
     <string name="deduplicator_arbiter_title">Diskarte sa pag-delete</string>

--- a/app-tool-deduplicator/src/main/res/values-fr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-fr/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s est occupé par des doublons</item>
         <item quantity="other">%s sont occupés par des doublons</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Taille du fichier</string>
     <string name="deduplicator_average_size_label">Taille moyenne</string>
     <string name="deduplicator_cluster_x_label">Grappe %s</string>
     <string name="deduplicator_delete_confirmation_message">Supprimer tous les exemplaires sauf un dans tous les jeux de fichiers dupliqués ?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Aperçu de l’ensemble de doublons</string>
     <string name="deduplicator_selection_keep_one_required">Au moins un fichier par ensemble de doublons doit rester. Activez « Rendre \'Supprimer tout\' possible » dans les paramètres pour contourner.</string>
     <string name="deduplicator_progress_comparing_files">Comparaison des fichiers</string>
-    <string name="deduplicator_details_cluster_title">Jeu de doublons</string>
     <string name="deduplicator_matches_exact_label">Copies identiques</string>
     <string name="deduplicator_matches_similar_label">Fichiers similaires</string>
     <string name="deduplicator_arbiter_title">Stratégie de suppression</string>

--- a/app-tool-deduplicator/src/main/res/values-ga/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ga/strings.xml
@@ -14,7 +14,6 @@
     <string name="deduplicator_detection_method_checksum_summary">Déan cinneadh ar dhúblachtaí trí sheicsuim a ríomh do chomhaid. Tá an t-inneachar céanna beacht ag comhaid le seicsuim chomhoiriúnacha.</string>
     <string name="deduplicator_detection_method_phash_title">Haiseáil tuisceanach</string>
     <string name="deduplicator_detection_method_phash_summary">Faigh comhaid chosúla trí anailís a dhéanamh ar ghnéithe inneachair agus luachanna haiseála tuisceanach a chur i gcomparáid.</string>
-    <string name="deduplicator_file_size_label">Méid comhaid</string>
     <string name="deduplicator_average_size_label">Meánmhéid</string>
     <string name="deduplicator_cluster_x_label">Braislín %s</string>
     <string name="deduplicator_delete_confirmation_message">Scrios gach cóip ach ceann amháin i ngach tacar comhad dúblach?</string>
@@ -24,7 +23,6 @@
     <string name="deduplicator_delete_multiple_sets_keep_none_confirmation_message">Scrios gach comhad i ngach tacar roghnaithe comhad dúblach? Ní fhágfar aon chomhad ar fágail!</string>
     <string name="deduplicator_delete_all_toggle_msg">Scrios gach cóip. Ní fhágfar aon chomhad ar fágail!</string>
     <string name="deduplicator_progress_comparing_files">Ag cur comhaid i gcomparáid</string>
-    <string name="deduplicator_details_cluster_title">Tacar dúblachtaí</string>
     <string name="deduplicator_matches_exact_label">Cóipeanna cruinne</string>
     <string name="deduplicator_matches_similar_label">Comhaid chosúla</string>
     <plurals name="deduplicator_result_x_clusters_processed">

--- a/app-tool-deduplicator/src/main/res/values-gl-rES/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-gl-rES/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s está ocupado por duplicados</item>
         <item quantity="other">%s están ocupados por duplicados</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Tamaño do ficheiro</string>
     <string name="deduplicator_average_size_label">Tamaño medio</string>
     <string name="deduplicator_cluster_x_label">Conxunto %s</string>
     <string name="deduplicator_delete_confirmation_message">Eliminar todas menos unha copia en todos os conxuntos de ficheiros duplicados?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Vista previa do conxunto de duplicados</string>
     <string name="deduplicator_selection_keep_one_required">Debe permanecer polo menos un ficheiro en cada conxunto de duplicados. Activa \"Facer posible \'Eliminar todos\'\" nos axustes para omitir isto.</string>
     <string name="deduplicator_progress_comparing_files">Comparando ficheiros</string>
-    <string name="deduplicator_details_cluster_title">Conxunto de duplicados</string>
     <string name="deduplicator_matches_exact_label">Copias exactas</string>
     <string name="deduplicator_matches_similar_label">Ficheiros similares</string>
     <string name="deduplicator_arbiter_title">Estratexia de eliminación</string>

--- a/app-tool-deduplicator/src/main/res/values-hi-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-hi-rIN/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s डुप्लिकेट्स द्वारा कब्जा किया गया है</item>
         <item quantity="other">%s डुप्लिकेट्स द्वारा कब्जा किया गया है</item>
     </plurals>
-    <string name="deduplicator_file_size_label">फ़ाइल का आकार</string>
     <string name="deduplicator_average_size_label">औसत आकार</string>
     <string name="deduplicator_cluster_x_label">क्लस्टर %s</string>
     <string name="deduplicator_delete_confirmation_message">डुप्लिकेट फ़ाइलों के सभी सेट में एक को छोड़कर सभी प्रतियां मिटाएं?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">डुप्लिकेट सेट पूर्वावलोकन</string>
     <string name="deduplicator_selection_keep_one_required">डुप्लिकेट सेट में कम से कम एक फ़ाइल बनी रहनी चाहिए। इसे अनदेखा करने के लिए सेटिंग्स में \"Make \'Delete all\' possible\" को सक्षम करें।</string>
     <string name="deduplicator_progress_comparing_files">फ़ाइलों की तुलना की जा रही है</string>
-    <string name="deduplicator_details_cluster_title">डुप्लिकेट का सेट</string>
     <string name="deduplicator_matches_exact_label">बिल्कुल मेल</string>
     <string name="deduplicator_matches_similar_label">समान मेल</string>
     <string name="deduplicator_arbiter_title">हटाने की रणनीति</string>

--- a/app-tool-deduplicator/src/main/res/values-hr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-hr/strings.xml
@@ -35,7 +35,6 @@
         <item quantity="few">%s su zauzeta duplikatima</item>
         <item quantity="other">%s je zauzeto duplikatima</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Veličina datoteke</string>
     <string name="deduplicator_average_size_label">Prosječna veličina</string>
     <string name="deduplicator_cluster_x_label">Grupa %s</string>
     <string name="deduplicator_delete_confirmation_message">Izbrisati sve osim jedne kopije u svim setovima dupliciranih datoteka?</string>
@@ -56,7 +55,6 @@
     <string name="deduplicator_cluster_preview_image">Pregled seta duplikata</string>
     <string name="deduplicator_selection_keep_one_required">Najmanje jedna datoteka po setu duplikata mora ostati. Omogući \"Učini \'Obriši sve\' moguće\" u postavkama da zaobiđete ovo.</string>
     <string name="deduplicator_progress_comparing_files">Uspoređivanje datoteka</string>
-    <string name="deduplicator_details_cluster_title">Set duplikata</string>
     <string name="deduplicator_matches_exact_label">Potpune kopije</string>
     <string name="deduplicator_matches_similar_label">Slične datoteke</string>
     <string name="deduplicator_arbiter_title">Strategija brisanja</string>

--- a/app-tool-deduplicator/src/main/res/values-hu/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-hu/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s duplikátummal elfoglalva</item>
         <item quantity="other">%s duplikátummal elfoglalva</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Fájlméret</string>
     <string name="deduplicator_average_size_label">Átlagos méret</string>
     <string name="deduplicator_cluster_x_label">Halmaz %s</string>
     <string name="deduplicator_delete_confirmation_message">Törölje az összes duplikált fájlkészletet egy kivételével?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Duplikált csoport előnézete</string>
     <string name="deduplicator_selection_keep_one_required">Minden duplikátum-halmazban legalább egy fájlnak meg kell maradnia. Az „Osszes törlés lehetővé tétele” beállítás engedélyezésével felülírhatja ezt.</string>
     <string name="deduplicator_progress_comparing_files">Fájlok összehasonlítása</string>
-    <string name="deduplicator_details_cluster_title">Duplikátumok készlete</string>
     <string name="deduplicator_matches_exact_label">Pontos másolatok</string>
     <string name="deduplicator_matches_similar_label">Hasonló fájlok</string>
     <string name="deduplicator_arbiter_title">Törlési stratégia</string>

--- a/app-tool-deduplicator/src/main/res/values-in/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-in/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ditempati oleh duplikat</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Ukuran file</string>
     <string name="deduplicator_average_size_label">Ukuran rata-rata</string>
     <string name="deduplicator_cluster_x_label">Kelompok %s</string>
     <string name="deduplicator_delete_confirmation_message">Hapus semua kecuali satu salinan di semua set file duplikat?</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">Pratinjau set duplikat</string>
     <string name="deduplicator_selection_keep_one_required">Setidaknya satu file per set duplikat harus tetap ada. Aktifkan opsi \"Izinkan \'Hapus semua\'\" di pengaturan untuk mengesampingkan ini.</string>
     <string name="deduplicator_progress_comparing_files">Membandingkan file</string>
-    <string name="deduplicator_details_cluster_title">Set duplikat</string>
     <string name="deduplicator_matches_exact_label">Salinan yang persis</string>
     <string name="deduplicator_matches_similar_label">File serupa</string>
     <string name="deduplicator_arbiter_title">Strategi penghapusan</string>

--- a/app-tool-deduplicator/src/main/res/values-is/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-is/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s er tekið af tvítekningum</item>
         <item quantity="other">%s eru tekin af tvítekningum</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Skráarstærð</string>
     <string name="deduplicator_average_size_label">Meðalstærð</string>
     <string name="deduplicator_cluster_x_label">Þyrping %s</string>
     <string name="deduplicator_delete_confirmation_message">Eyða öllu nema einu eintaki í öllum settum tvítekinna skráa?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Forskoðun á tvíteknu mengi</string>
     <string name="deduplicator_selection_keep_one_required">Að minnsta kosti ein skrá fyrir hvert sett tvítekinna hluta verður að vera eftir. Virkjaðu \"Gera \'Eyða öllu\' mögulegt\" í stillingum til að hnekkja þessu.</string>
     <string name="deduplicator_progress_comparing_files">Beri saman skrár</string>
-    <string name="deduplicator_details_cluster_title">Sett tvítekinna</string>
     <string name="deduplicator_matches_exact_label">Nákvæm eintök</string>
     <string name="deduplicator_matches_similar_label">Svipaðar skrár</string>
     <string name="deduplicator_arbiter_title">Eyðingarstefna</string>

--- a/app-tool-deduplicator/src/main/res/values-it/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-it/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s è occupato da duplicati</item>
         <item quantity="other">%s sono occupati da duplicati</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Dimensione file</string>
     <string name="deduplicator_average_size_label">Dimensione media</string>
     <string name="deduplicator_cluster_x_label">Cluster %s</string>
     <string name="deduplicator_delete_confirmation_message">Elimina tutto tranne una copia di ogni set dei file duplicati?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Anteprima set di duplicati</string>
     <string name="deduplicator_selection_keep_one_required">Almeno un file per ogni set di duplicati deve rimanere. Abilita “Rendi possibile ‘Elimina tutti’” nelle impostazioni per ignorare questa regola.</string>
     <string name="deduplicator_progress_comparing_files">Confrontando i file</string>
-    <string name="deduplicator_details_cluster_title">Set di duplicati</string>
     <string name="deduplicator_matches_exact_label">Copie identiche</string>
     <string name="deduplicator_matches_similar_label">File simili</string>
     <string name="deduplicator_arbiter_title">Strategia di eliminazione</string>

--- a/app-tool-deduplicator/src/main/res/values-iw/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-iw/strings.xml
@@ -38,7 +38,6 @@
         <item quantity="many">%s תפוס על ידי כפילויות</item>
         <item quantity="other">%s תפוס על ידי כפילויות</item>
     </plurals>
-    <string name="deduplicator_file_size_label">גודל קובץ</string>
     <string name="deduplicator_average_size_label">גודל ממוצע</string>
     <string name="deduplicator_cluster_x_label">אשכול %s</string>
     <string name="deduplicator_delete_confirmation_message">למחוק את כל העותקים מלבד אחד בכל קבוצות הקבצים הכפולים?</string>
@@ -60,7 +59,6 @@
     <string name="deduplicator_cluster_preview_image">תצוגה מקדימה של קבוצת כפילויות</string>
     <string name="deduplicator_selection_keep_one_required">חייב להישאר לפחות קובץ אחד בכל קבוצת כפילויות. הפעל את אפשרות \'haפעל מחיקת הכל\'\' בהגדרות כדי לעקוף.</string>
     <string name="deduplicator_progress_comparing_files">השוואת קבצים</string>
-    <string name="deduplicator_details_cluster_title">רשימת כפילויות</string>
     <string name="deduplicator_matches_exact_label">עותקים מדויקים</string>
     <string name="deduplicator_matches_similar_label">קבצים דומים</string>
     <string name="deduplicator_arbiter_title">אסטרטגיית מחיקה</string>

--- a/app-tool-deduplicator/src/main/res/values-ja/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ja/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%sが重複により占有されています</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ファイルサイズ</string>
     <string name="deduplicator_average_size_label">平均サイズ</string>
     <string name="deduplicator_cluster_x_label">クラスター %s</string>
     <string name="deduplicator_delete_confirmation_message">重複するファイルのすべてのセットで、1つのコピーを除いてすべてを削除しますか？</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">重複セットのプレビュー</string>
     <string name="deduplicator_selection_keep_one_required">重複セットごとに少なくとも1つのファイルが残っている必要があります。設定で「『すべてを削除』を可能にする」を有効にしてこれをオーバーライドしてください。</string>
     <string name="deduplicator_progress_comparing_files">ファイルの比較</string>
-    <string name="deduplicator_details_cluster_title">重複のセット</string>
     <string name="deduplicator_matches_exact_label">正確なコピー</string>
     <string name="deduplicator_matches_similar_label">類似のファイル</string>
     <string name="deduplicator_arbiter_title">削除戦略</string>

--- a/app-tool-deduplicator/src/main/res/values-ka-rGE/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ka-rGE/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s დაკავებულია დუბლიკატებით</item>
         <item quantity="other">%s დაკავებულია დუბლიკატებით</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ფაილის ზომა</string>
     <string name="deduplicator_average_size_label">საშუალო ზომა</string>
     <string name="deduplicator_cluster_x_label">კლასტერი %s</string>
     <string name="deduplicator_delete_confirmation_message">წაიშალოს ყველა ასლი ერთის გარდა დუბლიკატი ფაილების ყველა ნაკრებში?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">დუბლიკატების ნაკრების წინასწარი ნახვა</string>
     <string name="deduplicator_selection_keep_one_required">თითოეული დუბლიკატის ნაკრებში მინიმუმ ერთი ფაილი უნდა დარჩეს. ჩართეთ პარამეტრებში \"გააკეთეთ \'ყველას წაშლა\' შესაძლებელი\" გადალახვისთვის.</string>
     <string name="deduplicator_progress_comparing_files">ფაილების შედარება</string>
-    <string name="deduplicator_details_cluster_title">დუბლიკატების ნაკრები</string>
     <string name="deduplicator_matches_exact_label">ზუსტი ასლები</string>
     <string name="deduplicator_matches_similar_label">მსგავსი ფაილები</string>
     <string name="deduplicator_arbiter_title">წაშლის სტრატეგია</string>

--- a/app-tool-deduplicator/src/main/res/values-kaa/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-kaa/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s dublikatlları iyelep turır</item>
         <item quantity="other">%s dublikatlları iyelep turır</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Fayl kólemi</string>
     <string name="deduplicator_average_size_label">Ortasha kólem</string>
     <string name="deduplicator_cluster_x_label">Klaster %s</string>
     <string name="deduplicator_delete_confirmation_message">Barlıq dublikat fayllar toplamlarında birewden basqa barlıǵın öshirip taslama?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Dublikat toplamınıń aldın kóriwi</string>
     <string name="deduplicator_selection_keep_one_required">Hár bir dublikat toplamında keminde bir fayl qalıwı kerek. Bunı biykarlaw ushın sazlamalarda “\'Barlıǵın óshiriw\'di mümkin qıl” degendi qosıń.</string>
     <string name="deduplicator_progress_comparing_files">Fayllar salıstırılıwda</string>
-    <string name="deduplicator_details_cluster_title">Qosníshalar toplamı</string>
     <string name="deduplicator_matches_exact_label">Tolıq kóshirmeler</string>
     <string name="deduplicator_matches_similar_label">Uqsas fayllar</string>
     <string name="deduplicator_arbiter_title">O\'shiriw strategiyası</string>

--- a/app-tool-deduplicator/src/main/res/values-km-rKH/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-km-rKH/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ត្រួវ​បាន​ប្រើ​ប្រាស់​ដោយ​សែសែ</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ទម្ហើន​កំពិល័</string>
     <string name="deduplicator_average_size_label">ទម្ហើន​មីត្យភាគ</string>
     <string name="deduplicator_cluster_x_label">ក្លួម %s</string>
     <string name="deduplicator_delete_confirmation_message">លុប​កំពិល័​ថ័ល​នើស​ក្នុង​សែសែ​តែងហអ់៴</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">បង្ហាញមុនសំណុំច្បាប់ចម្លង</string>
     <string name="deduplicator_selection_keep_one_required">ត្រូវរក្សាឯកសារយ៉ាងហោចណាស់មួយក្នុងសំណុំឯកសារដដែល។ បើក \"ធ្វើឱ្យលុបបានទាំងអស់\" ក្នុងការកំណត់ដើម្បីលើស។</string>
     <string name="deduplicator_progress_comparing_files">កំពុង​ប្រើប្រាស់​កំពិល័</string>
-    <string name="deduplicator_details_cluster_title">សែសែ​ដែល​ជ័រ​ជ័រ</string>
     <string name="deduplicator_matches_exact_label">ចំនួន​កឹប​​ដឹក​គ្នា</string>
     <string name="deduplicator_matches_similar_label">ឯកសារដែលស្រដៀងគ្នា</string>
     <string name="deduplicator_arbiter_title">យុទ្ធសាស្ត្រលុប</string>

--- a/app-tool-deduplicator/src/main/res/values-ko/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ko/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s가 중복 파일로 점유되고 있습니다</item>
     </plurals>
-    <string name="deduplicator_file_size_label">파일 크기</string>
     <string name="deduplicator_average_size_label">평균 크기</string>
     <string name="deduplicator_cluster_x_label">클러스터 %s</string>
     <string name="deduplicator_delete_confirmation_message">모든 중복 파일 세트에서 복사본 하나를 제외한 모든 파일을 삭제하시겠습니까?</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">중복 집합 미리보기</string>
     <string name="deduplicator_selection_keep_one_required">각 중복 집합마다 최소 하나의 파일은 남아야 합니다. 설정에서 \'모두 삭제 가능하게 하기\'를 활성화하여 재정의할 수 있습니다.</string>
     <string name="deduplicator_progress_comparing_files">파일 비교</string>
-    <string name="deduplicator_details_cluster_title">중복 세트</string>
     <string name="deduplicator_matches_exact_label">정확한 복사본</string>
     <string name="deduplicator_matches_similar_label">유사 파일</string>
     <string name="deduplicator_arbiter_title">삭제 전략</string>

--- a/app-tool-deduplicator/src/main/res/values-lo-rLA/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-lo-rLA/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ຖືກໃຊ້ໂດຍສຳເນົາທີ່ຊ້າ</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ຂະໜາດໄຟລ໌</string>
     <string name="deduplicator_average_size_label">ຂະໜາດສະເລ່ຍ</string>
     <string name="deduplicator_cluster_x_label">Cluster %s</string>
     <string name="deduplicator_delete_confirmation_message">ລຶ້ທຸກສຳເນົາ ຍົກເວັ້ນໜຶ່ງ ໃນທຸກຊຸດຂອງໄຟລ໌ทີ່ຊ້າກັນ?</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">ກະບອກມອງຊຸດຣະເບີດຜໍ່າ</string>
     <string name="deduplicator_selection_keep_one_required">ຕ້ອງເກັບໄວ້ຍ່າງນໍ້ຍໝຶ່ງໄຟລ໌ຕໍ່ຊຸດຣະເບີດຜໍ່າ. ເປິດໃຊ້ \"ເຮັດໃຫ້ຖອນລົບທັງໝົດ ເປັນໄປໄດ້\" ໃນການຕັ້ງຄ່າເພື່ອຂ້າມໄປ.</string>
     <string name="deduplicator_progress_comparing_files">ກຳລັງປຽບທຽຍໄຟລ໌</string>
-    <string name="deduplicator_details_cluster_title">ຊຸດຂອງສຳເນົາทີ່ຊ້າກັນ</string>
     <string name="deduplicator_matches_exact_label">ສຳເນົາທີ່ຖືກຕ້ອງ</string>
     <string name="deduplicator_matches_similar_label">ໄຟລ໌ທີ່ຄ້າຍກັນ</string>
     <string name="deduplicator_arbiter_title">ຍຸດທະສາດການລຶ້</string>

--- a/app-tool-deduplicator/src/main/res/values-lt/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-lt/strings.xml
@@ -38,7 +38,6 @@
         <item quantity="many">%s užimama dublikatų</item>
         <item quantity="other">%s užimta dublikatų</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Failo dydis</string>
     <string name="deduplicator_average_size_label">Vidutinis dydis</string>
     <string name="deduplicator_cluster_x_label">Klasteris %s</string>
     <string name="deduplicator_delete_confirmation_message">Ištrinti visus, išskyrus vieną kopiją visuose dublikatų failuose?</string>
@@ -60,7 +59,6 @@
     <string name="deduplicator_cluster_preview_image">Dublikatų rinkinio peržiūra</string>
     <string name="deduplicator_selection_keep_one_required">Kiekviename pasikartojusių failų rinkinyje turi likti mažiausiai vienas failas. Norėdami nepaisyti šio apribojimo, nustatymuose įjunkite \"Leisti \'Ištrinti viską\'\".</string>
     <string name="deduplicator_progress_comparing_files">Lyginami failai</string>
-    <string name="deduplicator_details_cluster_title">Dublikatų rinkinys</string>
     <string name="deduplicator_matches_exact_label">Tikslios kopijos</string>
     <string name="deduplicator_matches_similar_label">Panašūs failai</string>
     <string name="deduplicator_arbiter_title">Ištrinimo strategija</string>

--- a/app-tool-deduplicator/src/main/res/values-lv/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-lv/strings.xml
@@ -35,7 +35,6 @@
         <item quantity="one">%s ir aizņemts ar dublikātiem</item>
         <item quantity="other">%s ir aizņemti ar dublikātiem</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Faila izmērs</string>
     <string name="deduplicator_average_size_label">Vidējais izmērs</string>
     <string name="deduplicator_cluster_x_label">Kopa %s</string>
     <string name="deduplicator_delete_confirmation_message">Dzēst visas kopijas, izņemot vienu, visos dublikātu komplektos?</string>
@@ -56,7 +55,6 @@
     <string name="deduplicator_cluster_preview_image">Dubultojumu kopas priekšskatījums</string>
     <string name="deduplicator_selection_keep_one_required">Katrā dublietu kopā jāpaliek vismaz vienam failam. Lai to mainītu, iestatījumos ieslēdziet „Padarīt \'Dzēst visu\' iespējamu“.</string>
     <string name="deduplicator_progress_comparing_files">Failu salīdzīnāšana</string>
-    <string name="deduplicator_details_cluster_title">Dublikātu kopa</string>
     <string name="deduplicator_matches_exact_label">Precizas kopijas</string>
     <string name="deduplicator_matches_similar_label">Līdzīgi faili</string>
     <string name="deduplicator_arbiter_title">Dzēšanas stratēģija</string>

--- a/app-tool-deduplicator/src/main/res/values-mk-rMK/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-mk-rMK/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s е зафатено од дупликати</item>
         <item quantity="other">%s се зафатени од дупликати</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Големина на датотека</string>
     <string name="deduplicator_average_size_label">Просечна големина</string>
     <string name="deduplicator_cluster_x_label">Група %s</string>
     <string name="deduplicator_delete_confirmation_message">Избриши ги сите освен една копија во сите групи дупликати?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Преглед на група дупликати</string>
     <string name="deduplicator_selection_keep_one_required">Мора да остане барем една датотека од секој сет дупликати. Вклучете ја опцијата „Овозможи ‘Избриши сè’“ во подесувањата за да го заобиколите ова.</string>
     <string name="deduplicator_progress_comparing_files">Споредување на датотеки</string>
-    <string name="deduplicator_details_cluster_title">Група дупликати</string>
     <string name="deduplicator_matches_exact_label">Точни копии</string>
     <string name="deduplicator_matches_similar_label">Слични датотеки</string>
     <string name="deduplicator_arbiter_title">Стратегија за бришење</string>

--- a/app-tool-deduplicator/src/main/res/values-ml-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ml-rIN/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s ഡ്യൂപ്ലിക്കേറ്റ് ഉപയോഗിക്കുന്നു</item>
         <item quantity="other">%s ഡ്യൂപ്ലിക്കേറ്റുകൾ ഉപയോഗിക്കുന്നു</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ഫയൽ വലുപ്പം</string>
     <string name="deduplicator_average_size_label">ശരാശരി വലുപ്പം</string>
     <string name="deduplicator_cluster_x_label">ക്ലസ്റ്റർ %s</string>
     <string name="deduplicator_delete_confirmation_message">എല്ലാ ഡ്യൂപ്ലിക്കേറ്റ് ഫയൽ സെറ്റുകളിലും ഒരു കോപ്പി ഒഴികെ ബാക്കിയെല്ലാം ഡിലീറ്റ് ചെയ്യണോ?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">ഡപ്ലിക്കേറ്റ് സെറ്റ് പ്രിവ്യൂ</string>
     <string name="deduplicator_selection_keep_one_required">ഓരോ ഡപ്ലിക്കേറ്റ് സെറ്റിലും കുറഞ്ഞത് ഒരു ഫയൽ ശേഷിക്കണം. അതിക്രമിക്കാൻ സെറ്റിംഗുകളിൽ \"എല്ലാം ഇല്ലാതാക്കൽ സാധ്യമാക്കുക\" സജ്ജമാക്കുക.</string>
     <string name="deduplicator_progress_comparing_files">ഫയലുകൾ താരതമ്യപ്പെടുത്തുന്നു</string>
-    <string name="deduplicator_details_cluster_title">ഡ്യൂപ്ലിക്കേറ്റുകളുടെ സെറ്റ്</string>
     <string name="deduplicator_matches_exact_label">കൃത്യമായ പകർപ്പുകൾ</string>
     <string name="deduplicator_matches_similar_label">സമാന ഫയലുകൾ</string>
     <string name="deduplicator_arbiter_title">ഡിലീഷൻ തന്ത്രം</string>

--- a/app-tool-deduplicator/src/main/res/values-mn-rMN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-mn-rMN/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s давхардах файлууд эзлаад байна</item>
         <item quantity="other">%s давхардах файлууд эзлаад байна</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Файлын хэмжээ</string>
     <string name="deduplicator_average_size_label">Дундаж хэмжээ</string>
     <string name="deduplicator_cluster_x_label">Кластер %s</string>
     <string name="deduplicator_delete_confirmation_message">Давхардсан файлуудын бүх бүлэгт нэг хуулбараас бусдыг устгах уу?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Давхардсан сэтийн урьдчилсан дүрс</string>
     <string name="deduplicator_selection_keep_one_required">Давхардсан сэт бүрээс дор хаяж нэг файл үлдэх ёстой. Үүнийг өөрчлөхийн тулд тохиргооны хэсэгт «Бүгдийг устгахыг боломжтой болгох» сонголтыг идэвхжүүлнэ.</string>
     <string name="deduplicator_progress_comparing_files">Файлуудыг харьцуулж байна</string>
-    <string name="deduplicator_details_cluster_title">Давхардах файлын багц</string>
     <string name="deduplicator_matches_exact_label">Ян копиууд</string>
     <string name="deduplicator_matches_similar_label">Төстэй файлууд</string>
     <string name="deduplicator_arbiter_title">Устгах стратеги</string>

--- a/app-tool-deduplicator/src/main/res/values-ms/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ms/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s diduduki oleh pendua</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Saiz fail</string>
     <string name="deduplicator_average_size_label">Saiz purata</string>
     <string name="deduplicator_cluster_x_label">Kelompok %s</string>
     <string name="deduplicator_delete_confirmation_message">Padam semua kecuali satu salinan dalam semua set fail pendua?</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">Pratonton set pendua</string>
     <string name="deduplicator_selection_keep_one_required">Sekurang-kurangnya satu fail setiap set duplikat mesti dikekalkan. Dayakan \"Buat \'Padam semua\' mungkin\" dalam tetapan untuk mengatasi.</string>
     <string name="deduplicator_progress_comparing_files">Membandingkan fail</string>
-    <string name="deduplicator_details_cluster_title">Butiran kelompok</string>
     <string name="deduplicator_matches_exact_label">Salinan tepat</string>
     <string name="deduplicator_matches_similar_label">Fail serupa</string>
     <string name="deduplicator_arbiter_title">Strategi pemadaman</string>

--- a/app-tool-deduplicator/src/main/res/values-my-rMM/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-my-rMM/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ကို ထပ်တူများက လွှမ်းမိုးထေသည်</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ဖိုင်အရွယ်အစား</string>
     <string name="deduplicator_average_size_label">ပျမ်မျှ အရွယ်အစား</string>
     <string name="deduplicator_cluster_x_label">Cluster %s</string>
     <string name="deduplicator_delete_confirmation_message">ထပ်တူဖိုင်များ အစုအဖွဲ့အားလုံးတွင် တစ်ခုမှလွဲး အားလုံး ဖျက်မည်လား?</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">တူညီအစု အစမ်းကြည့်မှု</string>
     <string name="deduplicator_selection_keep_one_required">ကူးတည့်မှုအစုတစ်ခုလျှင် ဖိုင်အနည်းဆုံးတစ်ခုသည်ကျန်ရှိရမည်။ အဆိုပါအခွင့်အရေးကိုအပြန်အလှန်ပြောင်းလဲရန်ချိန်ညှိချက်များတွင် \"အားလုံးဖျက်ခွင့်ပြုခြင်း\" ကိုဖွင့်ထားပါ။</string>
     <string name="deduplicator_progress_comparing_files">ဖိုင်များ နှိုင်းယှဉ်နေသည်</string>
-    <string name="deduplicator_details_cluster_title">ပွားသော ဖိုင်များ အစု</string>
     <string name="deduplicator_matches_exact_label">တိကျသော မိတ္တူများ</string>
     <string name="deduplicator_matches_similar_label">ဆင်တူသော ဖိုင်များ</string>
     <string name="deduplicator_arbiter_title">ဖျက်သောနည်းလမ်း</string>

--- a/app-tool-deduplicator/src/main/res/values-nb/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-nb/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s er brukt av duplikater</item>
         <item quantity="other">%s er brukt av duplikater</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Filstørrelse</string>
     <string name="deduplicator_average_size_label">Gjennomsnittlig størrelse</string>
     <string name="deduplicator_cluster_x_label">Klynge %s</string>
     <string name="deduplicator_delete_confirmation_message">Slette alle bortsett fra en kopi i alle sett med dupliserte filer?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Forhåndsvisning av duplikatsettet</string>
     <string name="deduplicator_selection_keep_one_required">Minst én fil per duplikatset må gjenstå. Slå på \"Gjør \'Slett alt\' mulig\" i innstillinger for å overstyre dette.</string>
     <string name="deduplicator_progress_comparing_files">Sammenligner filer</string>
-    <string name="deduplicator_details_cluster_title">Sett med duplikater</string>
     <string name="deduplicator_matches_exact_label">Nøyaktige kopier</string>
     <string name="deduplicator_matches_similar_label">Lignende filer</string>
     <string name="deduplicator_arbiter_title">Slettestrategi</string>

--- a/app-tool-deduplicator/src/main/res/values-ne-rNP/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ne-rNP/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s डुप्लिकेटले ओगटेको छ</item>
         <item quantity="other">%s डुप्लिकेटले ओगटेका छन्</item>
     </plurals>
-    <string name="deduplicator_file_size_label">फाइल साइज</string>
     <string name="deduplicator_average_size_label">औसत साइज</string>
     <string name="deduplicator_cluster_x_label">समूह %s</string>
     <string name="deduplicator_delete_confirmation_message">डुप्लिकेट फाइलहरूका सबै सेटहरूमा एक प्रति बाहेक सबै मेटाउनुहुन्छ?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">डुप्लिकेट सेट पूर्वावलोकन</string>
     <string name="deduplicator_selection_keep_one_required">कम्तिमा एक फाइल प्रत्येक डुप्लिकेट सेटमा रहनु आवश्यक छ। अधिरोह गर्न सेटिङ्समा \"\'सबै मेट्नु\' सम्भव बनाउनुहोस्\" सक्षम गर्नुहोस्।</string>
     <string name="deduplicator_progress_comparing_files">फाइलहरू तुलना गर्दै</string>
-    <string name="deduplicator_details_cluster_title">डुप्लिकेटहरूको सेट</string>
     <string name="deduplicator_matches_exact_label">सटीक प्रतिहरू</string>
     <string name="deduplicator_matches_similar_label">समान फाइलहरू</string>
     <string name="deduplicator_arbiter_title">मेटाउने रणनीति</string>

--- a/app-tool-deduplicator/src/main/res/values-nl/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-nl/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s wordt ingenomen door duplicaten</item>
         <item quantity="other">%s worden ingenomen door duplicaten</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Bestandsgrootte</string>
     <string name="deduplicator_average_size_label">Gemiddelde grootte</string>
     <string name="deduplicator_cluster_x_label">Groepeer %s</string>
     <string name="deduplicator_delete_confirmation_message">Verwijder alle kopieën in alle sets van dubbele bestanden?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Voorbeeld duplicatenset</string>
     <string name="deduplicator_selection_keep_one_required">Per duplicatenset moet minstens één bestand blijven. Schakel \'Alles verwijderen mogelijk maken\' in de instellingen in om dit te negeren.</string>
     <string name="deduplicator_progress_comparing_files">Bestanden vergelijken</string>
-    <string name="deduplicator_details_cluster_title">Set dubbele exemplaren</string>
     <string name="deduplicator_matches_exact_label">Exacte kopieën</string>
     <string name="deduplicator_matches_similar_label">Gelijkaardige bestanden</string>
     <string name="deduplicator_arbiter_title">Verwijderingsstrategie</string>

--- a/app-tool-deduplicator/src/main/res/values-or-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-or-rIN/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s ନକଲ ଦ୍ୱାରା ଦଖଲ ହୋଇଛି</item>
         <item quantity="other">%s ନକଲ ଦ୍ୱାରା ଦଖଲ ହୋଇଛି</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ଫାଇଲ ଆକାର</string>
     <string name="deduplicator_average_size_label">ହାରାହାରି ଆକାର</string>
     <string name="deduplicator_cluster_x_label">କ୍ଲଷ୍ଟର %s</string>
     <string name="deduplicator_delete_confirmation_message">ନକଲ ଫାଇଲଗୁଡ଼ିକର ସମସ୍ତ ସେଟରେ ଗୋଟିଏ କପି ବ୍ୟତୀତ ସବୁ ଡିଲିଟ୍ କରିବେ?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">ଡୁପ୍ଲିକେଟ ସେଟ ପୂର୍ବଦର୍ଶନ</string>
     <string name="deduplicator_selection_keep_one_required">ପ୍ରତ୍ୟେକ ଡୁପ୍ଲିକେଟ ସେଟରେ ଅନ୍ତତଃ ଗୋଟିଏ ଫାଇଲ ରହିବା ଆବଶ୍ୟକ। ଏହାକୁ ଅତିକ୍ରମ କରିବାକୁ ସେଟିଂସରେ \"ସମସ୍ତ ଡିଲିଟ ସମ୍ଭବ କରନ୍ତୁ\" ସକ୍ଷମ କରନ୍ତୁ।</string>
     <string name="deduplicator_progress_comparing_files">ଫାଇଲ ତୁଳନା କରୁଛି</string>
-    <string name="deduplicator_details_cluster_title">ନକଲଗୁଡ଼ିକର ସେଟ୍</string>
     <string name="deduplicator_matches_exact_label">ସଠିକ କପିଗୁଡ଼ିକ</string>
     <string name="deduplicator_matches_similar_label">ସମାନ ଫାଇଲଗୁଡ଼ିକ</string>
     <string name="deduplicator_arbiter_title">ଡିଲିଟ୍ ରଣନୀତି</string>

--- a/app-tool-deduplicator/src/main/res/values-pa-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pa-rIN/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s ਡੁਪਲੀਕੇਟਸ ਦੁਆਰਾ ਲਿਆ ਗਿਆ ਹੈ</item>
         <item quantity="other">%s ਡੁਪਲੀਕੇਟਸ ਦੁਆਰਾ ਲਿਆ ਗਿਆ ਹੈ</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ਫਾਈਲ ਆਕਾਰ</string>
     <string name="deduplicator_average_size_label">ਔਸਤ ਆਕਾਰ</string>
     <string name="deduplicator_cluster_x_label">ਕਲੱਸਟਰ %s</string>
     <string name="deduplicator_delete_confirmation_message">ਕੀ ਡੁਪਲੀਕੇਟ ਫਾਈਲਾਂ ਦੇ ਸਾਰੇ ਸੈੱਟਾਂ ਵਿੱਚ ਇੱਕ ਕਾਪੀ ਛੱਡ ਕੇ ਬਾਕੀ ਸਭ ਮਿਟਾਉਣੀਆਂ ਹਨ?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">ਨਕਲ ਸੈਟ ਪ੍ਰੀਵਿਊ</string>
     <string name="deduplicator_selection_keep_one_required">ਹਰੇਕ ਡੁਪਲੀਕੇਟ ਸੈਟ ਵਿੱਚ ਘੱਟੋ-ਘੱਟ ਇੱਕ ਫਾਈਲ ਬਾਕੀ ਰਹਿਣੀ ਚਾਹੀਦੀ ਹੈ। ਇਸ ਨੂੰ ਬਦਲਣ ਲਈ ਸੈਟਿੰਗਾਂ ਵਿੱਚ \"Make \'Delete all\' possible\" ਨੂੰ ਸਮਰੱਥ ਕਰੋ।</string>
     <string name="deduplicator_progress_comparing_files">ਫਾਈਲਾਂ ਦੀ ਤੁਲਨਾ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ</string>
-    <string name="deduplicator_details_cluster_title">ਡੁਪਲੀਕੇਟਾਂ ਦਾ ਸੈੱਟ</string>
     <string name="deduplicator_matches_exact_label">ਬਿਲਕੁਲ ਸਮਾਨ ਕਾਪੀਆਂ</string>
     <string name="deduplicator_matches_similar_label">ਸਮਾਨ ਫਾਈਲਾਂ</string>
     <string name="deduplicator_arbiter_title">ਮਿਟਾਉਣ ਦੀ ਰਣਨੀਤੀ</string>

--- a/app-tool-deduplicator/src/main/res/values-pl/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pl/strings.xml
@@ -38,7 +38,6 @@
         <item quantity="many">%s jest zajętych przez duplikaty</item>
         <item quantity="other">%s jest zajętych przez duplikaty</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Rozmiar pliku</string>
     <string name="deduplicator_average_size_label">Średni rozmiar</string>
     <string name="deduplicator_cluster_x_label">Klaster %s</string>
     <string name="deduplicator_delete_confirmation_message">Usunąć wszystkie pliki oprócz jednej kopii?</string>
@@ -60,7 +59,6 @@
     <string name="deduplicator_cluster_preview_image">Podgląd zestawu duplikatów</string>
     <string name="deduplicator_selection_keep_one_required">W każdym zestawie duplikatów musi pozostać co najmniej jeden plik. Włącz „Zezwól na usunięcie wszystkich” w ustawieniach, aby to zastąpić.</string>
     <string name="deduplicator_progress_comparing_files">Porównywanie plików</string>
-    <string name="deduplicator_details_cluster_title">Zestaw duplikatów</string>
     <string name="deduplicator_matches_exact_label">Dokładne kopie</string>
     <string name="deduplicator_matches_similar_label">Podobne pliki</string>
     <string name="deduplicator_arbiter_title">Strategia usuwania</string>

--- a/app-tool-deduplicator/src/main/res/values-pt-rBR/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pt-rBR/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s está ocupado por duplicados</item>
         <item quantity="other">%s estão ocupados por duplicados</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Tamanho do arquivo</string>
     <string name="deduplicator_average_size_label">Tamanho médio</string>
     <string name="deduplicator_cluster_x_label">Aglomerado %s</string>
     <string name="deduplicator_delete_confirmation_message">Excluir todas as cópias, exceto uma, neste conjunto de arquivos duplicados?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Visualização de conjunto duplicado</string>
     <string name="deduplicator_selection_keep_one_required">Pelo menos um arquivo por conjunto de duplicados deve permanecer. Ative \"Tornar \'Excluir tudo\' possível\" nas configurações para substituir.</string>
     <string name="deduplicator_progress_comparing_files">Comparando os arquivos</string>
-    <string name="deduplicator_details_cluster_title">Conjunto de duplicados</string>
     <string name="deduplicator_matches_exact_label">Cópias exatas</string>
     <string name="deduplicator_matches_similar_label">Arquivos similares</string>
     <string name="deduplicator_arbiter_title">Estratégia de exclusão</string>

--- a/app-tool-deduplicator/src/main/res/values-pt/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-pt/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s está ocupado por duplicados</item>
         <item quantity="other">%s estão ocupados por duplicados</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Tamanho do ficheiro</string>
     <string name="deduplicator_average_size_label">Tamanho médio</string>
     <string name="deduplicator_cluster_x_label">Grupo %s</string>
     <string name="deduplicator_delete_confirmation_message">Eliminar todas as cópias exceto uma em todos os conjuntos de ficheiros duplicados?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Pré-visualização do conjunto de duplicados</string>
     <string name="deduplicator_selection_keep_one_required">Pelo menos um ficheiro por conjunto de duplicados deve permanecer. Ative a opção \"Permitir eliminar tudo\" nas definições para substituir esta proteção.</string>
     <string name="deduplicator_progress_comparing_files">A comparar ficheiros</string>
-    <string name="deduplicator_details_cluster_title">Conjunto de duplicados</string>
     <string name="deduplicator_matches_exact_label">Cópias exatas</string>
     <string name="deduplicator_matches_similar_label">Ficheiros semelhantes</string>
     <string name="deduplicator_arbiter_title">Estratégia de eliminação</string>

--- a/app-tool-deduplicator/src/main/res/values-ro/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ro/strings.xml
@@ -35,7 +35,6 @@
         <item quantity="few">%s sunt ocupate de duplicate</item>
         <item quantity="other">%s sunt ocupate de duplicate</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Dimensiune fişier</string>
     <string name="deduplicator_average_size_label">Dimensiune medie</string>
     <string name="deduplicator_cluster_x_label">Cluster %s</string>
     <string name="deduplicator_delete_confirmation_message">Ștergeți toate copiile, cu o singură excepție, din toate seturile de fișiere duplicate?</string>
@@ -56,7 +55,6 @@
     <string name="deduplicator_cluster_preview_image">Previzualizare set de duplicate</string>
     <string name="deduplicator_selection_keep_one_required">Cel puțin un fișier per set de duplicate trebuie să rămână. Activează \"Fă posibil \'Șterge tot\'\" în setări pentru a ignora.</string>
     <string name="deduplicator_progress_comparing_files">Compararea fişierelor</string>
-    <string name="deduplicator_details_cluster_title">Set de dubluri</string>
     <string name="deduplicator_matches_exact_label">Copii exacte</string>
     <string name="deduplicator_matches_similar_label">Fișiere similare</string>
     <string name="deduplicator_arbiter_title">Strategia de ștergere</string>

--- a/app-tool-deduplicator/src/main/res/values-ru/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ru/strings.xml
@@ -38,7 +38,6 @@
         <item quantity="many">Дубликатами занято: %s</item>
         <item quantity="other">Дубликатами занято: %s</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Размер файла</string>
     <string name="deduplicator_average_size_label">Средний размер</string>
     <string name="deduplicator_cluster_x_label">Группа %s</string>
     <string name="deduplicator_delete_confirmation_message">Удалить все копии, кроме одной, в этом наборе дубликатов?</string>
@@ -60,7 +59,6 @@
     <string name="deduplicator_cluster_preview_image">Предпросмотр набора дубликатов</string>
     <string name="deduplicator_selection_keep_one_required">В каждом наборе дубликатов должен остаться хотя бы один файл. Включите параметр «Разрешить удаление всех» в настройках, чтобы переопределить это.</string>
     <string name="deduplicator_progress_comparing_files">Сравнение файлов</string>
-    <string name="deduplicator_details_cluster_title">Группы дубликатов</string>
     <string name="deduplicator_matches_exact_label">Точные копии</string>
     <string name="deduplicator_matches_similar_label">Похожие файлы</string>
     <string name="deduplicator_arbiter_title">Стратегия удаления</string>

--- a/app-tool-deduplicator/src/main/res/values-sc-rIT/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sc-rIT/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s est ocupadu dae duplicados</item>
         <item quantity="other">%s sunt ocupados dae duplicados</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Mannària de documentu</string>
     <string name="deduplicator_average_size_label">Mannària média</string>
     <string name="deduplicator_cluster_x_label">Grupu %s</string>
     <string name="deduplicator_delete_confirmation_message">Cantzellare totu manca una còpia in totu is grupos de documentos duplicados?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Prevista de conuntu de duplicados</string>
     <string name="deduplicator_selection_keep_one_required">Almenu unu archiviu pro cadaunu grupu di dupplicados debit rimandere. Abilita \"Faghe \'Cantzellare totu\' possibbile\" in is preferentias pro suberare.</string>
     <string name="deduplicator_progress_comparing_files">Cumparende documentos</string>
-    <string name="deduplicator_details_cluster_title">Grupu de duplicados</string>
     <string name="deduplicator_matches_exact_label">Còpias isatas</string>
     <string name="deduplicator_matches_similar_label">Documentos similares</string>
     <string name="deduplicator_arbiter_title">Estratègia de cantzelladura</string>

--- a/app-tool-deduplicator/src/main/res/values-si-rLK/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-si-rLK/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s බහුපත විසින් අවවන් න් වෙ</item>
         <item quantity="other">%s බහුපත විසින් අවවන් න් වෙ</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ගොනු ප්‍රමාණය</string>
     <string name="deduplicator_average_size_label">සමාන ප්‍රමාණය</string>
     <string name="deduplicator_cluster_x_label">සමුහය %s</string>
     <string name="deduplicator_delete_confirmation_message">සියලු බහුපත ගොනු සමුහවල එකක් මඟ එක් ගොනුවක් මකා දමන්නද?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">අනුපිටපත් සමූහ පෙරදසුන</string>
     <string name="deduplicator_selection_keep_one_required">එක් එක් අනුපිටපත් සමූහයට අවම වශයෙන් එක් ගොනුවක්වත් ඉතිරි විය යුතුය. එය මඟහරවා ගැනීමට සැකසීම්වල \"\'සියල්ල මකන්න\' හැකි කරන්න\" සක්‍රීය කරන්න.</string>
     <string name="deduplicator_progress_comparing_files">ගොනු සන්දර්භ කරමින්</string>
-    <string name="deduplicator_details_cluster_title">බහුපත සමුහය</string>
     <string name="deduplicator_matches_exact_label">නිවැරදි පිටපත්</string>
     <string name="deduplicator_matches_similar_label">සමාන ගොනු</string>
     <string name="deduplicator_arbiter_title">මකන උපාය මාර්ගය</string>

--- a/app-tool-deduplicator/src/main/res/values-sk/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sk/strings.xml
@@ -38,7 +38,6 @@
         <item quantity="many">%s je obsadených duplikátmi</item>
         <item quantity="other">%s je obsadených duplikátmi</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Veľkosť súboru</string>
     <string name="deduplicator_average_size_label">Priemerná veľkosť</string>
     <string name="deduplicator_cluster_x_label">Klaster %s</string>
     <string name="deduplicator_delete_confirmation_message">Chcete odstrániť všetky kópie okrem jednej zo všetkých skupín duplicitných súborov?</string>
@@ -60,7 +59,6 @@
     <string name="deduplicator_cluster_preview_image">Náhľad sady duplikátov</string>
     <string name="deduplicator_selection_keep_one_required">V každej sade duplikátov musí zostať aspoň jeden súbor. V nastaveniach zapnite „Umožniť ‘Zmazať všetko’“, aby ste toto prekonali.</string>
     <string name="deduplicator_progress_comparing_files">Porovnávanie súborov</string>
-    <string name="deduplicator_details_cluster_title">Skupina duplikátov</string>
     <string name="deduplicator_matches_exact_label">Presné kópie</string>
     <string name="deduplicator_matches_similar_label">Podobné súbory</string>
     <string name="deduplicator_arbiter_title">Stratégia odstraňovania</string>

--- a/app-tool-deduplicator/src/main/res/values-sl/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sl/strings.xml
@@ -38,7 +38,6 @@
         <item quantity="few">%s zasedajo dvojniki.</item>
         <item quantity="other">%s zasedajo dvojniki.</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Velikost datoteke</string>
     <string name="deduplicator_average_size_label">Povprečna velikost</string>
     <string name="deduplicator_cluster_x_label">Gruča %s</string>
     <string name="deduplicator_delete_confirmation_message">Izbriši vse razen ene kopije v vseh nizih podvojenih datotek?</string>
@@ -60,7 +59,6 @@
     <string name="deduplicator_cluster_preview_image">Predogled nabora podvojenih</string>
     <string name="deduplicator_selection_keep_one_required">V vsaki skupini podvojenih datotek mora ostati najmanj ena datoteka. Omogočite »Brisanje vseh« v nastavitvah, da to prepišete.</string>
     <string name="deduplicator_progress_comparing_files">Primerjanje datotek</string>
-    <string name="deduplicator_details_cluster_title">Niz dvojnikov</string>
     <string name="deduplicator_matches_exact_label">Natančne kopije</string>
     <string name="deduplicator_matches_similar_label">Podobne datoteke</string>
     <string name="deduplicator_arbiter_title">Strategija brisanja</string>

--- a/app-tool-deduplicator/src/main/res/values-sq-rAL/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sq-rAL/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s është zënë nga dublikata</item>
         <item quantity="other">%s janë zënë nga dublikata</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Madhësia e skedarit</string>
     <string name="deduplicator_average_size_label">Madhësia mesatare</string>
     <string name="deduplicator_cluster_x_label">Tog %s</string>
     <string name="deduplicator_delete_confirmation_message">Të fshihen të gjitha, përveç një kopje, në të gjitha grupet e skedarëve dublikatë?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Paraparje e bashkësisë së dublikateve</string>
     <string name="deduplicator_selection_keep_one_required">Të paktën një skedar në çdo grup duplikatesh duhet të mbetet. Aktivizoni \"Bëj të mundur fshirjen e të gjithëve\" në cilësimet për ta anashkaluar këtë kufizim.</string>
     <string name="deduplicator_progress_comparing_files">Krahasimi i skedarëve</string>
-    <string name="deduplicator_details_cluster_title">Set duplikatesh</string>
     <string name="deduplicator_matches_exact_label">Kopje ekzakte</string>
     <string name="deduplicator_matches_similar_label">Skedarë të ngjashëm</string>
     <string name="deduplicator_arbiter_title">Strategjia e fshirjes</string>

--- a/app-tool-deduplicator/src/main/res/values-sr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sr/strings.xml
@@ -35,7 +35,6 @@
         <item quantity="few">%s су заузета дупликатима</item>
         <item quantity="other">%s је заузето дупликатима</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Величина датотеке</string>
     <string name="deduplicator_average_size_label">Просечна величина</string>
     <string name="deduplicator_cluster_x_label">Кластер %s</string>
     <string name="deduplicator_delete_confirmation_message">Обрисати све осим једне копије у свим скуповима дупликата?</string>
@@ -56,7 +55,6 @@
     <string name="deduplicator_cluster_preview_image">Преглед скупа дупликата</string>
     <string name="deduplicator_selection_keep_one_required">Најмање једна датотека по скупу дупликата мора остати. Омогућите „Избриши све” у подешавањима да то заобиђете.</string>
     <string name="deduplicator_progress_comparing_files">Поређење датотека</string>
-    <string name="deduplicator_details_cluster_title">Скуп дупликата</string>
     <string name="deduplicator_matches_exact_label">Тачне копије</string>
     <string name="deduplicator_matches_similar_label">Сличне датотеке</string>
     <string name="deduplicator_arbiter_title">Стратегија брисања</string>

--- a/app-tool-deduplicator/src/main/res/values-sv/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sv/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s upptas av dubbletter</item>
         <item quantity="other">%s upptas av dubbletter</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Filstorlek</string>
     <string name="deduplicator_average_size_label">Genomsnittlig storlek</string>
     <string name="deduplicator_cluster_x_label">Kluster %s</string>
     <string name="deduplicator_delete_confirmation_message">Ta bort alla utom en kopia i alla uppsättningar av duplicerade filer?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Förhandsgranskning av dubblettuppsättning</string>
     <string name="deduplicator_selection_keep_one_required">Minst en fil per uppsättning duplicerade måste behållas. Aktivera \"Gör \'Ta bort alla\' möjligt\" i inställningarna för att åsidosätta.</string>
     <string name="deduplicator_progress_comparing_files">Jämför filer</string>
-    <string name="deduplicator_details_cluster_title">Uppsättning av dubbletter</string>
     <string name="deduplicator_matches_exact_label">Exakta kopior</string>
     <string name="deduplicator_matches_similar_label">Liknande filer</string>
     <string name="deduplicator_arbiter_title">Raderingsstrategi</string>

--- a/app-tool-deduplicator/src/main/res/values-sw/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-sw/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s inatumika na nakala</item>
         <item quantity="other">%s zinatumika na nakala</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Ukubwa wa faili</string>
     <string name="deduplicator_average_size_label">Ukubwa wa wastani</string>
     <string name="deduplicator_cluster_x_label">Kundi %s</string>
     <string name="deduplicator_delete_confirmation_message">Futa nakala zote isipokuwa moja katika seti zote za faili za nakala?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Muonekano wa seti ya nakala</string>
     <string name="deduplicator_selection_keep_one_required">Angalau faili moja katika kila seti ya nakala lazima ibaki. Washa \"Fanya \'Futa zote\' iwezekane\" katika mipangilio ili kuondoa kizuizi hiki.</string>
     <string name="deduplicator_progress_comparing_files">Inalinganisha faili</string>
-    <string name="deduplicator_details_cluster_title">Seti ya nakala</string>
     <string name="deduplicator_matches_exact_label">Nakala kamili</string>
     <string name="deduplicator_matches_similar_label">Faili zinazofanana</string>
     <string name="deduplicator_arbiter_title">Mkakati wa kufuta</string>

--- a/app-tool-deduplicator/src/main/res/values-ta-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ta-rIN/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s நகல்களால் ஆக்ரமிக்கப்பட்டுள்ளது</item>
         <item quantity="other">%s நகல்களால் ஆக்ரமிக்கப்பட்டுள்ளன</item>
     </plurals>
-    <string name="deduplicator_file_size_label">கோப்பு அளவு</string>
     <string name="deduplicator_average_size_label">சராசரி அளவு</string>
     <string name="deduplicator_cluster_x_label">தொகுதி %s</string>
     <string name="deduplicator_delete_confirmation_message">அனைத்து நகல் கோப்பு தொகுதிகளிலும் ஒரு நகலை தவிர மற்ற அனைத்தையும் நீக்கவா?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">நகல் தொகுப்பு முன்னோட்டம்</string>
     <string name="deduplicator_selection_keep_one_required">ஒவ்வொரு நகல் தொகுப்புக்கும் குறைந்தது ஒரு கோப்பு இருக்க வேண்டும். இதை மீற அமைப்புகளில் \"அனைத்தையும் நீக்க முடியுமாக உருவாக்கவும்\" இயக்கவும்.</string>
     <string name="deduplicator_progress_comparing_files">கோப்புகளை ஒப்பிடுகிறது</string>
-    <string name="deduplicator_details_cluster_title">நகல்களின் தொகுதி</string>
     <string name="deduplicator_matches_exact_label">சரியான நகல்கள்</string>
     <string name="deduplicator_matches_similar_label">ஒத்த கோப்புகள்</string>
     <string name="deduplicator_arbiter_title">நீக்கும் உத்தி</string>

--- a/app-tool-deduplicator/src/main/res/values-te-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-te-rIN/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s డుప్లికేట్‌లు ఆక్రమించాయి</item>
         <item quantity="other">%s డుప్లికేట్‌లు ఆక్రమించాయి</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ఫైల్ పరిమాణం</string>
     <string name="deduplicator_average_size_label">సరాసరి పరిమాణం</string>
     <string name="deduplicator_cluster_x_label">క్లస్టర్ %s</string>
     <string name="deduplicator_delete_confirmation_message">డుప్లికేట్ ఫైల్‌ల అన్ని సెట్‌లలో ఒక కాపీ కలిపి మిగిలిన మిందినిన్ని తొలగించాలా?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">నకిలు సమితి ప్రివ్యూ</string>
     <string name="deduplicator_selection_keep_one_required">ప్రతి నకిలు సెట్‌కు కనీసం ఒక ఫైల్ ఉండాలి. సెట్టింగ్‌లలో \"అన్నీ తీసివేయండి\" సాధ్యమైనదిని ఎనేబుల్ చేయండి.</string>
     <string name="deduplicator_progress_comparing_files">ఫైల్‌లను పోలిస్తోంది</string>
-    <string name="deduplicator_details_cluster_title">డుప్లికేట్‌ల సెట్</string>
     <string name="deduplicator_matches_exact_label">పూర్తి సరియాన కాపీలు</string>
     <string name="deduplicator_matches_similar_label">సమానమైన ఫైల్‌లు</string>
     <string name="deduplicator_arbiter_title">తొలగింపు వ్యూహం</string>

--- a/app-tool-deduplicator/src/main/res/values-th/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-th/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s ถูกใช้งานโดยไฟล์ซ้ำ</item>
     </plurals>
-    <string name="deduplicator_file_size_label">ขนาดไฟล์</string>
     <string name="deduplicator_average_size_label">ขนาดเฉลี่ย</string>
     <string name="deduplicator_cluster_x_label">กลุ่ม %s</string>
     <string name="deduplicator_delete_confirmation_message">ลบไฟล์ซ้ำทั้งหมดโดยเหลือไว้เพียงไฟล์เดียวในแต่ละกลุ่ม?</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">ตัวอย่างชุดรายการที่ซ้ำกัน</string>
     <string name="deduplicator_selection_keep_one_required">อย่างน้อยหนึ่งไฟล์ต่อชุดที่ซ้ำกันต้องเหลืออยู่ เปิดใช้งาน \"ทำให้ \'ลบทั้งหมด\' เป็นไปได้\" ในการตั้งค่าเพื่อข้ามข้อจำกัดนี้</string>
     <string name="deduplicator_progress_comparing_files">กำลังเปรียบเทียบไฟล์</string>
-    <string name="deduplicator_details_cluster_title">กลุ่มไฟล์ซ้ำ</string>
     <string name="deduplicator_matches_exact_label">ไฟล์เหมือนกันทุกประการ</string>
     <string name="deduplicator_matches_similar_label">ไฟล์ที่คล้ายกัน</string>
     <string name="deduplicator_arbiter_title">กลยุทธ์การลบ</string>

--- a/app-tool-deduplicator/src/main/res/values-tr/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-tr/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s kopyalar tarafından işgal edilmiş</item>
         <item quantity="other">%s kopyalar tarafından işgal edilmiş</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Dosya boyutu</string>
     <string name="deduplicator_average_size_label">Ortalama boyut</string>
     <string name="deduplicator_cluster_x_label">Küme %s</string>
     <string name="deduplicator_delete_confirmation_message">Tüm yinelenen dosya kümelerinde bir kopya hariç tümünü silinsin mi?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Yinelenen set önizlemesi</string>
     <string name="deduplicator_selection_keep_one_required">Her yinelenen set başına en az bir dosya kalmalıdır. Bunu geçersiz kılmak için ayarlarda \"Tümünü silmeyi mümkün yap\" seçeneğini etkinleştirin.</string>
     <string name="deduplicator_progress_comparing_files">Dosyalar karşılaştırılıyor</string>
-    <string name="deduplicator_details_cluster_title">Yinelenenler kümesi</string>
     <string name="deduplicator_matches_exact_label">Birebir kopyalar</string>
     <string name="deduplicator_matches_similar_label">Benzer dosyalar</string>
     <string name="deduplicator_arbiter_title">Silme stratejisi</string>

--- a/app-tool-deduplicator/src/main/res/values-uk/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-uk/strings.xml
@@ -38,7 +38,6 @@
         <item quantity="many">%s зайнято дублікатами</item>
         <item quantity="other">%s зайнято дублікатами</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Розмір файлу</string>
     <string name="deduplicator_average_size_label">Середній розмір</string>
     <string name="deduplicator_cluster_x_label">Кластер %s</string>
     <string name="deduplicator_delete_confirmation_message">Видалити всі копії, крім однієї, у всіх наборах дублікатів файлів?</string>
@@ -60,7 +59,6 @@
     <string name="deduplicator_cluster_preview_image">Попередній перегляд набору дублікатів</string>
     <string name="deduplicator_selection_keep_one_required">Щонайменше один файл на набір дублікатів має залишитися. Увімкніть у налаштуваннях «Зробити «Видалити все» можливим», щоб це обійти.</string>
     <string name="deduplicator_progress_comparing_files">Порівняння файлів</string>
-    <string name="deduplicator_details_cluster_title">Набір дублікатів</string>
     <string name="deduplicator_matches_exact_label">Точні копії</string>
     <string name="deduplicator_matches_similar_label">Схожі файли</string>
     <string name="deduplicator_arbiter_title">Стратегія видалення</string>

--- a/app-tool-deduplicator/src/main/res/values-ur-rIN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-ur-rIN/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s ڈپلیکیٹس کے ذریعے قبضہ میں ہے</item>
         <item quantity="other">%s ڈپلیکیٹس کے ذریعے قبضہ میں ہیں</item>
     </plurals>
-    <string name="deduplicator_file_size_label">فائل سائز</string>
     <string name="deduplicator_average_size_label">اوسط سائز</string>
     <string name="deduplicator_cluster_x_label">کلسٹر %s</string>
     <string name="deduplicator_delete_confirmation_message">ڈپلیکیٹ فائلوں کے تمام سیٹس میں ایک کاپی چھوڑ کر باقی تمام ڈیلیٹ کریں؟</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">نقل سیٹ کی پریویو</string>
     <string name="deduplicator_selection_keep_one_required">ہر نقل سیٹ میں کم از کم ایک فائل برقرار رہنی چاہیے۔ سیٹنگز میں \"تمام کو حذف کرنا ممکن بنائیں\" کو فعال کریں۔</string>
     <string name="deduplicator_progress_comparing_files">فائلوں کی موازنہ</string>
-    <string name="deduplicator_details_cluster_title">ڈپلیکیٹس کا سیٹ</string>
     <string name="deduplicator_matches_exact_label">بالکل طور پر کاپیاں</string>
     <string name="deduplicator_matches_similar_label">مشابہ فائلیں</string>
     <string name="deduplicator_arbiter_title">حذف کی حکمت عملی</string>

--- a/app-tool-deduplicator/src/main/res/values-uz/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-uz/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s takrorlanganlar tomonidan band qilingan</item>
         <item quantity="other">%s takrorlanganlar tomonidan band qilingan</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Fayl hajmi</string>
     <string name="deduplicator_average_size_label">O\'rtacha hajm</string>
     <string name="deduplicator_cluster_x_label">Klaster %s</string>
     <string name="deduplicator_delete_confirmation_message">Takrorlangan fayllarning barcha to\'plamlarida bitta nusxadan tashqari hammasini o\'chirish kerakmi?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Nusxalar to\'plamini ko\'rib chiqish</string>
     <string name="deduplicator_selection_keep_one_required">Har bir nusxalar to\'plamidan kamida bitta fayl qolishi kerak. Buni bekor qilish uchun sozlamalarda \"Barchasini o\'chirish\"ni yoqing.</string>
     <string name="deduplicator_progress_comparing_files">Fayllarni solishtirish</string>
-    <string name="deduplicator_details_cluster_title">Takrorlanganlar to\'plami</string>
     <string name="deduplicator_matches_exact_label">Aniq nusxalar</string>
     <string name="deduplicator_matches_similar_label">O\'xshash fayllar</string>
     <string name="deduplicator_arbiter_title">O\'chirish strategiyasi</string>

--- a/app-tool-deduplicator/src/main/res/values-vi/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-vi/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s bị chiếm bởi các bản sao</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Kích thước tệp</string>
     <string name="deduplicator_average_size_label">Kích thước trung bình</string>
     <string name="deduplicator_cluster_x_label">Cụm %s</string>
     <string name="deduplicator_delete_confirmation_message">Xóa tất cả trừ một bản sao trong tất cả các bộ tệp trùng lặp?</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">Xem trước tập hợp bản sao</string>
     <string name="deduplicator_selection_keep_one_required">Phải giữ lại ít nhất một tệp trong mỗi bộ trùng lặp. Bật tùy chọn \"Cho phép \'Xóa tất cả\'\" trong cài đặt để ghi đè.</string>
     <string name="deduplicator_progress_comparing_files">So sánh các tập tin</string>
-    <string name="deduplicator_details_cluster_title">Tập hợp các bản sao</string>
     <string name="deduplicator_matches_exact_label">Bản sao chính xác</string>
     <string name="deduplicator_matches_similar_label">Các tập tin tương tự</string>
     <string name="deduplicator_arbiter_title">Chiến lược xóa</string>

--- a/app-tool-deduplicator/src/main/res/values-zh-rCN/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zh-rCN/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">重复项占用 %s</item>
     </plurals>
-    <string name="deduplicator_file_size_label">文件大小</string>
     <string name="deduplicator_average_size_label">平均大小</string>
     <string name="deduplicator_cluster_x_label">集群 %s</string>
     <string name="deduplicator_delete_confirmation_message">删除所有重复文件组中除一份副本之外的所有副本？</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">重复项集合预览</string>
     <string name="deduplicator_selection_keep_one_required">每个重复文件集合中至少必须保留一个文件。在设置中启用“使‘全部删除’成为可能”来覆盖此限制。</string>
     <string name="deduplicator_progress_comparing_files">正在比较文件</string>
-    <string name="deduplicator_details_cluster_title">重复组</string>
     <string name="deduplicator_matches_exact_label">完全相同</string>
     <string name="deduplicator_matches_similar_label">相似文件</string>
     <string name="deduplicator_arbiter_title">删除策略</string>

--- a/app-tool-deduplicator/src/main/res/values-zh-rHK/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zh-rHK/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s 被重複項佔用</item>
     </plurals>
-    <string name="deduplicator_file_size_label">文件大小</string>
     <string name="deduplicator_average_size_label">平均大小</string>
     <string name="deduplicator_cluster_x_label">集群 %s</string>
     <string name="deduplicator_delete_confirmation_message">你要刪除所有重複文件組中的重複副本（保留一個副本）嗎？</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">重複項目組預覽</string>
     <string name="deduplicator_selection_keep_one_required">每個重複項目組合中必須保留至少一個檔案。在設定中啟用「讓「全部刪除」成為可能」以覆蓋此限制。</string>
     <string name="deduplicator_progress_comparing_files">正在比對文件</string>
-    <string name="deduplicator_details_cluster_title">一組副本</string>
     <string name="deduplicator_matches_exact_label">精確副本</string>
     <string name="deduplicator_matches_similar_label">相似文件</string>
     <string name="deduplicator_arbiter_title">刪除策略</string>

--- a/app-tool-deduplicator/src/main/res/values-zh-rTW/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zh-rTW/strings.xml
@@ -29,7 +29,6 @@
     <plurals name="deduplicator_x_space_occupied_by_duplicates_msg">
         <item quantity="other">%s 被重複項目佔用</item>
     </plurals>
-    <string name="deduplicator_file_size_label">檔案大小</string>
     <string name="deduplicator_average_size_label">平均大小</string>
     <string name="deduplicator_cluster_x_label">叢集 %s</string>
     <string name="deduplicator_delete_confirmation_message">刪除所有組重複檔案中除一份複本之外的所有複本？</string>
@@ -48,7 +47,6 @@
     <string name="deduplicator_cluster_preview_image">重複集合預覽</string>
     <string name="deduplicator_selection_keep_one_required">每個重複檔案集合中至少必須保留一個檔案。在設定中啟用「允許刪除全部」選項可以覆寫此限制。</string>
     <string name="deduplicator_progress_comparing_files">正在比較檔案</string>
-    <string name="deduplicator_details_cluster_title">重複檔案組</string>
     <string name="deduplicator_matches_exact_label">完全重複</string>
     <string name="deduplicator_matches_similar_label">相似檔案</string>
     <string name="deduplicator_arbiter_title">刪除策略</string>

--- a/app-tool-deduplicator/src/main/res/values-zu/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values-zu/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">I-%s ihleli okukhophisiwe</item>
         <item quantity="other">I-%s zihleli okukhophisiwe</item>
     </plurals>
-    <string name="deduplicator_file_size_label">Usayizi wefayela</string>
     <string name="deduplicator_average_size_label">Usayizi wesilinganiso</string>
     <string name="deduplicator_cluster_x_label">Iqembu %s</string>
     <string name="deduplicator_delete_confirmation_message">Susa konke ngaphandle kwekhophi eyodwa kuwo wonke amasethe amafayela akhophisiwe?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Isiqalo selolungiselelo lweisethi yokufanayo</string>
     <string name="deduplicator_selection_keep_one_required">Okungenani ifayela elilodwa ngosizwe sokudubha kufanele lihlale. Vula u-\'Yenza \"Susa konke\" ikwazi\' ezinikithaseni ukuze ubuyele umva.</string>
     <string name="deduplicator_progress_comparing_files">Kuqhathanisa amafayela</string>
-    <string name="deduplicator_details_cluster_title">Isethe sokukhophisa</string>
     <string name="deduplicator_matches_exact_label">Amakhophi aqondile</string>
     <string name="deduplicator_matches_similar_label">Amafayela afanayo</string>
     <string name="deduplicator_arbiter_title">Isu lokususa</string>

--- a/app-tool-deduplicator/src/main/res/values/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values/strings.xml
@@ -32,7 +32,6 @@
         <item quantity="one">%s is occupied by duplicates</item>
         <item quantity="other">%s are occupied by duplicates</item>
     </plurals>
-    <string name="deduplicator_file_size_label">File size</string>
     <string name="deduplicator_average_size_label">Average size</string>
     <string name="deduplicator_cluster_x_label">Cluster %s</string>
     <string name="deduplicator_delete_confirmation_message">Delete all but one copy in all sets of duplicate files?</string>
@@ -52,7 +51,6 @@
     <string name="deduplicator_cluster_preview_image">Duplicate set preview</string>
     <string name="deduplicator_selection_keep_one_required">At least one file per duplicate set must remain. Enable \"Make \'Delete all\' possible\" in settings to override.</string>
     <string name="deduplicator_progress_comparing_files">Comparing files</string>
-    <string name="deduplicator_details_cluster_title">Set of duplicates</string>
     <string name="deduplicator_matches_exact_label">Exact copies</string>
     <string name="deduplicator_matches_similar_label">Similar files</string>
     <string name="deduplicator_arbiter_title">Deletion strategy</string>

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Moenie Shizuku gebruik nie</string>
     <string name="setup_dismiss_hint">Jy kan die opstelling skerm weer vind via die instellings menu.</string>
     <string name="setup_permission_granted_label">Toestemming verleen</string>
-    <string name="setup_permission_error_label">Toestemming fout</string>
-    <string name="setup_inventory_invalid_label">Ongeldige app-lys</string>
     <string name="setup_usagestats_title">Gebruik statistieke</string>
     <string name="setup_usagestats_body">Die gebruik statistieke toestemming verleen toegang tot meer toepassing besonderhede. SD Maid gebruik dit om addisionele kas groottes te bepaal.</string>
     <string name="setup_usagestats_hint">Nodig vir toeganklikheid diens gebaseerde kas skrapping.</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">ሺዙኩን አትጠቀም</string>
     <string name="setup_dismiss_hint">የማዋቀሪያ ስክሪኑን ከቅንብሮች ምናሌ በኩል እንደገና ማግኘት ይችላሉ।</string>
     <string name="setup_permission_granted_label">ፈቃድ ተሰጥቷል</string>
-    <string name="setup_permission_error_label">የፈቃድ ስህተት</string>
-    <string name="setup_inventory_invalid_label">ልክ ያልሆነ የመተግበሪያ ዝርዝር</string>
     <string name="setup_usagestats_title">የአጠቃቀም ስታቲስቲክስ</string>
     <string name="setup_usagestats_body">የአጠቃቀም ስታቲስቲክስ ፈቃድ ወደ ተጨማሪ የመተግበሪያ ዝርዝሮች መዳረሻን ይሰጣል። ኤስዲ ሜይድ ተጨማሪ የመሸጎጫ መጠኖችን ለመለካት ይጠቀምበታል።</string>
     <string name="setup_usagestats_hint">በተደራሽነት አገልግሎት ላይ ለተመሰረተ የመሸጎጫ ማጥፋት ያስፈልጋል።</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -298,8 +298,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">لا تستخدم شيزوكو</string>
     <string name="setup_dismiss_hint">يمكنك العثور على شاشة الإعداد مرة أخرى عبر قائمة الإعدادات.</string>
     <string name="setup_permission_granted_label">تم منح الصَّلاحِيَة</string>
-    <string name="setup_permission_error_label">خطأ في الإذن</string>
-    <string name="setup_inventory_invalid_label">قائمة التطبيقات غير صالحة</string>
     <string name="setup_usagestats_title">بيانات الاستخدام</string>
     <string name="setup_usagestats_body">يمنح إذن إحصائيات الاستخدام إمكانية الوصول إلى مزيد من تفاصيل التطبيق. يستخدم SD Maid لتحديد أحجام ذاكرة التخزين المؤقت الإضافية.</string>
     <string name="setup_usagestats_hint">مطلوب لحذف ذاكرة التخزين المؤقت المستندة إلى خدمة الوصول.</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku-dan istifadə etməyin</string>
     <string name="setup_dismiss_hint">Parametrlər menyusu vasitəsilə quraşdırma ekranını tapa bilərsiniz.</string>
     <string name="setup_permission_granted_label">Icazə verildi</string>
-    <string name="setup_permission_error_label">İcazə xətası</string>
-    <string name="setup_inventory_invalid_label">Qeyri-etibarlı tətbiq siyahısı</string>
     <string name="setup_usagestats_title">İstifadə statistikası</string>
     <string name="setup_usagestats_body">İstifadə statistikası icazəsi daha çox tətbiq təfərrüatına giriş imkanı verir. SD Maid bunu əlavə keş ölçülərini müəyyən etmək üçün istifadə edir.</string>
     <string name="setup_usagestats_hint">Əlçatanlılıq xidməti əsasında keş silmə üçün tələb olunur.</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -282,8 +282,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Не выкарыстоўваць Shizuku</string>
     <string name="setup_dismiss_hint">Вы можаце зноў знайсці экран наладжвання ў меню налад.</string>
     <string name="setup_permission_granted_label">Дазвол дадзены</string>
-    <string name="setup_permission_error_label">Памылка доступу</string>
-    <string name="setup_inventory_invalid_label">Няправільны спіс прыкладанняў</string>
     <string name="setup_usagestats_title">Статыстыка выкарыстання</string>
     <string name="setup_usagestats_body">Дазвол на аналіз статыстыкі выкарыстання дае доступ да дадатковай інфармацыі пра праграму. SD Maid выкарыстоўвае яго для вызначэння дадатковых памераў кэшу.</string>
     <string name="setup_usagestats_hint">Патрабуецца для выдалення кэшу з дапамогай службы спецыяльных магчымасцей.</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Не използвайте Shizuku</string>
     <string name="setup_dismiss_hint">Можете да намерите екрана за настройка чрез менюто с настройки.</string>
     <string name="setup_permission_granted_label">Разрешението е предоставено</string>
-    <string name="setup_permission_error_label">Грешка в разрешението</string>
-    <string name="setup_inventory_invalid_label">Невалиден списък с приложения</string>
     <string name="setup_usagestats_title">Статистики за използване</string>
     <string name="setup_usagestats_body">Разрешението за статистики за използване предоставя достъп до повече подробности за приложенията. SD Maid го използва за определяне на допълнителни размери на кеш.</string>
     <string name="setup_usagestats_hint">Необходимо за изтриване на кеш базирано на услуги за достъпност.</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku ব্যবহার করবেন না।</string>
     <string name="setup_dismiss_hint">আপনি সেটিংস মেনুর মাধ্যমে আবার সেটআপ স্ক্রীনটি খুঁজে পেতে পারেন।</string>
     <string name="setup_permission_granted_label">অনুমতি মঞ্জুর করা হয়েছে</string>
-    <string name="setup_permission_error_label">অনুমতি ত্রুটি</string>
-    <string name="setup_inventory_invalid_label">অবৈধ অ্যাপ তালিকা।</string>
     <string name="setup_usagestats_title">ব্যবহারের পরিসংখ্যান</string>
     <string name="setup_usagestats_body">অ্যাপের বিস্তারিত তথ্যের জন্য Statistics permission এর অনুমতি দিন। SD Maid এটি ব্যবহার করবে অবশিষ্ট cache সাইজ নির্ধারণ করতে।</string>
     <string name="setup_usagestats_hint">অ্যাক্সেসিবিলিটি পরিষেবাভিত্তিক cache মোছার জন্য প্রয়োজন৷</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">No utilitzis Shizuku</string>
     <string name="setup_dismiss_hint">Podeu tornar a trobar la pantalla de configuració mitjançant el menú de configuració.</string>
     <string name="setup_permission_granted_label">Permís concedit</string>
-    <string name="setup_permission_error_label">Error de permís</string>
-    <string name="setup_inventory_invalid_label">Llista d\'aplicacions no vàlida</string>
     <string name="setup_usagestats_title">Estadístiques d\'ús</string>
     <string name="setup_usagestats_body">El permís d\'estadístiques d\'ús permet accedir a més detalls de l\'aplicació. L\'SD Maid l\'utilitza per determinar mides de memòria cau addicionals.</string>
     <string name="setup_usagestats_hint">Necessari per a la supressió de la memòria cau basada en el servei d\'accessibilitat.</string>

--- a/app/src/main/res/values-ckb-rIR/strings.xml
+++ b/app/src/main/res/values-ckb-rIR/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku بەکارنەبە</string>
     <string name="setup_dismiss_hint">دەتوانیت رووپەڕی ڕێکخستن دیسان لە مێنووی ڕێکخستنەکانەوە بدۆزیتەوە.</string>
     <string name="setup_permission_granted_label">مۆڵەت درابوو</string>
-    <string name="setup_permission_error_label">هەڵەی مۆڵەت</string>
-    <string name="setup_inventory_invalid_label">لیستی ئەپلیکێشنی نادرووست</string>
     <string name="setup_usagestats_title">ئامارەکانی بەکارهێنان</string>
     <string name="setup_usagestats_body">مۆڵەتی ئامارەکانی بەکارهێنان دەسیەڵات بە وردەکاری زیاتری ئەپەکان دەدات. SD Maid بەکاری دەهێنێت بۆ دیاریکردنی قەبارەی کاش زیادە.</string>
     <string name="setup_usagestats_hint">پێویستە بۆ سڕینەوەی کاش لەسەر بنەمای خزمەتگوزاری دەستڕاگەیشتن.</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -282,8 +282,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Nepoužít Shizuku</string>
     <string name="setup_dismiss_hint">Obrazovku úvodního nastavení najdete opět v nabídce nastavení.</string>
     <string name="setup_permission_granted_label">Oprávnění uděleno</string>
-    <string name="setup_permission_error_label">Chyba oprávnění</string>
-    <string name="setup_inventory_invalid_label">Neplatný seznam aplikací</string>
     <string name="setup_usagestats_title">Statistiky používání</string>
     <string name="setup_usagestats_body">Oprávnění ke statistikám používání umožňuje přístup k dalším podrobnostem o aplikaci. SD Maid je používá k určení dalších velikostí mezipaměti.</string>
     <string name="setup_usagestats_hint">Vyžadováno pro mazání mezipaměti na základě služby přístupnosti.</string>

--- a/app/src/main/res/values-cy/strings.xml
+++ b/app/src/main/res/values-cy/strings.xml
@@ -98,7 +98,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Peidio â defnyddio Shizuku</string>
     <string name="setup_dismiss_hint">Gallwch ddod o hyd i\'r sgrin gosod eto drwy\'r ddewislen gosodiadau.</string>
     <string name="setup_permission_granted_label">Caniatâd wedi\'i roi</string>
-    <string name="setup_permission_error_label">Gwall caniatâd</string>
     <string name="setup_usagestats_title">Ystadegau defnydd</string>
     <string name="setup_usagestats_body">Mae\'r caniatâd ystadegau defnydd yn rhoi mynediad i ragor o fanylion apiau. Mae SD Maid yn ei ddefnyddio i bennu meintiau cache ychwanegol.</string>
     <string name="setup_usagestats_hint">Yn ofynnol ar gyfer dileu cache yn seiliedig ar wasanaeth hygyrchedd.</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Brug ikke Shizuku</string>
     <string name="setup_dismiss_hint">Du kan finde opsætningsskærmen igen via indstillingsmenuen.</string>
     <string name="setup_permission_granted_label">Tilladelse givet</string>
-    <string name="setup_permission_error_label">Tilladelsesfejl</string>
-    <string name="setup_inventory_invalid_label">Ugyldig appliste</string>
     <string name="setup_usagestats_title">Brugsstatistik</string>
     <string name="setup_usagestats_body">Tilladelsen til brugsstatistik giver adgang til flere appdetaljer. SD Maid bruger den til at afgøre flere cachestørrelser.</string>
     <string name="setup_usagestats_hint">Påkrævet for tilgængelighedstjenestebaseret cachesletning.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku nicht verwenden</string>
     <string name="setup_dismiss_hint">Du kannst die Einrichtung im Einstellungsmenü wiederfinden.</string>
     <string name="setup_permission_granted_label">Erlaubnis erteilt</string>
-    <string name="setup_permission_error_label">Berechtigungsfehler</string>
-    <string name="setup_inventory_invalid_label">Ungültige App-Liste</string>
     <string name="setup_usagestats_title">Nutzungsstatistiken</string>
     <string name="setup_usagestats_body">Die Nutzungsstatistiken-Berechtigung gewährt Zugriff auf weitere App-Details. SD Maid verwendet sie, um zusätzliche Cache-Größen zu ermitteln.</string>
     <string name="setup_usagestats_hint">Erforderlich für das Löschen des Caches auf der Grundlage des Zugriffsdiensts.</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Να μη χρησιμοποιηθεί το Shizuku</string>
     <string name="setup_dismiss_hint">Μπορείτε να βρείτε ξανά την οθόνη εγκατάστασης μέσω του μενού ρυθμίσεων.</string>
     <string name="setup_permission_granted_label">Χορηγήθηκε πρόσβαση</string>
-    <string name="setup_permission_error_label">Σφάλμα δικαιωμάτων</string>
-    <string name="setup_inventory_invalid_label">Μη έγκυρη λίστα εφαρμογών</string>
     <string name="setup_usagestats_title">Στατιστικά χρήσης</string>
     <string name="setup_usagestats_body">Η άδεια στατιστικών χρήσης παρέχει πρόσβαση σε περισσότερες λεπτομέρειες εφαρμογής. Το SD Maid το χρησιμοποιεί για να καθορίσει πρόσθετα μεγέθη κρυφής μνήμης.</string>
     <string name="setup_usagestats_hint">Απαιτείται για διαγραφή προσωρινής μνήμης βάσει υπηρεσίας προσβασιμότητας.</string>

--- a/app/src/main/res/values-eo/strings.xml
+++ b/app/src/main/res/values-eo/strings.xml
@@ -98,7 +98,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Ne uzi Shizuku</string>
     <string name="setup_dismiss_hint">Vi povas trovi la agordan ekranon denove per la agorda menuo.</string>
     <string name="setup_permission_granted_label">Permeso donita</string>
-    <string name="setup_permission_error_label">Permesa eraro</string>
     <string name="setup_usagestats_title">Uzaj statistikoj</string>
     <string name="setup_usagestats_body">La permeso de uzaj statistikoj donas aliron al pli da aplikaĵaj detaloj. SD Maid uzas ĝin por determini aldonajn kaŝmemorajn grandecojn.</string>
     <string name="setup_usagestats_hint">Bezonata por alirebleca servo bazita kaŝmemora forigo.</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">No usar Shizuku</string>
     <string name="setup_dismiss_hint">Podés volver a encontrar la pantalla de configuración mediante el menú de la configuración.</string>
     <string name="setup_permission_granted_label">Permiso concedido</string>
-    <string name="setup_permission_error_label">Error de permiso</string>
-    <string name="setup_inventory_invalid_label">Lista de aplicaciones no válida</string>
     <string name="setup_usagestats_title">Estadísticas de uso</string>
     <string name="setup_usagestats_body">El permiso de Estadísticas de uso permite el acceso a más detalles de aplicaciones. SD Maid lo usa para determinar tamaños de caché adicionales.</string>
     <string name="setup_usagestats_hint">Requerido para la eliminación de caché basado en el servicio de accesibilidad.</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">No usar Shizuku</string>
     <string name="setup_dismiss_hint">Puedes encontrar la pantalla de configuración nuevamente vía el menú de configuración.</string>
     <string name="setup_permission_granted_label">Permiso concedido</string>
-    <string name="setup_permission_error_label">Error de permiso</string>
-    <string name="setup_inventory_invalid_label">Lista de aplicaciones inválida</string>
     <string name="setup_usagestats_title">Estadísticas de uso</string>
     <string name="setup_usagestats_body">El permiso de estadísticas de uso otorga acceso a más detalles de aplicaciones. SD Maid lo usa para determinar tamaños adicionales de caché.</string>
     <string name="setup_usagestats_hint">Requerido para eliminación de caché basada en servicio de accesibilidad.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">No utilizar Shizuku</string>
     <string name="setup_dismiss_hint">Puedes volver a encontrar la pantalla de configuración a través del menú de la configuración.</string>
     <string name="setup_permission_granted_label">Permiso concedido</string>
-    <string name="setup_permission_error_label">Error de autorización</string>
-    <string name="setup_inventory_invalid_label">Lista de aplicaciones inválida</string>
     <string name="setup_usagestats_title">Estadísticas de uso</string>
     <string name="setup_usagestats_body">El permiso de estadísticas de uso concede acceso a más detalles de la aplicación. SD Maid lo usa para determinar tamaños de caché adicionales.</string>
     <string name="setup_usagestats_hint">Necesaria para la eliminación de la caché basada en el servicio de accesibilidad.</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Ära kasuta Shizukut</string>
     <string name="setup_dismiss_hint">Seadistamisekraani leiate taas seadete menüüst.</string>
     <string name="setup_permission_granted_label">Lubatud</string>
-    <string name="setup_permission_error_label">Lubamise tõrge</string>
-    <string name="setup_inventory_invalid_label">Vigane rakenduste loend</string>
     <string name="setup_usagestats_title">Kasutusstatistika</string>
     <string name="setup_usagestats_body">Kasutusstatistika luba annab juurdepääsetavuse rakenduse täpsematele andmetele. SD Maid tuvastab nendega muidu märkamatuks jäävat vahemälu mahtu.</string>
     <string name="setup_usagestats_hint">Vaja juurdepääsetavusteenusel põhineva vahemälu kustutamiseks.</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Ez erabili Shizuku</string>
     <string name="setup_dismiss_hint">Konfigurazio-pantaila berriro aurki dezakezu ezarpenen menua bidez.</string>
     <string name="setup_permission_granted_label">Baimena emanda</string>
-    <string name="setup_permission_error_label">Baimen-errorea</string>
-    <string name="setup_inventory_invalid_label">Aplikazio zerrenda baliogabea</string>
     <string name="setup_usagestats_title">Erabilera-estatistikak</string>
     <string name="setup_usagestats_body">Erabilera-estatistiken baimenarekin aplikazio-xehetasun gehiago atzitu daitezke. SD Maid-ek cache tamaina gehigarriak zehazteko erabiltzen du.</string>
     <string name="setup_usagestats_hint">Beharrezkoa irisgarritasun-zerbitzuan oinarritutako cache-ezabaketan.</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">عدم استفاده از Shizuku</string>
     <string name="setup_dismiss_hint">می‌توانید صفحه راه‌اندازی را از طریق منوی تنظیمات دوباره پیدا کنید.</string>
     <string name="setup_permission_granted_label">مجوز اعطا شد</string>
-    <string name="setup_permission_error_label">خطای دسترسی</string>
-    <string name="setup_inventory_invalid_label">فهرست برنامه نامعتبر</string>
     <string name="setup_usagestats_title">آمار استفاده</string>
     <string name="setup_usagestats_body">دسترسی به آمار استفاده، اجازه دسترسی به جزئیات بیشتری از برنامه را فراهم می‌کند. SD Maid از این دسترسی برای تعیین اندازه‌های اضافی حافظه پنهان استفاده می‌کند.</string>
     <string name="setup_usagestats_hint">برای حذف حافظه پنهان بر اساس خدمات دسترسی ضروری است.</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Älä käytä Shizukua</string>
     <string name="setup_dismiss_hint">Löydät asennusnäytön uudelleen asetusvalikosta.</string>
     <string name="setup_permission_granted_label">Lupa myönnetty</string>
-    <string name="setup_permission_error_label">Lupahvirhe</string>
-    <string name="setup_inventory_invalid_label">Virheellinen sovellusluettelo</string>
     <string name="setup_usagestats_title">Käyttötilastot</string>
     <string name="setup_usagestats_body">Käyttötilastolupa antaa pääsyn sovelluksen lisätietoihin. SD Maid käyttää sitä lisävälimuistien kokojen määrittämiseen.</string>
     <string name="setup_usagestats_hint">Vaaditaan esteettömyyspalveluun perustuvaa välimuistin poistoa varten.</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Huwag gamitin ang Shizuku</string>
     <string name="setup_dismiss_hint">Mahahanap ninyo ulit ang setup screen sa pamamagitan ng settings menu.</string>
     <string name="setup_permission_granted_label">Nabigyan ng permission</string>
-    <string name="setup_permission_error_label">Error sa permission</string>
-    <string name="setup_inventory_invalid_label">Invalid ang app list</string>
     <string name="setup_usagestats_title">Istatistika sa paggamit</string>
     <string name="setup_usagestats_body">Ang usage statistics permission ay nagbibigay ng access sa mas maraming detalye ng app. Ginagamit ito ng SD Maid para malaman ang mga karagdagang cache size.</string>
     <string name="setup_usagestats_hint">Kailangan para sa accessibility service based cache deletion.</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Ne pas utiliser Shizuku</string>
     <string name="setup_dismiss_hint">Vous pouvez retrouver l’écran de configuration dans le menu des paramètres.</string>
     <string name="setup_permission_granted_label">L’autorisation a été accordée</string>
-    <string name="setup_permission_error_label">Erreur d’autorisation</string>
-    <string name="setup_inventory_invalid_label">Liste d’applis invalide</string>
     <string name="setup_usagestats_title">Statistiques d’utilisation</string>
     <string name="setup_usagestats_body">L’autorisation « Statistiques d’utilisation » donne l’accès à davantage de détails sur l’appli. SD Maid l’utilise pour déterminer les tailles de cache supplémentaires.</string>
     <string name="setup_usagestats_hint">Nécessaire pour la suppression du cache grâce au service d’accessibilité.</string>

--- a/app/src/main/res/values-ga/strings.xml
+++ b/app/src/main/res/values-ga/strings.xml
@@ -97,7 +97,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Ná húsáid Shizuku</string>
     <string name="setup_dismiss_hint">Is féidir leat an scailéan socrú a aiméir arís trí roghchlár na socruithe.</string>
     <string name="setup_permission_granted_label">Cead deonta</string>
-    <string name="setup_permission_error_label">Earráid ceada</string>
     <string name="setup_usagestats_title">Staitisticí úsáide</string>
     <string name="setup_usagestats_body">Tugann cead na staitisticí úsáide rochtain ar thuilleadh sonraí aipe. Úsáideann SD Maid é chun méideanna taisce bhreise a chinneadh.</string>
     <string name="setup_usagestats_hint">Riachtanach le haghaidh scriosadh taisce bunaithe ar sheirbhís inrochtaineachta.</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Non usar Shizuku</string>
     <string name="setup_dismiss_hint">Podes atopar a pantalla de configuración outra vez a través do menú de configuración.</string>
     <string name="setup_permission_granted_label">Permiso concedido</string>
-    <string name="setup_permission_error_label">Erro de permiso</string>
-    <string name="setup_inventory_invalid_label">Lista de aplicacións non válida</string>
     <string name="setup_usagestats_title">Estatísticas de uso</string>
     <string name="setup_usagestats_body">O permiso de estatísticas de uso concede acceso a máis detalles da aplicación. SD Maid úsao para determinar tamaños de caché adicionais.</string>
     <string name="setup_usagestats_hint">Requirido para a eliminación de caché baseada no servizo de accesibilidade.</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku का उपयोग न करें</string>
     <string name="setup_dismiss_hint">आप सेटिंग मेनू के माध्यम से व्यवस्था स्क्रीन फिर से पा सकते हैं।</string>
     <string name="setup_permission_granted_label">अनुमति प्रदान की गई</string>
-    <string name="setup_permission_error_label">अनुमति त्रुटि</string>
-    <string name="setup_inventory_invalid_label">अमान्य ऐप सूची</string>
     <string name="setup_usagestats_title">उपयोग के आँकड़े</string>
     <string name="setup_usagestats_body">उपयोग आँकड़े अनुमति अधिक ऐप विवरण तक पहुँच प्रदान करती है। SD मेड अतिरिक्त कैश आकार निर्धारित करने के लिए इसका उपयोग करती है।</string>
     <string name="setup_usagestats_hint">पहुंच-योग्यता सेवा आधारित संचय मिटाने के लिए आवश्यक है।</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -274,8 +274,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Ne koristi Shizuku</string>
     <string name="setup_dismiss_hint">Zaslon za postavljanje možete ponovno pronaći putem izbornika postavki.</string>
     <string name="setup_permission_granted_label">Dopuštenje odobreno</string>
-    <string name="setup_permission_error_label">Pogreška dopuštenja</string>
-    <string name="setup_inventory_invalid_label">Neispravan popis aplikacija</string>
     <string name="setup_usagestats_title">Statistike upotrebe</string>
     <string name="setup_usagestats_body">Dopuštenje za statistike upotrebe omogućuje pristup više pojedinosti o aplikacijama. SD Maid ga koristi za određivanje dodatnih veličina predmemorije.</string>
     <string name="setup_usagestats_hint">Potrebno za brisanje predmemorije na temelju usluge pristupačnosti.</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Ne használjon Shizuku-t</string>
     <string name="setup_dismiss_hint">A beállítási képernyőt ismét megtalálhatja a beállítások menüben.</string>
     <string name="setup_permission_granted_label">Hozzáférés megadva</string>
-    <string name="setup_permission_error_label">Jogosultsági hiba</string>
-    <string name="setup_inventory_invalid_label">Érvénytelen alkalmazáslista</string>
     <string name="setup_usagestats_title">Használati statisztikák</string>
     <string name="setup_usagestats_body">A használati statisztikák engedélye hozzáférést biztosít az alkalmazás további részleteihez. Az SD Maid további gyorsítótárméretek meghatározására használja.</string>
     <string name="setup_usagestats_hint">Szükséges a kisegítő lehetőségek szolgáltatás alapú gyorsítótár törléséhez.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Jangan gunakan Shizuku</string>
     <string name="setup_dismiss_hint">Kamu dapat menemukan layar penyiapan lagi melalui menu pengaturan.</string>
     <string name="setup_permission_granted_label">Izin diberikan</string>
-    <string name="setup_permission_error_label">Kesalahan perizinan</string>
-    <string name="setup_inventory_invalid_label">Daftar aplikasi tidak valid</string>
     <string name="setup_usagestats_title">Statistik penggunaan</string>
     <string name="setup_usagestats_body">Izin statistik penggunaan memberi akses ke lebih banyak detail aplikasi. SD Maid menggunakannya untuk menentukan ukuran cache tambahan.</string>
     <string name="setup_usagestats_hint">Diperlukan untuk penghapusan cache berbasis layanan aksesibilitas.</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Ekki nota Shizuku</string>
     <string name="setup_dismiss_hint">Þú getur fundið uppsetningarskjáinn aftur í gegnum stillingavalmynd.</string>
     <string name="setup_permission_granted_label">Leyfi veitt</string>
-    <string name="setup_permission_error_label">Villa í leyfi</string>
-    <string name="setup_inventory_invalid_label">Ógildur app-listi</string>
     <string name="setup_usagestats_title">Notkunartölfræði</string>
     <string name="setup_usagestats_body">Notkunartölfræðileyfið veitir aðgang að nánari upplýsingum um forrit. SD Maid notar það til að ákvarða viðbótar skyndiminnisstærðir.</string>
     <string name="setup_usagestats_hint">Nauðsynlegt fyrir eyðingu skyndiminnis byggt á aðgengisþjónustu.</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Non usare Shizuku</string>
     <string name="setup_dismiss_hint">Puoi riconfigurare la schermata iniziale nel menu delle impostazioni.</string>
     <string name="setup_permission_granted_label">Autorizzazione concessa</string>
-    <string name="setup_permission_error_label">Errore di autorizzazione</string>
-    <string name="setup_inventory_invalid_label">Elenco app non valido</string>
     <string name="setup_usagestats_title">Statistiche di utilizzo</string>
     <string name="setup_usagestats_body">L\'accesso alle statistiche di utilizzo concede l\'accesso a maggiori dettagli delle app. SD Maid li utilizza per calcolare le dimensioni aggiuntive della cache.</string>
     <string name="setup_usagestats_hint">Richiesto per cancellare la cache dei servizi di accessibilità.</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -283,8 +283,6 @@ SD Maid ישתמש בו כאלטרנטיבה.</string>
     <string name="setup_shizuku_disable_shizuku_use_label">אל תשתמש בShizuku</string>
     <string name="setup_dismiss_hint">תוכל למצוא שוב את מסך ההגדרה דרך תפריט ההגדרות.</string>
     <string name="setup_permission_granted_label">ההרשאה ניתנה</string>
-    <string name="setup_permission_error_label">שגיאת הרשאה</string>
-    <string name="setup_inventory_invalid_label">רשימת יישומים לא תקינה</string>
     <string name="setup_usagestats_title">סטטיסטיקות שימוש</string>
     <string name="setup_usagestats_body">הרשאת סטטיסטיקת השימוש מעניקה גישה לפרטי אפליקציה נוספים. SD Maid משתמש בו כדי לקבוע גדלי מטמון נוספים.</string>
     <string name="setup_usagestats_hint">נדרש עבור מחיקת מטמון מבוססת שירות נגישות.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizukuを使用しない</string>
     <string name="setup_dismiss_hint">設定メニューから再度設定画面を確認できます。</string>
     <string name="setup_permission_granted_label">権限は許可されています</string>
-    <string name="setup_permission_error_label">権限エラー</string>
-    <string name="setup_inventory_invalid_label">無効なアプリリスト</string>
     <string name="setup_usagestats_title">使用状況の統計</string>
     <string name="setup_usagestats_body">使用統計の許可により、アプリの詳細へのアクセスが許可されます。SD Maid は追加のキャッシュサイズを決定するために使用します。</string>
     <string name="setup_usagestats_hint">ユーザー補助サービスは基本的なキャッシュの削除に必要です。</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">არ გამოიყენოთ Shizuku</string>
     <string name="setup_dismiss_hint">პარამეტრების მენიუს მეშვეობით შეგიძლიათ კვლავ იპოვოთ დაყენების ეკრანი.</string>
     <string name="setup_permission_granted_label">Ნებართვა აღებულია</string>
-    <string name="setup_permission_error_label">ნებართვის შეცდომა</string>
-    <string name="setup_inventory_invalid_label">არასწორი აპლიკაციების სია</string>
     <string name="setup_usagestats_title">გამოყენების სტატისტიკა</string>
     <string name="setup_usagestats_body">გამოყენების სტატისტიკის ნებართვა ანიჭებს წვდომას აპის სხვა დეტალებზე. SD Maid იყენებს მას დამატებითი ქეშის ზომის დასადგენად.</string>
     <string name="setup_usagestats_hint">საჭიროა ხელმისაწვდომობის სერვისზე დაფუძნებული ქეშის წაშლისთვის.</string>

--- a/app/src/main/res/values-kaa/strings.xml
+++ b/app/src/main/res/values-kaa/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku paydanma</string>
     <string name="setup_dismiss_hint">Ornatlash ekranın sázlemeler menyüsı arqalı qayta tabıw mümkin.</string>
     <string name="setup_permission_granted_label">Ruxsat berildi</string>
-    <string name="setup_permission_error_label">Ruqsát qatelik</string>
-    <string name="setup_inventory_invalid_label">Qáte qosımshalar dizimi</string>
     <string name="setup_usagestats_title">Paydalanıw statistikası</string>
     <string name="setup_usagestats_body">Paydlanıw statistikası ruqsátı köbirek programma egélliklerine qôl jetiwdi beredi. SD Maid onı qosimsha kesh ölshemlerdi aniqlaw üşin paydalanadi.</string>
     <string name="setup_usagestats_hint">Arnawlı múmkinshilikler xızmetine tiykarlanǵan keshti óshiriw ushın talap etiledi.</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">កុំប្រើ Shizuku</string>
     <string name="setup_dismiss_hint">អ្នកអាចរៀបចំអេក្រង់ម្ដងទៀតបាន តាមរយៈម៉ឺនុយការកំណត់។</string>
     <string name="setup_permission_granted_label">ការអនុញ្ញាតបានផ្តល់ឱ្យ</string>
-    <string name="setup_permission_error_label">កំហុសអនុញ្ញាត</string>
-    <string name="setup_inventory_invalid_label">បញ្ជីកម្មវិធីមិនត្រឹមត្រូវ</string>
     <string name="setup_usagestats_title">ស្ថិតិការប្រើប្រាស់</string>
     <string name="setup_usagestats_body">ការអនុញ្ញាតស្ថិតិការប្រើប្រាស់ផ្តល់ការចូលប្រើប្រាស់លម្អិតបន្ថែមទៀត។ SD Maid ប្រើវាដើម្បីកំណត់ទំហំឃ្លាំងសម្ងាក់បន្ថែម។</string>
     <string name="setup_usagestats_hint">ត្រូវការសម្រាប់ការលុបឃ្លាំងសម្ងាក់ផ្អែកលើសេវាកម្មយល់ដឹង។</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -64,7 +64,6 @@
     <string name="setup_incomplete_card_body">Ji bo encamên çêtir sazkirina SD Maid\'ê temam bikin.</string>
     <string name="setup_incomplete_card_continue_action">Sazkirinê bidomîne</string>
     <string name="setup_permission_granted_label">Destûr hat dayîn</string>
-    <string name="setup_permission_error_label">Xeletiya destûrê</string>
     <string name="setup_notification_title">Agahdarî</string>
     <string name="setup_root_card_title">Gihîştina root</string>
     <string name="setup_root_state_ready_label">Gihîştina root amade ye.</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku 사용하지 않음</string>
     <string name="setup_dismiss_hint">본 초기 설정은 앱 내 설정 메뉴에서 다시 볼 수 있습니다.</string>
     <string name="setup_permission_granted_label">권한 부여 완료</string>
-    <string name="setup_permission_error_label">권한 오류</string>
-    <string name="setup_inventory_invalid_label">잘못된 앱 목록</string>
     <string name="setup_usagestats_title">사용 통계</string>
     <string name="setup_usagestats_body">사용 통계 권한을 부여하면 SD Maid가 각 앱의 추가적 세부 정보를 확인할 수 있습니다. SD Maid는 캐시 크기 정보를 사용합니다.</string>
     <string name="setup_usagestats_hint">접근성 서비스를 통한 캐시 삭제 기능을 위해 필요합니다.</string>

--- a/app/src/main/res/values-ku-rTR/strings.xml
+++ b/app/src/main/res/values-ku-rTR/strings.xml
@@ -58,7 +58,6 @@
     <string name="setup_incomplete_card_body">دامەزراندنی SD Maid تەواو بکە بۆ ئەنجامی باشتر.</string>
     <string name="setup_incomplete_card_continue_action">دامەزراندن بەردەوام بکە</string>
     <string name="setup_permission_granted_label">مۆڵەت دراوە</string>
-    <string name="setup_permission_error_label">هەڵەی مۆڵەت</string>
     <string name="setup_notification_title">ئاگاداریەکان</string>
     <string name="setup_root_card_title">دەستپێگەیشتنی ڕوت</string>
     <string name="setup_shizuku_card_title">Shizuku</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">ບໍ່ໃຊ້ Shizuku</string>
     <string name="setup_dismiss_hint">ທ່ານສາມາດຫາໜ້າຈໍຕັ້ງຄ່າໄດ້ອີກຄັ້ງຜ່ານເມນູການຕັ້ງຄ່າ.</string>
     <string name="setup_permission_granted_label">ໄດ້ຮັບການອະນຸຍາດ</string>
-    <string name="setup_permission_error_label">ຂໍ້ຜິດພາດການອະນຸຍາດ</string>
-    <string name="setup_inventory_invalid_label">ລາຍການແອັບ ບໍ່ຖືກຕ້ອງ</string>
     <string name="setup_usagestats_title">ສະຖິຕິການໃຊ້ງານ</string>
     <string name="setup_usagestats_body">ການອະນຸຍາດສະຖິຕິການໃຊ້ງານເປີດເຂົ້າເຖິງລາຍລະອຽດຂອງແອັບເພີ່ມເຕີມ. SD Maid ໃຊ້ມັນເພື່ອກໍານົດຂະໜາດການເກັບຮັກສາຊົ່ວຄຣາວເພີ່ມເຕີມ.</string>
     <string name="setup_usagestats_hint">ຈໍາເປັນສໍາຫຼັບການລຶບເກັບຮັກສາຊົ່ວຄຣາວຂອງບໍລິການເຂົ້າເຖິງໄດ້.</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -282,8 +282,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Nenaudokite Shizuku</string>
     <string name="setup_dismiss_hint">Sąrankos ekraną vėl rasite nustatymų meniu.</string>
     <string name="setup_permission_granted_label">Leidimas suteiktas</string>
-    <string name="setup_permission_error_label">Leidimo klaida</string>
-    <string name="setup_inventory_invalid_label">Netinkamas programų sąrašas</string>
     <string name="setup_usagestats_title">Naudojimo statistika</string>
     <string name="setup_usagestats_body">Naudojimo statistikos leidimas suteikia prieigą prie išsamesnės informacijos apie programėlę. SD Maid jį naudoja papildomiems talpyklos dydžiams nustatyti.</string>
     <string name="setup_usagestats_hint">Reikalinga norint ištrinti talpyklą naudojant prieigos paslaugą.</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -274,8 +274,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Neizmantot Shizuku</string>
     <string name="setup_dismiss_hint">Iestatīšanas ekrānu var atrast atkal iestatījumu izvēlnē.</string>
     <string name="setup_permission_granted_label">Atļauja piešķirta</string>
-    <string name="setup_permission_error_label">Atļaujas kļūda</string>
-    <string name="setup_inventory_invalid_label">Nederīgs lietotņu saraksts</string>
     <string name="setup_usagestats_title">Lietošanas statistika</string>
     <string name="setup_usagestats_body">Lietošanas statistikas atļauja nodrošina piekļuvi detalizētākai informācijai par lietotnēm. SD Maid to izmanto, lai noteiktu papildu kešatmiņas izmērus.</string>
     <string name="setup_usagestats_hint">Nepieciešams kešatmiņas dzēšanai, izmantojot pieejamības pakalpojumu.</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Не користи Shizuku</string>
     <string name="setup_dismiss_hint">Можете повторно да го најдете екранот за поставување преку менито за поставки.</string>
     <string name="setup_permission_granted_label">Дозволата е дадена</string>
-    <string name="setup_permission_error_label">Грешка со дозвола</string>
-    <string name="setup_inventory_invalid_label">Невалидна листа на апликации</string>
     <string name="setup_usagestats_title">Статистика на користење</string>
     <string name="setup_usagestats_body">Дозволата за статистика на користење дава пристап до повеќе детали за апликации. SD Maid ја користи за одредување дополнителни големини на кеш.</string>
     <string name="setup_usagestats_hint">Потребна за бришење на кеш базирано на услуга за пристапност.</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku ഉപയോഗിക്കരുത്</string>
     <string name="setup_dismiss_hint">സെറ്റിംഗ്സ് മെനു വഴി നിങ്ങൾക്ക് സെറ്റപ്പ് സ്ക്രീൻ വീണ്ടും കണ്ടെത്താനാകും.</string>
     <string name="setup_permission_granted_label">അനുമതി നൽകി</string>
-    <string name="setup_permission_error_label">അനുമതി പിശക്</string>
-    <string name="setup_inventory_invalid_label">അസാധുവായ അപ്ലിക്കേഷൻ പട്ടിക</string>
     <string name="setup_usagestats_title">ഉപയോഗ സ്ഥിതിവിവരക്കണക്കുകൾ</string>
     <string name="setup_usagestats_body">ഉപയോഗ സ്ഥിതിവിവര അനുമതി കൂടുതൽ ആപ്പ് വിവരങ്ങളിലേക്ക് ആക്‌സസ് നൽകുന്നു. അധിക കാഷെ വലിപ്പങ്ങൾ നിർണ്ണയിക്കാൻ SD Maid ഇത് ഉപയോഗിക്കുന്നു.</string>
     <string name="setup_usagestats_hint">ആക്‌സസിബിലിറ്റി സേവന അടിസ്ഥാനത്തിലുള്ള കാഷെ ഡിലീഷനു ആവശ്യമാണ്.</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku ашиглахгүй</string>
     <string name="setup_dismiss_hint">Та тохиргооны цэснээс тохиргооны дэлгэцийг дахин олох боломжтой.</string>
     <string name="setup_permission_granted_label">Зөвшөөрөл олгогдсон</string>
-    <string name="setup_permission_error_label">Зөвшөөрлийн алдаа</string>
-    <string name="setup_inventory_invalid_label">Буруу програмын жагсаалт</string>
     <string name="setup_usagestats_title">Хэрэглээний статистик</string>
     <string name="setup_usagestats_body">Хэрэглээний статистикийн зөвшөөрөл нь аппликешний нэмэлт мэдээлэлд хандах боломж олгодог. SD Maid үүнийг нэмэлт кэшийн хэмжээг тодорхойлоход ашигладаг.</string>
     <string name="setup_usagestats_hint">Хүрэлцээний үйлчилгүүнийг ашигладаг кэш устгахын тулд шаардлагатай.</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Jangan gunakan Shizuku</string>
     <string name="setup_dismiss_hint">Anda boleh mencari skrin persediaan sekali lagi melalui menu tetapan.</string>
     <string name="setup_permission_granted_label">Kebenaran diberikan</string>
-    <string name="setup_permission_error_label">Ralat kebenaran</string>
-    <string name="setup_inventory_invalid_label">Senarai aplikasi tidak sah</string>
     <string name="setup_usagestats_title">Statistik penggunaan</string>
     <string name="setup_usagestats_body">Kebenaran statistik penggunaan memberikan akses kepada lebih banyak butiran aplikasi. SD Maid menggunakannya untuk menentukan saiz cache tambahan.</string>
     <string name="setup_usagestats_hint">Diperlukan untuk pemadaman cache berasaskan perkhidmatan aksesibiliti.</string>

--- a/app/src/main/res/values-mt/strings.xml
+++ b/app/src/main/res/values-mt/strings.xml
@@ -113,7 +113,6 @@
     <string name="setup_shizuku_enable_shizuku_use_label">Uża Shizuku jekk disponibbli</string>
     <string name="setup_shizuku_disable_shizuku_use_label">Tużax Shizuku</string>
     <string name="setup_permission_granted_label">Permess mogħti</string>
-    <string name="setup_permission_error_label">Żball fil-permess</string>
     <string name="setup_usagestats_title">Statistika tal-użu</string>
     <string name="setup_notification_title">Notifiki</string>
     <string name="setup_acs_card_title">Servizz ta\' aċċessibilità</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku ကို မသုံးရန်</string>
     <string name="setup_dismiss_hint">သင်သည် ဆက်တင်မီနူးမှတစ်ဆင့် တပ်ဆင်မှုစာမျက်နှာကို ပြန်ရှာတွေ့နိုင်သည်။</string>
     <string name="setup_permission_granted_label">ခွင့်ပြုချက်ပေးအပ်ပြီး</string>
-    <string name="setup_permission_error_label">ခွင့်ပြုချက်အမှား</string>
-    <string name="setup_inventory_invalid_label">မမှန်သော app စာရင်း</string>
     <string name="setup_usagestats_title">အသုံးပြုမှုစာရင်းအင်း</string>
     <string name="setup_usagestats_body">အသုံးပြုမှုစာရင်းအင်းခွင့်ပြုချက်သည် နောက်ထပ်အက်ပ်အသေးစိတ်များသို့ ဝင်ရောက်ခွင့်ပေးသည်။ SD Maid သည် နောက်ထပ်ကက်ရှ်အရွယ်အစားများကို ဆုံးဖြတ်ရန် ၎င်းကို အသုံးပြုသည်။</string>
     <string name="setup_usagestats_hint">အသုံးပြုရလွယ်ကူမှုဝန်ဆောင်မှု အခြေခံကက်ရှ်ဖျက်ခြင်းအတွက် လိုအပ်သည်။</string>

--- a/app/src/main/res/values-nb/strings.xml
+++ b/app/src/main/res/values-nb/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Ikke bruk Shizuku</string>
     <string name="setup_dismiss_hint">Du finner skjermen for oppsett igjen via innstillingsmenyen.</string>
     <string name="setup_permission_granted_label">Tillatelse gitt</string>
-    <string name="setup_permission_error_label">Tillatelsesfeil</string>
-    <string name="setup_inventory_invalid_label">Ugyldig appliste</string>
     <string name="setup_usagestats_title">Bruksstatistikk</string>
     <string name="setup_usagestats_body">Tillatelsen for bruksstatistikk gir tilgang til flere appdetaljer. SD Maid bruker den for å fastslå størrelser på flere hurtigbuffere.</string>
     <string name="setup_usagestats_hint">Kreves for tilgjengelighetstjeneste-basert sletting av hurtigbuffere.</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku प्रयोग नगर्नुहोस्</string>
     <string name="setup_dismiss_hint">तपाईं सेटिङ्ग मेनुमार्फत पुनः सेटअप स्क्रिन फेला पाउन सक्नुहुन्छ।</string>
     <string name="setup_permission_granted_label">अनुमति दिइयो</string>
-    <string name="setup_permission_error_label">अनुमति त्रुटि</string>
-    <string name="setup_inventory_invalid_label">अमान्य एप सूची</string>
     <string name="setup_usagestats_title">उपयोग तथ्याङ्क</string>
     <string name="setup_usagestats_body">उपयोग तथ्याङ्क अनुमतिले थप अनुप्रयोग विवरणहरूमा पहुँच दिन्छ। SD Maid अतिरिक्त क्यास आकारहरू निर्धारण गर्न यसलाई प्रयोग गर्छ।</string>
     <string name="setup_usagestats_hint">पहुँचयोग्यता सेवा आधारित क्यास मेट्नेको लागि आवश्यक।</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku niet gebruiken</string>
     <string name="setup_dismiss_hint">Je vindt het instellingenscherm terug via het instellingenmenu.</string>
     <string name="setup_permission_granted_label">Toestemming verleend</string>
-    <string name="setup_permission_error_label">Toestemmingsfout</string>
-    <string name="setup_inventory_invalid_label">Ongeldige app-lijst</string>
     <string name="setup_usagestats_title">Gebruiksstatistieken</string>
     <string name="setup_usagestats_body">De toestemming voor gebruiksstatistieken geeft toegang tot meer app details. SD Maid gebruikt het om extra cachegroottes te bepalen.</string>
     <string name="setup_usagestats_hint">Vereist voor cacheverwijdering op basis van toegankelijkheidsservice.</string>

--- a/app/src/main/res/values-or-rIN/strings.xml
+++ b/app/src/main/res/values-or-rIN/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku ବ୍ୟବହାର କରିବାନି</string>
     <string name="setup_dismiss_hint">ଆପଣ ସେଟିଂସ ମେନୁ ମାଧ୍ୟମରେ ପୁଣି ସେଟଅପ ସ୍କ୍ରିନ ଖୋଜିପାରିବେ।</string>
     <string name="setup_permission_granted_label">ଅନୁମତି ଦିଆଯାଇଛି</string>
-    <string name="setup_permission_error_label">ଅନୁମତି ତ୍ରୁଟି</string>
-    <string name="setup_inventory_invalid_label">ଅବୈଧ ଆପ୍ ତାଲିକା</string>
     <string name="setup_usagestats_title">ବ୍ୟବହାର ପରିସଂଖ୍ୟାନ</string>
     <string name="setup_usagestats_body">ବ୍ୟବହାର ପରିସଂଖ୍ୟାନ ଅନୁମତି ଅଧିକ ଆପ୍ ବିବରଣୀକୁ ଆକ୍ସେସ ପ୍ରଦାନ କରେ। SD Maid ଅତିରିକ୍ତ କ୍ୟାଶ ଆକାର ନିର୍ଣ୍ଣୟ କରିବା ପାଇଁ ଏହାକୁ ବ୍ୟବହାର କରେ।</string>
     <string name="setup_usagestats_hint">ଆକ୍ସେସିବିଲିଟି ସର୍ଭିସ ଆଧାରିତ କ୍ୟାଶ ଡିଲିଟ ପାଇଁ ଆବଶ୍ୟକ।</string>

--- a/app/src/main/res/values-pa-rIN/strings.xml
+++ b/app/src/main/res/values-pa-rIN/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku ਦੀ ਵਰਤੋਂ ਨਾ ਕਰੋ</string>
     <string name="setup_dismiss_hint">ਤੁਸੀਂ ਸੈਟਿੰਗਸ ਮੇਨੂ ਰਾਹੀਂ ਸੈਟਅੱਪ ਸਕਰੀਨ ਨੂੰ ਮੁੜ ਲੱਭ ਸਕਦੇ ਹੋ।</string>
     <string name="setup_permission_granted_label">ਇਜਾਜ਼ਤ ਦਿੱਤੀ ਗਈ</string>
-    <string name="setup_permission_error_label">ਅਨੁਮਤੀ ਤਰੁੱਟੀ</string>
-    <string name="setup_inventory_invalid_label">ਅਵੈਧ ਐਪ ਸੂਚੀ</string>
     <string name="setup_usagestats_title">ਵਰਤੋਂ ਅੰਕੜੇ</string>
     <string name="setup_usagestats_body">ਵਰਤੋਂ ਦੇ ਅੰਕੜਿਆਂ ਦੀ ਅਨੁਮਤੀ ਹੋਰ ਐਪ ਵੇਰਵਿਆਂ ਤੱਕ ਪਹੁੰਚ ਪ੍ਰਦਾਨ ਕਰਦੀ ਹੈ। SD Maid ਇਸਦੀ ਵਰਤੋਂ ਵਾਧੂ ਕੈਸ਼ ਆਕਾਰ ਨਿਰਧਾਰਤ ਕਰਨ ਲਈ ਕਰਦਾ ਹੈ।</string>
     <string name="setup_usagestats_hint">ਪਹੁੰਚਯੋਗਤਾ ਸੇਵਾ ਆਧਾਰਿਤ ਕੈਸ਼ ਮਿਟਾਉਣ ਲਈ ਲੋੜੀਂਦਾ।</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -282,8 +282,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Nie korzystaj z Shizuku</string>
     <string name="setup_dismiss_hint">Możesz ponownie otworzyć ekran ustawień poprzez menu ustawień.</string>
     <string name="setup_permission_granted_label">Uprawnienie przyznane</string>
-    <string name="setup_permission_error_label">Błąd uprawnień</string>
-    <string name="setup_inventory_invalid_label">Nieprawidłowa lista aplikacji</string>
     <string name="setup_usagestats_title">Statystyki używania</string>
     <string name="setup_usagestats_body">Uprawnienie do statystyk używania umożliwia uzyskanie dostępu do większej liczby szczegółów dotyczących aplikacji. SD Maid korzysta z niego, aby określić dodatkowe rozmiary pamięci podręcznej.</string>
     <string name="setup_usagestats_hint">Wymagane do usunięcia pamięci podręcznej za pomocą usługi ułatwienia dostępu.</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Não use Shizuku</string>
     <string name="setup_dismiss_hint">Você pode encontrar a tela de configuração novamente através do menu de configurações.</string>
     <string name="setup_permission_granted_label">Permissão concedida</string>
-    <string name="setup_permission_error_label">Erro de permissão</string>
-    <string name="setup_inventory_invalid_label">Lista de aplicativos inválida</string>
     <string name="setup_usagestats_title">Estatísticas de uso</string>
     <string name="setup_usagestats_body">A permissão de estatísticas de uso concede acesso a mais detalhes do aplicativo. O SD Maid usa-o para determinar tamanhos de cache adicionais.</string>
     <string name="setup_usagestats_hint">Necessário serviço de acessibilidade para a remoção do cache.</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Não utilizar o Shizuku</string>
     <string name="setup_dismiss_hint">Pode voltar a encontrar o ecrã de configuração através do menu Definições.</string>
     <string name="setup_permission_granted_label">Permissão concedida</string>
-    <string name="setup_permission_error_label">Erro de permissão</string>
-    <string name="setup_inventory_invalid_label">Lista de aplicações inválida</string>
     <string name="setup_usagestats_title">Estatísticas de utilização</string>
     <string name="setup_usagestats_body">A permissão de estatísticas de utilização concede acesso a mais detalhes das aplicações. O SD Maid utiliza-a para determinar tamanhos adicionais da cache.</string>
     <string name="setup_usagestats_hint">Necessário para eliminar a cache através do serviço de acessibilidade.</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -274,8 +274,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Nu utiliza Shizuku</string>
     <string name="setup_dismiss_hint">Poți căuta partea de configurare din nou în meniul de setări.</string>
     <string name="setup_permission_granted_label">Permisiune acordată</string>
-    <string name="setup_permission_error_label">Eroare de permisiune</string>
-    <string name="setup_inventory_invalid_label">Lista de aplicații invalidă</string>
     <string name="setup_usagestats_title">Statici de utilizare</string>
     <string name="setup_usagestats_body">Permisiunea pentru acces la statici de utilizare pentru mai multe detalii despre aplicații. SD Maid va folosi pentru a determina dimensiunile cache suplimentare.</string>
     <string name="setup_usagestats_hint">Necesar pentru serviciul de accesibilitate bazat pe ștergerea memoriei cache.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -282,8 +282,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Не использовать Shizuku</string>
     <string name="setup_dismiss_hint">Вы можете снова перейти к экрану установки через меню настроек.</string>
     <string name="setup_permission_granted_label">Разрешение предоствлено</string>
-    <string name="setup_permission_error_label">Ошибка доступа</string>
-    <string name="setup_inventory_invalid_label">Недопустимый список приложений</string>
     <string name="setup_usagestats_title">Статистика использования</string>
     <string name="setup_usagestats_body">Разрешение на статистику использования предоставляет доступ к более подробной информации о приложении. SD Maid использует его для определения дополнительных размеров кэша.</string>
     <string name="setup_usagestats_hint">Требуется для удаления кэша с помощью службы специальных возможностей.</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Non impreare Shizuku</string>
     <string name="setup_dismiss_hint">Podes agatare s\'ischermada de cunfiguratzione torra a travessu de su menù de is impostatziones.</string>
     <string name="setup_permission_granted_label">Permissu cuncèdidu</string>
-    <string name="setup_permission_error_label">Errore de permissu</string>
-    <string name="setup_inventory_invalid_label">Lista de applicatziones non balida</string>
     <string name="setup_usagestats_title">Istàtcias de impreu</string>
     <string name="setup_usagestats_body">Su permissu de is istàtcias de impreu cunchet s\'atzessu a prus detallios de aplicatziones. SD Maid dd\'impreat pro determinare mannarias additzionales de cache.</string>
     <string name="setup_usagestats_hint">Rieketu pro sa cantzelladura de cache basada in su servitziu de atzessibilidade.</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku භාවිතා නොකරන්න</string>
     <string name="setup_dismiss_hint">සම්සා රන්ග මෙනුව අරහා ඔබට පිහිටුවීම් තිරය නැවත සොයා ගැනීමට හැකියි.</string>
     <string name="setup_permission_granted_label">අනුමතිය ලබා දී</string>
-    <string name="setup_permission_error_label">අනුමති හොපීම</string>
-    <string name="setup_inventory_invalid_label">වලංගු නොවන app ලැයිස්තුව</string>
     <string name="setup_usagestats_title">භාවිත සංඛ්යාලේැන</string>
     <string name="setup_usagestats_body">භාවිත සංඛ්යාලේැන අනුමතිය වැඩි යෙදුම් විශේෂ වලට ප්‍රවේශය ලබා දේ. SD Maid එය අමතර කැශ් ප්‍රමාණ නිර්ණාරණය කිරීමට භාවිතා කරයි.</string>
     <string name="setup_usagestats_hint">ඇන්ද්‍රිය පරිගැන්න සේවාව මෆින් කැශ් මකාදම් සඳහා අවශ්‍යි.</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -282,8 +282,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Nepoužiť Shizuku</string>
     <string name="setup_dismiss_hint">Obrazovku úvodného nastavenia môžete znova nájsť cez ponuku nastavení.</string>
     <string name="setup_permission_granted_label">Povolenie udelené</string>
-    <string name="setup_permission_error_label">Chyba oprávnenia</string>
-    <string name="setup_inventory_invalid_label">Neplatný zoznam aplikácií</string>
     <string name="setup_usagestats_title">Štatistiky používania</string>
     <string name="setup_usagestats_body">Povolenie štatistiky používania poskytuje prístup k ďalším podrobnostiam aplikácie. SD Maid ju používa na určenie dodatočných veľkostí vyrovnávacej pamäte.</string>
     <string name="setup_usagestats_hint">Vyžaduje sa na vymazanie vyrovnávacej pamäte na základe služby dostupnosti.</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -282,8 +282,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Ne uporabi Shizukuja</string>
     <string name="setup_dismiss_hint">Zaslon za nastavitev lahko znova najdete v meniju z nastavitvami.</string>
     <string name="setup_permission_granted_label">Dovoljenje je bilo odobreno.</string>
-    <string name="setup_permission_error_label">Napaka dovoljenja</string>
-    <string name="setup_inventory_invalid_label">Neveljaven seznam aplikacij</string>
     <string name="setup_usagestats_title">Statistika uporabe</string>
     <string name="setup_usagestats_body">Dovoljenje za statistiko uporabe odobri dostop do več podrobnosti o programih.  SD Maid ga uporablja za določanje dodatnih velikosti predpomnilnikov.</string>
     <string name="setup_usagestats_hint">Zahtevano za izbris predpomnilnikov s pomočjo storitve dostopnosti.</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Mos përdorni Shizuku</string>
     <string name="setup_dismiss_hint">Mund ta gjeni sërish ekranin e konfigurimit nëpërmjet menysë së cilësimeve.</string>
     <string name="setup_permission_granted_label">Leja e dhënë</string>
-    <string name="setup_permission_error_label">Gabim leje</string>
-    <string name="setup_inventory_invalid_label">Listë e pavlefshme e aplikacioneve</string>
     <string name="setup_usagestats_title">Statistikat e përdorimit</string>
     <string name="setup_usagestats_body">Leja e statistikave të përdorimit jep akses në më shumë detaje të aplikacionit. SD Maid e përdor atë për të përcaktuar madhësitë shtesë të cache-it.</string>
     <string name="setup_usagestats_hint">Kërkohet për fshirjen e cache-it të bazuar në shërbimin e aksesueshmërisë.</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -274,8 +274,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Не користи Shizuku</string>
     <string name="setup_dismiss_hint">Екран за подешавање можете поново пронаћи преко менија подешавања.</string>
     <string name="setup_permission_granted_label">Дозвола одобрена</string>
-    <string name="setup_permission_error_label">Грешка дозволе</string>
-    <string name="setup_inventory_invalid_label">Неважећа листа апликација</string>
     <string name="setup_usagestats_title">Статистика коришћења</string>
     <string name="setup_usagestats_body">Дозвола за статистику коришћења даје приступ више детаља о апликацији. СД Чистач је користи за одређивање додатних величина кеша.</string>
     <string name="setup_usagestats_hint">Потребно за приступачност сервиса за брисање кеша.</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Använd inte Shizuku</string>
     <string name="setup_dismiss_hint">Du kan hitta inställningsskärmen igen via inställningsmenyn.</string>
     <string name="setup_permission_granted_label">Behörighet beviljad</string>
-    <string name="setup_permission_error_label">Behörighetsfel</string>
-    <string name="setup_inventory_invalid_label">Ogiltig applista</string>
     <string name="setup_usagestats_title">Användningsstatistik</string>
     <string name="setup_usagestats_body">Behörigheten för användningsstatistik ger åtkomst till fler appdetaljer. SD Maid använder den för att bestämma ytterligare cachestorlekar.</string>
     <string name="setup_usagestats_hint">Krävs för tillgänglighetsservice-baserad cache-borttagning.</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Usitumie Shizuku</string>
     <string name="setup_dismiss_hint">Unaweza kupata skrini ya usanidi tena kupitia menyu ya mipangilio.</string>
     <string name="setup_permission_granted_label">Ruhusa imetolewa</string>
-    <string name="setup_permission_error_label">Kosa la ruhusa</string>
-    <string name="setup_inventory_invalid_label">Orodha batili ya programu</string>
     <string name="setup_usagestats_title">Takwimu za matumizi</string>
     <string name="setup_usagestats_body">Ruhusa ya takwimu za matumizi inatoa ufikiaji wa maelezo zaidi ya programu. SD Maid inaitumia kuamua ukubwa wa ziada wa akiba.</string>
     <string name="setup_usagestats_hint">Inahitajika kwa ufutaji wa akiba unaotegemea huduma ya ufikiaji.</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku ஐப் பயன்படுத்த வேண்டாம்</string>
     <string name="setup_dismiss_hint">அமைப்புகள் பட்டி வழியாக அமைப்பு திரையை மீண்டும் கண்டுபிடிக்கலாம்.</string>
     <string name="setup_permission_granted_label">அனுமதி வழங்கப்பட்டது</string>
-    <string name="setup_permission_error_label">அனுமதி பிழை</string>
-    <string name="setup_inventory_invalid_label">தவறான பயன்பாட்டு பட்டியல்</string>
     <string name="setup_usagestats_title">பயன்பாட்டு புள்ளிவிவரங்கள்</string>
     <string name="setup_usagestats_body">பயன்பாட்டு புள்ளிவிவர அனுமதி மேலும் பயன்பாட்டு விவரங்களுக்கு அணுகல் வழங்குகிறது. கூடுதல் கேச் அளவுகளை தீர்மானிக்க SD Maid அதைப் பயன்படுத்துகிறது.</string>
     <string name="setup_usagestats_hint">அணுகல் சேவை அடிப்படையிலான கேச் நீக்கத்திற்கு தேவை.</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku ఉపయోగించవద్దు</string>
     <string name="setup_dismiss_hint">మీరు సెట్టింగ్స్ మెనూ ద్వారా సెటప్ స్క్రీన్‌ను మళ్లీ కనుగొనవచ్చు.</string>
     <string name="setup_permission_granted_label">అనుమతి మంజూరు చేయబడింది</string>
-    <string name="setup_permission_error_label">అనుమతి లోపం</string>
-    <string name="setup_inventory_invalid_label">చెల్లని యాప్ జాబితా</string>
     <string name="setup_usagestats_title">వినియోగ గణాంకాలు</string>
     <string name="setup_usagestats_body">వినియోగ గణాంకాల అనుమతి కూడా యాప్ వివరాలకు ప్రాప్యతను మంజూరు చేస్తుంది. SD Maid అదనపు క్యాషే పరిమాణాలను నిర్ణయించడానికి దానిని ఉపయోగిస్తుంది.</string>
     <string name="setup_usagestats_hint">యక్షస్వాధీనత సెర్విస్ ఆధారయుక్త క్యాషే తొలగింపు కోసం అవసరం.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">อย่าใช้ Shizuku</string>
     <string name="setup_dismiss_hint">คุณจะหาเมนูตั้งค่าเพื่อเริ่มใช้งานได้โดยไปที่การตั้งค่าของแอพ</string>
     <string name="setup_permission_granted_label">สิทธิ์ที่ได้รับอนุญาต</string>
-    <string name="setup_permission_error_label">ข้อผิดพลาดของสิทธิ์</string>
-    <string name="setup_inventory_invalid_label">รายชื่อแอปไม่ถูกต้อง</string>
     <string name="setup_usagestats_title">สถิติการใช้งาน</string>
     <string name="setup_usagestats_body">สิทธิ์เข้าถึงสถิติการใช้งานช่วยให้เข้าถึงรายละเอียดของแอพต่างๆ ได้มากขึ้น SD Maid ใช้สิทธิ์นี้เพื่อคำนวณแคชเพิ่มเติม</string>
     <string name="setup_usagestats_hint">จำเป็นสำหรับการลบแคชที่เกี่ยวข้องกับบริการตัวช่วยการเข้าถึง</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku\'yu kullanma</string>
     <string name="setup_dismiss_hint">Ayarlar menüsünden kurulum ekranına tekrar ulaşabilirsiniz.</string>
     <string name="setup_permission_granted_label">İzin verildi</string>
-    <string name="setup_permission_error_label">İzin Hatası</string>
-    <string name="setup_inventory_invalid_label">Geçersiz uygulama listesi</string>
     <string name="setup_usagestats_title">Kullanım istatistikleri</string>
     <string name="setup_usagestats_body">Kullanım istatistikleri izni daha fazla uygulama detayına erişim sağlar. SD Maid bunu ek önbellek boyutlarını belirlemek için kullanır.</string>
     <string name="setup_usagestats_hint">Erişilebilirlik hizmeti tabanlı önbellek silme işlemi için gereklidir.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -282,8 +282,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Не використовувати Shizuku</string>
     <string name="setup_dismiss_hint">Ви можете знову знайти екран налаштувань через меню налаштувань.</string>
     <string name="setup_permission_granted_label">Дозвіл надано</string>
-    <string name="setup_permission_error_label">Помилка доступу</string>
-    <string name="setup_inventory_invalid_label">Недійсний список додатків</string>
     <string name="setup_usagestats_title">Статистика використання</string>
     <string name="setup_usagestats_body">Дозвіл на статистику використання надає доступ до додаткової інформації про додаток. SD Maid використовує його для визначення додаткових розмірів кешу.</string>
     <string name="setup_usagestats_hint">Необхідно для видалення кешу за допомогою сервісу \"Спеціальних можливостей\".</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku استعمال نہ کریں</string>
     <string name="setup_dismiss_hint">آپ سیٹنگز مینو کے ذریعے سیٹ اپ سکرین دوبارہ تلاش کر سکتے ہیں۔</string>
     <string name="setup_permission_granted_label">اجازت دی گئی</string>
-    <string name="setup_permission_error_label">اجازت کی خرابی</string>
-    <string name="setup_inventory_invalid_label">غلط ایپ کی فہرست</string>
     <string name="setup_usagestats_title">استعمال کے شماریات</string>
     <string name="setup_usagestats_body">استعمال کے شماریات کی اجازت زیادہ ایپ تفصیلات تک رسائی فراہم کرتی ہے۔ SD Maid اسے اضافی کیش سائز کا تعین کرنے کے لیے استعمال کرتا ہے۔</string>
     <string name="setup_usagestats_hint">رسائی سروس پر مبنی کیش ڈیلیٹ کے لیے ضروری۔</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Shizuku dan foydalanmang</string>
     <string name="setup_dismiss_hint">Sozlash ekranini sozlamalar menyusi orqali qayta topishingiz mumkin.</string>
     <string name="setup_permission_granted_label">Ruxsat berildi</string>
-    <string name="setup_permission_error_label">Ruxsat xatosi</string>
-    <string name="setup_inventory_invalid_label">Noto\'g\'ri ilovalar ro\'yxati</string>
     <string name="setup_usagestats_title">Foydalanish statistikasi</string>
     <string name="setup_usagestats_body">Foydalanish statistikasi ruxsati ko\'proq ilova tafsilotlariga kirish imkonini beradi. SD Maid uni qo\'shimcha kesh hajmlarini aniqlash uchun ishlatadi.</string>
     <string name="setup_usagestats_hint">Kirish xizmati asosida kesh o\'chirish uchun zarur.</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Không sử dụng Shizuku</string>
     <string name="setup_dismiss_hint">Bạn có thể tìm lại màn hình thiết lập thông qua menu cài đặt.</string>
     <string name="setup_permission_granted_label">Đã được cấp quyền</string>
-    <string name="setup_permission_error_label">Lỗi quyền truy cập</string>
-    <string name="setup_inventory_invalid_label">Danh sách ứng dụng không hợp lệ</string>
     <string name="setup_usagestats_title">Thống kê sử dụng</string>
     <string name="setup_usagestats_body">Quyền thống kê sử dụng cấp quyền truy cập vào nhiều chi tiết ứng dụng hơn. SD Maid sử dụng nó để xác định kích thước bộ đệm bổ sung.</string>
     <string name="setup_usagestats_hint">Cần thiết để xóa bộ nhớ cache dựa trên dịch vụ trợ năng.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">不使用 Shizuku</string>
     <string name="setup_dismiss_hint">您可以在设置菜单中再次找到初始设置页面。</string>
     <string name="setup_permission_granted_label">已授予权限</string>
-    <string name="setup_permission_error_label">权限错误</string>
-    <string name="setup_inventory_invalid_label">应用列表无效</string>
     <string name="setup_usagestats_title">使用情况</string>
     <string name="setup_usagestats_body">通过允许查看使用情况，可以查看应用的更多详细信息。SD Maid 使用此权限计算额外缓存的大小。</string>
     <string name="setup_usagestats_hint">使用无障碍服务的缓存删除操作需要此权限。</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">不要使用 Shizuku</string>
     <string name="setup_dismiss_hint">您可以透過設定選單再次找到安裝程式畫面。</string>
     <string name="setup_permission_granted_label">權限已授予</string>
-    <string name="setup_permission_error_label">權限錯誤</string>
-    <string name="setup_inventory_invalid_label">應用程式清單無效</string>
     <string name="setup_usagestats_title">使用量統計資料</string>
     <string name="setup_usagestats_body">使用量統計資料權限授予更多應用程式的存取權，SD 女僕用它來確定額外快取大小。</string>
     <string name="setup_usagestats_hint">需要基於無障礙服務的快取偵測。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -258,8 +258,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">不要使用 Shizuku</string>
     <string name="setup_dismiss_hint">您可以透過設定選單再次找到安裝程式畫面。</string>
     <string name="setup_permission_granted_label">權限已授予</string>
-    <string name="setup_permission_error_label">權限錯誤</string>
-    <string name="setup_inventory_invalid_label">無效的應用程式清單</string>
     <string name="setup_usagestats_title">使用量統計資料</string>
     <string name="setup_usagestats_body">使用量統計資料權限授予更多應用程式的存取權，SD 女僕用它來確定額外快取大小。</string>
     <string name="setup_usagestats_hint">需要基於無障礙服務的快取偵測。</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -266,8 +266,6 @@
     <string name="setup_shizuku_disable_shizuku_use_label">Ungasebenzisi i-Shizuku</string>
     <string name="setup_dismiss_hint">Ungakuthola isikrini sokusetshenziswa futhi ngemenu yezilungiselelo.</string>
     <string name="setup_permission_granted_label">Imvume inikeziwe</string>
-    <string name="setup_permission_error_label">Iphutha lemvume</string>
-    <string name="setup_inventory_invalid_label">Uhlu lwezinhlelo olungavumelekile</string>
     <string name="setup_usagestats_title">Izibalo zokusetshenziswa</string>
     <string name="setup_usagestats_body">Imvume yezibalo zokusetshenziswa inikeza ukufinyelela emininingwaneni eminingi yohlelo lokusebenza. I-SD Maid iyakusebenzisa ukuze inqume osayizi benqobo-cache engeziwe.</string>
     <string name="setup_usagestats_hint">Kuyadingeka kwinsiza yokufinyelela esekelwe ekususweni kwe-cache.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -288,8 +288,6 @@
 
     <string name="setup_dismiss_hint">You can find the setup screen again via the settings menu.</string>
     <string name="setup_permission_granted_label">Permission granted</string>
-    <string name="setup_permission_error_label">Permission error</string>
-    <string name="setup_inventory_invalid_label">Invalid app list</string>
 
     <string name="setup_usagestats_title">Usage statistics</string>
     <string name="setup_usagestats_body">The usage statistics permission grants access to more app details. SD Maid uses it to determine additional cache sizes.</string>


### PR DESCRIPTION
## What changed

Removes five pieces of text that no screen in the app displays any more. Nothing changes for people using the app. The effect is for translators: these had to be translated into every language, and none of that work could reach a user.

## Technical Context

- Found by a sweep of every `<string>` and `<plurals>` name declared in every module's base `strings.xml` against every non-resource source file. Five names had no reference anywhere; after this change the sweep reports zero. Matching is by identifier, not by an `R.string.` pattern, because that pattern misses plurals, as `general_x_selected_count` demonstrated during this work.
- Why each one is unused, from git history: `setup_permission_error_label` was displaced in 62ab66fd8 by a specific invalid-app-list label. `setup_inventory_invalid_label` was orphaned in a46d2aa78, which kept it deliberately because removing the base entry alone trips the fatal `ExtraTranslation` check; removing base and locales together is exactly what that reasoning was waiting for. `stats_space_history_upgrade_body` was superseded in 208a5ee49 by a `_v2` key. `deduplicator_file_size_label` and `deduplicator_details_cluster_title` have no such story, just no callers.
- The comment above `stats_space_history_upgrade_body_v2` is removed with it. Its claim that the old key was retained so locales would not keep showing the old copy does not hold: the key is referenced nowhere, so its translations are inert either way. The real reason for the `_v2` rename is in 208a5ee49's message.
- Base and locale files are deleted together, 382 elements across 231 files. A base-only deletion leaves locales with translations whose base string is gone, which lint reports as `ExtraTranslation`, escalated to `fatal` for non-beta builds in `app/build.gradle.kts:101`.
- The bulk of the diff is near-identical locale deletions. The three base `strings.xml` files are the only ones worth reading closely.
- Verified beyond the build: both flavors were installed on an emulator and driven through onboarding, setup, the dashboard and StorageAnalyzer, with no fatal exceptions and no resource-not-found errors. The app has no dynamic lookup of its own string resources (the `getIdentifier` calls in `SpecGenerator.kt` and `AutomationLabelSource.kt` resolve strings from other packages), so a compiling build already rules out a missed reference.