### PR TITLE
Deduplicator: Find duplicate HEIC photos

### DIFF
--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/CommonFilesCheck.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/core/scanner/CommonFilesCheck.kt
@@ -38,6 +38,8 @@ class CommonFilesCheck @Inject constructor(
             "image/png",
             "image/gif",
             "image/webp",
+            "image/heic",
+            "image/heif",
             "image/svg+xml",
         )
 

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/scanner/CommonFilesCheckTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/core/scanner/CommonFilesCheckTest.kt
@@ -1,0 +1,42 @@
+package eu.darken.sdmse.deduplicator.core.scanner
+
+import eu.darken.sdmse.common.MimeTypeTool
+import eu.darken.sdmse.common.files.APathLookup
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class CommonFilesCheckTest : BaseTest() {
+
+    private val mimeTypeTool: MimeTypeTool = mockk()
+
+    private val subject = CommonFilesCheck(mimeTypeTool)
+
+    private fun lookupOfType(mimeType: String): APathLookup<*> = mockk<APathLookup<*>>(relaxed = true).also {
+        coEvery { mimeTypeTool.determineMimeType(it) } returns mimeType
+    }
+
+    @Test
+    fun `heic is common and an image`() = runTest {
+        val lookup = lookupOfType("image/heic")
+        subject.isCommon(lookup) shouldBe true
+        subject.isImage(lookup) shouldBe true
+    }
+
+    @Test
+    fun `heif is common and an image`() = runTest {
+        val lookup = lookupOfType("image/heif")
+        subject.isCommon(lookup) shouldBe true
+        subject.isImage(lookup) shouldBe true
+    }
+
+    @Test
+    fun `an unlisted mime type is neither common nor an image`() = runTest {
+        val lookup = lookupOfType("application/x-unlisted")
+        subject.isCommon(lookup) shouldBe false
+        subject.isImage(lookup) shouldBe false
+    }
+}


### PR DESCRIPTION
## What changed

The Deduplicator now includes HEIC and HEIF photos in its scan. Until now they were skipped entirely, so identical HEIC photos (the default camera format on iPhones and some Android devices) never showed up as duplicates. They are now covered by the default checksum scan and, if enabled, by the similar-image scan as well.

## Technical Context

- Root cause: the common-file filter that runs ahead of every detection method had no `image/heic` or `image/heif` entry, and "skip uncommon files" is on by default, so HEIC files were dropped before any sleuth saw them.
- The mime resolver already maps `.heic` and `.heif` to those types, with a fallback for devices whose `MimeTypeMap` lacks them, so extending the filter's image set is the whole change.
- Similar-image (pHash) detection on HEIC relies on platform HEIF decoding (Android 9+). Where decoding fails, the existing skip path applies. HEIC-heavy libraries will make an enabled pHash scan take longer, since HEVC decoding is slower than JPEG.
- Squeezer's HEIC mime constant is not reused because the Deduplicator module has no dependency on the Squeezer module.
