### PR TITLE
AppCleaner: Fix cache cleaning on Motorola devices with Android 16+

### DIFF
--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -551,15 +551,16 @@ class AOSPSpecs @Inject constructor(
             val canInjectInput = inputInjector.canInject()
             log(TAG, INFO) { "InputInjector available? (canInjectInput=$canInjectInput)" }
 
-            // On Android 16+ Pixel devices, "Clear cache" and "Clear storage" buttons are marked
-            // as NAF (Not Accessibility Focusable), making them invisible to the accessibility service.
+            // On Android 16+, "Clear cache" and "Clear storage" buttons are marked as NAF
+            // (Not Accessibility Focusable) on some devices, making them invisible to the
+            // accessibility service. Known on Google and Motorola Hello UI.
             // DPAD navigation works around this by using keyboard-style navigation (DOWN, RIGHT, CENTER)
             // from the entity_header_content anchor to blindly click the invisible button.
             // https://github.com/d4rken-org/sdmaid-se/issues/2056
-            val isGoogle = BuildWrap.MANUFACTOR.equals("Google", ignoreCase = true)
-            val useDpadFallback = hasApiLevel(36) && isGoogle
+            val dpadManufacturer = supportsDpadFallback(BuildWrap.MANUFACTOR)
+            val useDpadFallback = hasApiLevel(36) && dpadManufacturer
             log(TAG, INFO) {
-                "isGoogle=$isGoogle, useDpadFallback=$useDpadFallback (MANUFACTURER=${BuildWrap.MANUFACTOR}, PRODUCT=${BuildWrap.PRODUCT})"
+                "dpadManufacturer=$dpadManufacturer, useDpadFallback=$useDpadFallback (MANUFACTURER=${BuildWrap.MANUFACTOR}, PRODUCT=${BuildWrap.PRODUCT})"
             }
 
             var nodeActionAttempts = 0

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecs.kt
@@ -566,6 +566,7 @@ class AOSPSpecs @Inject constructor(
             var nodeActionAttempts = 0
             var dpadExhausted = false
             var sizeParser: SizeParser? = null
+            var pendingVerdict = false
             val verdictConfirmer = VerdictConfirmer()
             val nodeAction: suspend StepContext.() -> Boolean = action@{
                 val attempt = nodeActionAttempts++
@@ -595,6 +596,9 @@ class AOSPSpecs @Inject constructor(
                     if (sizeParser == null) sizeParser = runCatching { SizeParser(host.service) }.getOrNull()
                     val cacheSize = readCacheRowSize(cacheSizeLabels, sizeParser)
                     val verdict = noButtonVerdict(cacheSize, pkg.isSystemApp, useDpadFallback)
+                    // A verdict that still needs its confirming pass must not be raced by a blind
+                    // click: an already empty cache would otherwise be reported as a failure.
+                    pendingVerdict = verdict != NoButtonVerdict.KEEP_TRYING
                     when (verdictConfirmer.confirm(verdict)) {
                         NoButtonVerdict.KEEP_TRYING -> {
                             log(tag, VERBOSE) { "$verdict, cacheSize=$cacheSize (attempt=$attempt)" }
@@ -621,13 +625,13 @@ class AOSPSpecs @Inject constructor(
                 val dpadMinAttempts = 2
                 if (useDpadFallback && dpadExhausted) {
                     throw StepAbortException("DPAD exhausted, clear-cache button not reachable (attempt=$attempt)")
-                } else if (useDpadFallback && attempt >= dpadMinAttempts) {
+                } else if (useDpadFallback && attempt >= dpadMinAttempts && !pendingVerdict) {
                     log(tag, INFO) { "DPAD fallback triggered (attempt=$attempt)" }
                     if (tryClickViaFocusNavigation(clearCacheButtonLabels, canInjectInput)) return@action true
                     dpadExhausted = true
                     log(tag, WARN) { "DPAD fallback exhausted, won't retry" }
                 } else if (useDpadFallback) {
-                    log(tag) { "Skipping DPAD fallback (attempt=$attempt < $dpadMinAttempts)" }
+                    log(tag) { "Skipping DPAD fallback (attempt=$attempt, pendingVerdict=$pendingVerdict)" }
                 }
 
                 false

--- a/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/DpadFallbackGate.kt
+++ b/app-tool-appcleaner/src/main/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/DpadFallbackGate.kt
@@ -1,0 +1,10 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
+
+/**
+ * Manufacturers whose Settings withholds the clear-cache row from the accessibility tree, where
+ * D-pad focus traversal is the only way to reach it.
+ */
+internal val DPAD_FALLBACK_MANUFACTURERS = setOf("google", "motorola")
+
+internal fun supportsDpadFallback(manufacturer: String): Boolean =
+    DPAD_FALLBACK_MANUFACTURERS.any { it.equals(manufacturer, ignoreCase = true) }

--- a/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/DpadFallbackGateTest.kt
+++ b/app-tool-appcleaner/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/DpadFallbackGateTest.kt
@@ -1,0 +1,39 @@
+package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * Covers which manufacturers AOSPSpecs opens the DPAD focus-traversal fallback for.
+ *
+ * BuildWrap.MANUFACTOR is whatever the ROM wrote into android.os.Build, so casing is not
+ * guaranteed: the Motorola report that added it here reads "motorola", Google devices read
+ * "Google".
+ */
+class DpadFallbackGateTest : BaseTest() {
+
+    @Test
+    fun `motorola gets the fallback regardless of casing`() {
+        supportsDpadFallback("motorola") shouldBe true
+        supportsDpadFallback("Motorola") shouldBe true
+        supportsDpadFallback("MOTOROLA") shouldBe true
+    }
+
+    @Test
+    fun `google keeps the fallback it already had`() {
+        supportsDpadFallback("Google") shouldBe true
+        supportsDpadFallback("google") shouldBe true
+    }
+
+    @Test
+    fun `manufacturers without the withheld-row behaviour stay on the label matcher`() {
+        supportsDpadFallback("samsung") shouldBe false
+        supportsDpadFallback("Xiaomi") shouldBe false
+    }
+
+    @Test
+    fun `an unset manufacturer does not open the fallback`() {
+        supportsDpadFallback("") shouldBe false
+    }
+}

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/BaseAppCleanerSpecTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/BaseAppCleanerSpecTest.kt
@@ -155,6 +155,8 @@ abstract class BaseAppCleanerSpecTest<S : AppCleanerSpecGenerator, L : Any> : Ba
     protected suspend fun captureAndRunClearCacheAction(
         spec: S = createSpec(),
         pkg: Installed = createTestPkg(),
+        maxAttempts: Int = 10,
+        rethrowAbort: Boolean = false,
     ): Boolean {
         var actionResult = false
 
@@ -171,14 +173,15 @@ abstract class BaseAppCleanerSpecTest<S : AppCleanerSpecGenerator, L : Any> : Ba
                 val nodeAction = step.nodeAction
                 if (nodeAction != null) {
                     try {
-                        for (i in 0 until 10) {
+                        for (i in 0 until maxAttempts) {
                             val result = nodeAction.invoke(stepContext)
                             if (result) {
                                 actionResult = true
                                 break
                             }
                         }
-                    } catch (_: StepAbortException) {
+                    } catch (e: StepAbortException) {
+                        if (rethrowAbort) throw e
                         actionResult = false
                     }
                 }

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
@@ -214,6 +214,38 @@ class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
     }
 
     @Test
+    fun `clear cache quick-try succeeds via DPAD on Motorola`() = runTest {
+        setupTestScope(this)
+        mockkStatic(::hasApiLevel)
+        every { hasApiLevel(any()) } answers { firstArg<Int>() <= 37 }
+        mockkObject(BuildWrap)
+        every { BuildWrap.MANUFACTOR } returns "motorola"
+        every { BuildWrap.PRODUCT } returns "leap_g"
+
+        coEvery { inputInjector.canInject() } returns false
+        every { testHost.service.performGlobalAction(any()) } answers {
+            if (firstArg<Int>() == android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_CENTER) {
+                emitValidationEventAsync()
+            }
+            true
+        }
+
+        testRoot = buildTestTree(
+            """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=true, checkable=false enabled=true, id=com.android.settings:id/entity_header_content pkg=com.android.settings, identity=header, bounds=Rect(84, 328 - 996, 675)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=com.android.settings:id/content_parent pkg=com.android.settings, identity=content, bounds=Rect(0, 159 - 1080, 2300)
+            """.trimIndent()
+        )
+
+        val result = captureAndRunClearCacheAction()
+
+        result shouldBe true
+        verify(exactly = 1) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_RIGHT) }
+        verify(exactly = 1) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_CENTER) }
+    }
+
+    @Test
     fun `clear cache uses InputInjector DPAD path when injection is available`() = runTest {
         setupTestScope(this)
         mockkStatic(::hasApiLevel)

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
@@ -3,17 +3,22 @@ package eu.darken.sdmse.appcleaner.core.automation.specs.aosp
 import eu.darken.sdmse.appcleaner.core.automation.specs.BaseAppCleanerSpecTest
 import eu.darken.sdmse.automation.core.common.ACSNodeInfo
 import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.errors.StepAbortException
 import eu.darken.sdmse.automation.core.input.InputInjector
 import eu.darken.sdmse.common.BuildWrap
 import eu.darken.sdmse.common.device.RomType
 import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.ui.SizeParser
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkConstructor
 import io.mockk.mockkObject
 import io.mockk.mockkStatic
+import io.mockk.unmockkConstructor
 import io.mockk.unmockkObject
 import io.mockk.unmockkStatic
 import io.mockk.verify
@@ -66,6 +71,7 @@ class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
     fun cleanup() {
         unmockkStatic(::hasApiLevel)
         unmockkObject(BuildWrap)
+        unmockkConstructor(SizeParser::class)
     }
 
     private fun emitValidationEventAsync(pkgId: String = "com.android.settings") {
@@ -243,6 +249,43 @@ class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
         result shouldBe true
         verify(exactly = 1) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_RIGHT) }
         verify(exactly = 1) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_CENTER) }
+    }
+
+    @Test
+    fun `an already empty cache is confirmed before any blind DPAD click`() = runTest {
+        setupTestScope(this)
+        mockkStatic(::hasApiLevel)
+        every { hasApiLevel(any()) } answers { firstArg<Int>() <= 37 }
+        mockkObject(BuildWrap)
+        every { BuildWrap.MANUFACTOR } returns "motorola"
+        every { BuildWrap.PRODUCT } returns "leap_g"
+
+        // SizeParser goes through android.text.format.Formatter, an android.jar stub that throws
+        // in this harness, which would make the size unreadable and the verdict inconclusive.
+        mockkConstructor(SizeParser::class)
+        every { anyConstructed<SizeParser>().parse("0 B") } returns 0L
+
+        coEvery { inputInjector.canInject() } returns false
+        every { testHost.service.performGlobalAction(any()) } returns true
+
+        // Anchor is there, so DPAD could run, but Settings prints an empty cache row and there is
+        // no clickable clear-cache node at all.
+        testRoot = buildTestTree(
+            """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=true, checkable=false enabled=true, id=com.android.settings:id/entity_header_content pkg=com.android.settings, identity=header, bounds=Rect(84, 328 - 996, 675)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=row, bounds=Rect(0, 900 - 1080, 1000)
+            ACS-DEBUG: --2: text='Cache', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=android:id/title pkg=com.android.settings, identity=rowTitle, bounds=Rect(60, 900 - 500, 1000)
+            ACS-DEBUG: --2: text='0 B', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=android:id/summary pkg=com.android.settings, identity=rowSummary, bounds=Rect(600, 900 - 1020, 1000)
+            """.trimIndent()
+        )
+
+        val abort = shouldThrow<StepAbortException> {
+            captureAndRunClearCacheAction(maxAttempts = 15, rethrowAbort = true)
+        }
+
+        abort.treatAsSuccess shouldBe true
+        verify(exactly = 0) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_CENTER) }
     }
 
     @Test

