### PR TITLE
General: Also build a Play-signed APK for local install testing

### DIFF
--- a/.claude/rules/build-commands.md
+++ b/.claude/rules/build-commands.md
@@ -12,6 +12,16 @@ paths:
 Flavors are `Foss` and `Gplay`. Local development uses `assembleFossDebug`, unit tests `testFossDebugUnitTest`,
 CI lint `lintVitalFossRelease` / `lintVitalGplayRelease`.
 
+## Gplay APK outputs
+
+`assembleGplayRelease` / `assembleGplayBeta` produce two APKs:
+
+- `app/build/outputs/apk/gplay/<type>/...-UPLOAD.apk` — upload key, what the Play AAB is signed with. Not installable
+  as an update over a Play install.
+- `app/build/outputs/apk_gplay_signed/<type>/....apk` — Play app signing key, the installable one. Produced by the
+  `signGplay<Type>Apk` finalizer, which no-ops when `~/.config/projects/eu.darken.sdmse/signing-gplay.properties`
+  is absent (CI).
+
 ## Pitfalls
 
 ### Dependency Updates

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,7 @@ apply(plugin = "dagger.hilt.android.plugin")
 apply(plugin = "org.jetbrains.kotlin.plugin.serialization")
 
 val commitHashProvider = providers.of(CommitHashValueSource::class) {}
