### PR TITLE
Deduplicator: Keep similar-photo groups the same between scans

### DIFF
--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/phash/PHashSleuth.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/phash/PHashSleuth.kt
@@ -146,34 +146,7 @@ class PHashSleuth @Inject constructor(
         }
 
         val compareStart = System.currentTimeMillis()
-        val requiredSim = 0.95f
-        val remainingItems = LinkedList(filteredItems.keys)
-        val hashBuckets = mutableSetOf<Set<Pair<APathLookup<*>, Double>>>()
-
-        updateProgressCount(Progress.Count.Percent(remainingItems.size))
-
-        while (currentCoroutineContext().isActive && remainingItems.isNotEmpty()) {
-            val target = remainingItems.removeFirst()
-            val targetHash = filteredItems[target]!!
-
-            val others = remainingItems
-                .map { it to targetHash.similarityTo(filteredItems[it]!!) }
-                .onEach { (other, sim) ->
-                    if (Bugs.isTrace || sim > requiredSim) {
-                        log(TAG, VERBOSE) { "${String.format("%.2f%%", sim * 100)} : $target <-> $other" }
-                    }
-                }
-                .filter { it.second > requiredSim }
-
-            remainingItems.removeAll(others.map { it.first }.toSet())
-
-            if (others.isEmpty()) continue
-
-            // We group the target with others and use the average distance as it's distance
-            val targetWithOthers = others.plus(target to others.map { it.second }.average()).toSet()
-            hashBuckets.add(targetWithOthers)
-            increaseProgress(remainingItems.size)
-        }
+        val hashBuckets = groupBySimilarity(filteredItems)
 
         val hashStop = System.currentTimeMillis()
         val wallMs = hashStop - hashStart
@@ -203,6 +176,42 @@ class PHashSleuth @Inject constructor(
                 }.toSet()
             )
         }.toSet()