--- a/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcleaner/core/automation/specs/aosp/AOSPSpecsTest.kt
@@ -623,4 +623,38 @@ class AOSPSpecsTest : BaseAppCleanerSpecTest<AOSPSpecs, AOSPLabels>() {
         val clearCacheButton = tree.crawl().first { it.node.text == "Clear cache" }.node as TestACSNodeInfo
         clearCacheButton.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
     }
+
+    @Test
+    fun `a non-allowlisted manufacturer never gets a DPAD click`() = runTest {
+        setupTestScope(this)
+        mockkStatic(::hasApiLevel)
+        every { hasApiLevel(any()) } answers { firstArg<Int>() <= 37 }
+        // MANUFACTOR stays at the "TestOEM" default from aospSetup: the API level alone must not
+        // open the fallback, or every AOSP device on 36+ would start blind-clicking. The cache row
+        // is deliberately non-empty, an empty one would end the run at the ALREADY_EMPTY verdict
+        // before the DPAD is ever reachable and leave the assertions below nothing to catch.
+        mockkConstructor(SizeParser::class)
+        every { anyConstructed<SizeParser>().parse("143 kB") } returns 143360L
+
+        coEvery { inputInjector.canInject() } returns false
+        every { testHost.service.performGlobalAction(any()) } returns true
+
+        // Anchor is there, so DPAD could run, but there is no clickable clear-cache node at all.
+        testRoot = buildTestTree(
+            """
+            ACS-DEBUG: 0: text='null', class=android.widget.FrameLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=root, bounds=Rect(0, 0 - 1080, 2400)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=true, checkable=false enabled=true, id=com.android.settings:id/entity_header_content pkg=com.android.settings, identity=header, bounds=Rect(84, 328 - 996, 675)
+            ACS-DEBUG: -1: text='null', class=android.widget.LinearLayout, clickable=false, checkable=false enabled=true, id=null pkg=com.android.settings, identity=row, bounds=Rect(0, 900 - 1080, 1000)
+            ACS-DEBUG: --2: text='Cache', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=android:id/title pkg=com.android.settings, identity=rowTitle, bounds=Rect(60, 900 - 500, 1000)
+            ACS-DEBUG: --2: text='143 kB', class=android.widget.TextView, clickable=false, checkable=false enabled=true, id=android:id/summary pkg=com.android.settings, identity=rowSummary, bounds=Rect(600, 900 - 1020, 1000)
+            """.trimIndent()
+        )
+
+        val result = captureAndRunClearCacheAction(maxAttempts = 5)
+
+        result shouldBe false
+        verify(exactly = 0) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_CENTER) }
+        verify(exactly = 0) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_DOWN) }
+        verify(exactly = 0) { testHost.service.performGlobalAction(android.accessibilityservice.AccessibilityService.GLOBAL_ACTION_DPAD_RIGHT) }
+    }
 }