+val signingBasePath = File(System.getProperty("user.home"), ".config/projects/${projectConfig.packageName}")
 
 android {
     if (projectConfig.compileSdkPreview != null) {
@@ -40,18 +41,17 @@ android {
     }
 
     signingConfigs {
-        val basePath = File(System.getProperty("user.home"), ".config/projects/${projectConfig.packageName}")
         val hasEnvCredentials = System.getenv("STORE_PATH")?.let { File(it).exists() } == true
         create("releaseFoss") {
-            if (hasEnvCredentials || basePath.exists()) {
-                setupCredentials(File(basePath, "signing-foss.properties"))
+            if (hasEnvCredentials || signingBasePath.exists()) {
+                setupCredentials(File(signingBasePath, "signing-foss.properties"))
             } else {
                 initWith(signingConfigs["debug"])
             }
         }
         create("releaseGplay") {
-            if (hasEnvCredentials || basePath.exists()) {
-                setupCredentials(File(basePath, "signing-gplay-upload.properties"))
+            if (hasEnvCredentials || signingBasePath.exists()) {
+                setupCredentials(File(signingBasePath, "signing-gplay-upload.properties"))
             } else {
                 initWith(signingConfigs["debug"])
             }
@@ -157,30 +157,27 @@ androidComponents {
         val formattedVariantName = variant.name
             .replace(Regex("([a-z])([A-Z])"), "$1-$2")
             .uppercase()
+        val isGplay = variant.flavorName == "gplay"
+        // The gplay variant APK carries the upload key, not the Play app signing key; mark it
+        // so it can't be confused with the installable re-signed APK produced below.
+        val suffix = if (isGplay) "-UPLOAD" else ""
 
-        val apkFolder = variant.artifacts.get(com.android.build.api.artifact.SingleArtifact.APK)
-        val loader = variant.artifacts.getBuiltArtifactsLoader()
-        val packageName = projectConfig.packageName
+        val apkFileName = "${projectConfig.packageName}" +
+            "-v${projectConfig.version.name}-${projectConfig.version.code}" +
+            "-$formattedVariantName$suffix.apk"
+        variant.outputs.single().outputFileName.set(apkFileName)
 
-        val renameTask = tasks.register("rename${variant.name.replaceFirstChar { it.uppercase() }}Apk") {
-            inputs.files(apkFolder)
-            outputs.upToDateWhen { false }
-
-            doLast {
-                val builtArtifacts = loader.load(apkFolder.get()) ?: return@doLast
-
-                builtArtifacts.elements.forEach { element ->
-                    val apkFile = File(element.outputFile)
-                    val outputFileName = "$packageName-v${element.versionName}-${element.versionCode}-$formattedVariantName.apk"
-                    if (apkFile.exists() && apkFile.name != outputFileName) {
-                        apkFile.copyTo(File(apkFile.parentFile, outputFileName), overwrite = true)
-                    }
-                }
+        // The gplay variant is signed with the upload key so the AAB passes Play's upload check.
+        // For a directly installable Play-signed APK, re-sign the assembled APK with the app
+        // signing key. Local-only: without signing-gplay.properties (e.g. CI) the task no-ops.
+        if (isGplay) {
+            tasks.register<SignGplayApkTask>("signGplay${buildType.replaceFirstChar { it.uppercase() }}Apk") {
+                apkDir.set(variant.artifacts.get(com.android.build.api.artifact.SingleArtifact.APK))
+                apkName.set(apkFileName)
+                signingProps.from(File(signingBasePath, "signing-gplay.properties"))
+                sdkDir.set(sdkComponents.sdkDirectory)
+                outputDir.set(layout.buildDirectory.dir("outputs/apk_gplay_signed/$buildType"))
             }
-        }
-
-        tasks.matching { it.name == "assemble${variant.name.replaceFirstChar { it.uppercase() }}" }.configureEach {
-            finalizedBy(renameTask)
         }
     }
 }
@@ -193,6 +190,12 @@ afterEvaluate {
     }
     tasks.matching { it.name == "bundleGplayRelease" }.configureEach {
         dependsOn("lintVitalGplayRelease")
+    }
+    tasks.matching { it.name == "assembleGplayBeta" }.configureEach {
+        finalizedBy("signGplayBetaApk")
+    }
+    tasks.matching { it.name == "assembleGplayRelease" }.configureEach {
+        finalizedBy("signGplayReleaseApk")
     }
 }
 

--- a/buildSrc/src/main/java/SignGplayApkTask.kt
+++ b/buildSrc/src/main/java/SignGplayApkTask.kt
@@ -1,0 +1,132 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+import java.io.File
+import java.io.FileInputStream
+import java.util.Properties
+import javax.inject.Inject
+
+/**
+ * Re-signs the gplay APK with the Google Play app signing key.
+ * The gplay variant itself is signed with the upload key (required for the Play AAB),
+ * so a directly installable APK needs this second signature.
+ *
+ * Runs as a finalizer of the gplay assemble tasks; without readable credentials
+ * (e.g. on CI) it clears its output and does nothing.
+ */
+abstract class SignGplayApkTask @Inject constructor(
+    private val execOps: ExecOperations,
+) : DefaultTask() {
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val apkDir: DirectoryProperty
+
+    /**
+     * Name of the upload-key APK inside [apkDir]. Set from the same expression that names the
+     * variant output, so a stale APK left in that directory by an earlier build is never picked up.
+     */
+    @get:Input
+    abstract val apkName: Property<String>
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val signingProps: ConfigurableFileCollection
+
+    @get:Internal
+    abstract val sdkDir: DirectoryProperty
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    init {
+        // The keystore and apksigner are resolved at execution time and not tracked as
+        // inputs, so never trust previous output.
+        outputs.upToDateWhen { false }
+    }
+
+    @TaskAction
+    fun sign() {
+        val outDir = outputDir.get().asFile.apply {
+            mkdirs()
+            listFiles()?.forEach { it.delete() }
+        }
+
+        val propsFile = signingProps.singleFile
+        if (!propsFile.canRead()) {
+            logger.lifecycle("No Google Play signing credentials at $propsFile, skipping APK re-sign.")
+            return
+        }
+
+        val props = Properties().apply {
+            FileInputStream(propsFile).use { load(it) }
+        }
+        val storeFile = File(requireNotNull(props.getProperty("release.storePath")))
+        require(storeFile.exists()) { "Keystore not found: $storeFile" }
+        val storePassword = requireNotNull(props.getProperty("release.storePassword"))
+        val keyAlias = requireNotNull(props.getProperty("release.keyAlias"))
+        val keyPassword = requireNotNull(props.getProperty("release.keyPassword"))
+
+        val apksigner = findApksigner()
+
+        val apk = File(apkDir.get().asFile, apkName.get())
+        require(apk.exists()) { "APK not found: $apk" }
+
+        val outFile = File(outDir, apk.name.replace("-UPLOAD", ""))
+        execOps.exec {
+            commandLine(
+                apksigner.absolutePath, "sign",
+                "--ks", storeFile.absolutePath,
+                "--ks-key-alias", keyAlias,
+                "--ks-pass", "env:SDMSE_SIGN_KS_PASS",
+                "--key-pass", "env:SDMSE_SIGN_KEY_PASS",
+                "--v4-signing-enabled", "false",
+                "--out", outFile.absolutePath,
+                apk.absolutePath,
+            )
+            environment("SDMSE_SIGN_KS_PASS", storePassword)
+            environment("SDMSE_SIGN_KEY_PASS", keyPassword)
+        }
+        execOps.exec { commandLine(apksigner.absolutePath, "verify", outFile.absolutePath) }
+        logger.lifecycle("Signed with Google Play key: $outFile")
+    }
+
+    private fun findApksigner(): File {
+        val buildTools = sdkDir.get().asFile.resolve("build-tools")
+        val candidates = buildTools
+            .listFiles { dir: File -> EXECUTABLES.any { File(dir, it).exists() } }
+            .orEmpty()
+        require(candidates.isNotEmpty()) { "No build-tools with apksigner found in $buildTools" }
+        val newest = candidates.maxWith(compareBy(VERSION_COMPARATOR) { it.name })
+        return EXECUTABLES.map { File(newest, it) }.first { it.exists() }
+    }
+
+    companion object {
+        private val EXECUTABLES = listOf("apksigner", "apksigner.bat")
+
+        // Orders e.g. 36.0.0 < 37.0.0-rc1 < 37.0.0-rc2 < 37.0.0
+        private val VERSION_COMPARATOR = Comparator<String> { a, b ->
+            val (aBase, aPreview) = versionKey(a)
+            val (bBase, bPreview) = versionKey(b)
+            (0 until maxOf(aBase.size, bBase.size))
+                .map { aBase.getOrElse(it) { 0 }.compareTo(bBase.getOrElse(it) { 0 }) }
+                .firstOrNull { it != 0 }
+                ?: aPreview.compareTo(bPreview)
+        }
+
+        private fun versionKey(name: String): Pair<List<Int>, Int> {
+            val base = name.substringBefore('-').split('.').mapNotNull { it.toIntOrNull() }
+            val preview = name.substringAfter('-', "").filter { it.isDigit() }.toIntOrNull()
+            return base to (preview ?: Int.MAX_VALUE)
+        }
+    }
+}


### PR DESCRIPTION
## What changed

No user-facing behavior change.

Building the Google Play flavor now produces two APKs instead of one. The existing APK is signed with the Play upload key, which is what the AAB needs to pass Play's upload check, but it can't be installed over an app that came from the Play Store. The new one is signed with the Play app signing key and installs directly, which makes testing the gplay flavor on a device possible without going through a Play track.

The upload-key APK now carries a `-UPLOAD` suffix so the two can't be mixed up. It lands in `outputs/apk/gplay/<type>/` as before; the installable one lands in `outputs/apk_gplay_signed/<type>/`.

The credentials for the second key live outside the repo, next to the ones already used for the upload key. Without them the extra step logs a line and does nothing, so CI and anyone without release credentials are unaffected.

## Technical Context

- The re-sign runs as a `finalizedBy` of the gplay assemble tasks rather than a step inside packaging, so the AAB path is untouched and no lint or bundle task picks up a signing dependency.
- APK renaming moved from a `doLast` copy to setting `outputFileName` on the variant output. The copy wrote an undeclared second APK into the packaging task's output directory, and after stripping `-UPLOAD` both names resolve to the same destination, so whichever the re-sign step happened to read first would win. It now reads the single file named by the same expression that sets `outputFileName`. Side effect worth knowing: `app-<flavor>-<type>.apk` no longer appears in release and beta output dirs. The FOSS release workflow globs `eu.darken.sdmse-*.apk`, so it still matches.
- Passwords are handed to `apksigner` through `env:` references, not argv, so they don't appear in process listings.
- `apksigner` is resolved from the newest `build-tools` directory that has it, ordering previews before their final release (`37.0.0-rc2` before `37.0.0`).
- Worth a close look: the `finalizedBy` wiring in `app/build.gradle.kts` and the input declarations on `SignGplayApkTask`, since the task deliberately opts out of up-to-date checks and build-cache reuse.