+    }
+
+    internal suspend fun groupBySimilarity(
+        hashes: Map<APathLookup<*>, PHasher.Result>,
+    ): Set<Set<Pair<APathLookup<*>, Double>>> {
+        // Greedy grouping: each item is compared against the first unassigned target only,
+        // so traversal order decides the partition. Sorting by path keeps it reproducible.
+        val remainingItems = LinkedList(hashes.keys.sortedBy { it.path })
+        val hashBuckets = mutableSetOf<Set<Pair<APathLookup<*>, Double>>>()
+
+        updateProgressCount(Progress.Count.Percent(remainingItems.size))
+
+        while (currentCoroutineContext().isActive && remainingItems.isNotEmpty()) {
+            val target = remainingItems.removeFirst()
+            val targetHash = hashes[target]!!
+
+            val others = remainingItems
+                .map { it to targetHash.similarityTo(hashes[it]!!) }
+                .onEach { (other, sim) ->
+                    if (Bugs.isTrace || sim > REQUIRED_SIMILARITY) {
+                        log(TAG, VERBOSE) { "${String.format("%.2f%%", sim * 100)} : $target <-> $other" }
+                    }
+                }
+                .filter { it.second > REQUIRED_SIMILARITY }
+
+            remainingItems.removeAll(others.map { it.first }.toSet())
+
+            if (others.isEmpty()) continue
+
+            // We group the target with others and use the average distance as it's distance
+            val targetWithOthers = others.plus(target to others.map { it.second }.average()).toSet()
+            hashBuckets.add(targetWithOthers)
+            increaseProgress(remainingItems.size)
+        }
+
+        return hashBuckets
     }
 
     private suspend fun APathLookup<*>.loadBitmap(): Bitmap {
@@ -244,6 +253,8 @@ class PHashSleuth @Inject constructor(
 
     companion object {
         private const val MAX_CONCURRENT_OPS = 4
+
+        private const val REQUIRED_SIMILARITY = 0.95f
 
         // Minimum AC coefficient variance for a meaningful pHash comparison.
         // Images below this have near-uniform content where DCT hash bits are noise-dominated.

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/scanner/phash/PHashSleuthGroupingTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/scanner/phash/PHashSleuthGroupingTest.kt
@@ -1,0 +1,66 @@
+package eu.darken.sdmse.deduplicator.core.scanner.phash
+
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.deduplicator.core.scanner.phash.phash.PHashBits
+import eu.darken.sdmse.deduplicator.core.scanner.phash.phash.PHasher
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class PHashSleuthGroupingTest : BaseTest() {
+
+    private val sleuth = PHashSleuth(mockk(), mockk(), mockk())
+
+    private fun lookup(path: String): APathLookup<*> = mockk {
+        every { this@mockk.path } returns path
+    }
+
+    private fun result(bits: Long) = PHasher.Result(hash = PHashBits(bits))
+
+    private fun Set<Set<Pair<APathLookup<*>, Double>>>.paths() =
+        map { group -> group.map { it.first.path }.toSet() }.toSet()
+
+    // A~B: 3 differing bits (61/64 > 0.95), B~C: 3 differing bits, A~C: 6 differing bits (58/64 < 0.95)
+    private val a = lookup("/dcim/a.jpg") to result(0L)
+    private val b = lookup("/dcim/b.jpg") to result(0b111L)
+    private val c = lookup("/dcim/c.jpg") to result(0b111111L)
+
+    @Test
+    fun `chain grouping does not depend on input order`() = runTest {
+        val forward = sleuth.groupBySimilarity(linkedMapOf(a, b, c)).paths()
+        val reversed = sleuth.groupBySimilarity(linkedMapOf(c, b, a)).paths()
+
+        forward shouldBe setOf(setOf("/dcim/a.jpg", "/dcim/b.jpg"))
+        reversed shouldBe forward
+    }
+
+    @Test
+    fun `target without similar sibling produces no group`() = runTest {
+        val lone = lookup("/dcim/z.jpg") to result(-1L)
+        val groups = sleuth.groupBySimilarity(linkedMapOf(a, b, lone)).paths()
+
+        groups shouldBe setOf(setOf("/dcim/a.jpg", "/dcim/b.jpg"))
+    }
+
+    @Test
+    fun `target similarity is the average over its group`() = runTest {
+        // target 0L; siblings differ by 1 bit (63/64) and 3 bits (61/64); average is 62/64
+        val target = lookup("/dcim/t.jpg") to result(0L)
+        val near = lookup("/dcim/u.jpg") to result(1L)
+        val far = lookup("/dcim/v.jpg") to result(0b111L)
+
+        listOf(linkedMapOf(target, near, far), linkedMapOf(far, near, target)).forEach { input ->
+            val group = sleuth.groupBySimilarity(input).single()
+            val byPath = group.associate { it.first.path to it.second }
+
+            byPath shouldBe mapOf(
+                "/dcim/t.jpg" to 62.0 / 64.0,
+                "/dcim/u.jpg" to 63.0 / 64.0,
+                "/dcim/v.jpg" to 61.0 / 64.0,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What changed

When the Deduplicator searches for similar photos, the same set of pictures could land in different groups from one scan to the next, and a different photo could be suggested as the one to keep. Groups are now built in a fixed order, so scanning the same photos again yields the same groups and the same keep suggestion.

## Technical Context

- Root cause: similarity grouping is greedy against the first unassigned candidate, so traversal order decides the partition. The candidate map was materialised from a `flatMapMerge`, whose iteration order follows concurrent emission order and differs between runs. For A~B and B~C above threshold but A~C below it, starting at A yields {A,B}, starting at C yields {C,B}.
- Candidates are now sorted by path before the grouping loop. The parallel hashing stage is untouched, since order only matters once grouping starts.
- Transitive clustering would also remove the order dependence but changes what a group means (A and C would be grouped through B without being similar to each other), so it was left out.
- The loop moved into `groupBySimilarity` so it can be exercised with synthetic hashes. The new test pins the chain case in both insertion orders and fails without the sort.
- Review focus: the extracted loop should be identical to the previous inline version apart from the sort and the threshold constant.