### PR DESCRIPTION
## What changed

AppCleaner could not clear app caches on Motorola devices running Android 16 or newer. The storage
page in Settings shows a working "Clear cache" button, but the system hides that whole row from
accessibility services, so SD Maid could not find anything to press. It waited 30 seconds on each app
and the run ended with a generic automation error and nothing cleaned.

SD Maid already has a workaround for this on Google devices: instead of looking for the button, it
navigates to it the way a TV remote would and presses it blind. That workaround was switched on for
Google phones only. It now covers Motorola at Android 16 and newer as well.

Also fixed: on devices using that workaround, an app whose cache was already empty could be reported
as a failure instead of quietly being skipped.

Reported on a Motorola razr 60 ultra running Android 17, without root or Shizuku.

## Technical Context

- Root cause is structural, not a matching problem: the clear-cache row is absent from the
  accessibility tree entirely — no node with the label as text or content description exists anywhere
  in the reporter's dump, and the label is resolved correctly from the Settings APK. No change to
  matching or label resolution could have helped, which is why the fallback gate is the fix.
- The gate stays a manufacturer allowlist rather than an API-level check. This path presses whatever
  currently holds focus, and on that screen the neighbouring control wipes app data. Opening it by API
  level alone would start blind clicking on every AOSP device at 36+. One of the added tests exists
  purely to fail if someone later reduces the gate to an API check — it drives the full spec with a
  non-empty cache row, because an empty one terminates before the fallback is reachable and would
  make the test pass regardless.
- Accepted behaviour change for Motorola system apps: the fallback is consulted before the
  "system app with no button" branch, so such apps no longer raise the specific unclearable-cache
  error that stops SD Maid advertising those bytes, and instead count toward the run-level failure
  limit. This is the semantics Google devices have had since the fallback shipped.
- The second commit fixes an ordering bug that the gate change newly exposes: confirming an empty
  cache takes two consecutive reads about a second apart, but the fallback fired between them and
  aborted first, so the app was reported as failed. The fallback now waits for that confirmation.
  Known limitation, deliberately left: if Settings has not rendered a readable cache size by the
  first read, an already-empty cache is still reported as a failure. That is unchanged from current
  behaviour on Google devices.
- Not verified, and cannot be from here: whether the remote-control navigation actually reaches the
  buttons on this ROM. That path had never run on it, because the gate was closed. The earlier work
  it copies was validated on a device with Shizuku, which uses real input injection; without Shizuku
  this uses global accessibility actions, which report only that the event was accepted, not that
  focus moved. This needs confirmation from the reporter's test build before release.
