### PR TITLE
Swiper: Fix taps on a card's buttons being treated as swipes

### DIFF
--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeScreen.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/SwiperSwipeScreen.kt
@@ -48,6 +48,10 @@ import eu.darken.sdmse.common.compose.tour.LocalGuidedTourController
 import eu.darken.sdmse.common.compose.tour.guidedTourTarget
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.error.ErrorEventHandler
 import eu.darken.sdmse.common.exclusion.R as ExclusionR
 import eu.darken.sdmse.common.navigation.NavigationEventHandler
@@ -66,6 +70,8 @@ import eu.darken.sdmse.swiper.ui.swipe.items.SwiperStatsCard
 import eu.darken.sdmse.swiper.ui.swipe.tour.SwiperSwipeTour
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+
+private val TAG = logTag("Swiper", "Swipe", "Screen")
 
 @Composable
 fun SwiperSwipeScreenHost(
@@ -89,7 +95,10 @@ fun SwiperSwipeScreenHost(
                     haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                 is SwiperSwipeViewModel.Event.OpenExternally -> runCatching {
                     context.startActivity(event.intent)
-                }.onFailure { snackbarHostState.showSnackbar(openNotSupportedText) }
+                }.onFailure {
+                    log(TAG, ERROR) { "Failed to start activity for ${event.intent}: ${it.asLog()}" }
+                    snackbarHostState.showSnackbar(openNotSupportedText)
+                }
                 is SwiperSwipeViewModel.Event.ShowOpenNotSupported ->
                     snackbarHostState.showSnackbar(openNotSupportedText)
             }

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperDeckCard.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperDeckCard.kt
@@ -89,8 +89,11 @@ internal fun SwiperDeckCard(
 
                 // Gesture-local source of truth. Animatable.snapTo is suspend and runs on the
                 // animation scope, so reading offsetX.value back mid-gesture can miss deltas that
-                // are still queued; this accumulates them synchronously instead.
-                var dragOffset = Offset(offsetX.value, offsetY.value)
+                // are still queued; this accumulates them synchronously instead. It is seeded in
+                // the slop callback rather than here: a press landing on a running snap-back must
+                // start from where the card has actually travelled to by the time the drag is
+                // claimed, not from where it sat when the finger went down.
+                var dragOffset = Offset.Zero
 
                 // Below touch slop this consumes nothing, so a tap still reaches the clickable
                 // corner buttons inside the card. It also cancels if another recognizer claims the
@@ -98,7 +101,7 @@ internal fun SwiperDeckCard(
                 val slopChange = awaitTouchSlopOrCancellation(down.id) { change, overSlop ->
                     change.consume()
                     tracker.addPointerInputChange(change)
-                    dragOffset += overSlop
+                    dragOffset = Offset(offsetX.value, offsetY.value) + overSlop
                     val target = dragOffset
                     animationScope.launch {
                         offsetX.snapTo(target.x)

--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperDeckCard.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperDeckCard.kt
@@ -5,6 +5,7 @@ import androidx.compose.animation.core.spring
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitTouchSlopOrCancellation
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
@@ -15,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
@@ -85,21 +87,40 @@ internal fun SwiperDeckCard(
                 val tracker = VelocityTracker()
                 tracker.addPointerInputChange(down)
 
+                // Gesture-local source of truth. Animatable.snapTo is suspend and runs on the
+                // animation scope, so reading offsetX.value back mid-gesture can miss deltas that
+                // are still queued; this accumulates them synchronously instead.
+                var dragOffset = Offset(offsetX.value, offsetY.value)
+
+                // Below touch slop this consumes nothing, so a tap still reaches the clickable
+                // corner buttons inside the card. It also cancels if another recognizer claims the
+                // pointer and follows a pointer handoff when the tracked finger lifts.
+                val slopChange = awaitTouchSlopOrCancellation(down.id) { change, overSlop ->
+                    change.consume()
+                    tracker.addPointerInputChange(change)
+                    dragOffset += overSlop
+                    val target = dragOffset
+                    animationScope.launch {
+                        offsetX.snapTo(target.x)
+                        offsetY.snapTo(target.y)
+                    }
+                } ?: return@awaitEachGesture
+
                 while (true) {
                     val event = awaitPointerEvent(PointerEventPass.Main)
-                    val change = event.changes.firstOrNull { it.id == down.id }
+                    val change = event.changes.firstOrNull { it.id == slopChange.id }
                         ?: event.changes.first()
                     if (!change.pressed) break
                     val drag = change.positionChange()
                     if (drag.x != 0f || drag.y != 0f) {
                         tracker.addPointerInputChange(change)
-                        val targetX = offsetX.value + drag.x
-                        val targetY = offsetY.value + drag.y
+                        dragOffset += drag
+                        val target = dragOffset
                         // Hop to the regular coroutine scope to call Animatable.snapTo;
                         // awaitEachGesture's RestrictsSuspension scope can't invoke it directly.
                         animationScope.launch {
-                            offsetX.snapTo(targetX)
-                            offsetY.snapTo(targetY)
+                            offsetX.snapTo(target.x)
+                            offsetY.snapTo(target.y)
                         }
                         change.consume()
                     }
@@ -107,8 +128,8 @@ internal fun SwiperDeckCard(
 
                 val velocity = tracker.calculateVelocity()
                 val outcome = decideSwipe(
-                    offsetX = offsetX.value,
-                    offsetY = offsetY.value,
+                    offsetX = dragOffset.x,
+                    offsetY = dragOffset.y,
                     velocityX = velocity.x,
                     velocityY = velocity.y,
                     threshold = swipeThreshold,
@@ -127,13 +148,13 @@ internal fun SwiperDeckCard(
                             offsetX.animateTo(0f, spring())
                             offsetY.animateTo(0f, spring())
                         }
-                        onCommit(outcome, offsetX.value, offsetY.value)
+                        onCommit(outcome, dragOffset.x, dragOffset.y)
                     }
                     else -> {
                         // Keep / Delete / Skip: hand the fly-off to a leaving overlay; this card is
                         // about to be dropped from the deck as the cursor advances.
                         isCommitting = true
-                        onCommit(outcome, offsetX.value, offsetY.value)
+                        onCommit(outcome, dragOffset.x, dragOffset.y)
                     }
                 }
             }

--- a/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperDeckCardTest.kt
+++ b/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperDeckCardTest.kt
@@ -1,0 +1,122 @@
+package eu.darken.sdmse.swiper.ui.swipe.items
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalViewConfiguration
+import androidx.compose.ui.test.center
+import androidx.compose.ui.test.down
+import androidx.compose.ui.test.moveBy
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performTouchInput
+import androidx.compose.ui.test.up
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.swiper.ui.preview.previewSwipeItem
+import eu.darken.sdmse.swiper.ui.swipe.SwipeOutcome
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class SwiperDeckCardTest : BaseComposeRobolectricTest() {
+
+    private class Harness {
+        var openClicks = 0
+        var previewClicks = 0
+        var committed: SwipeOutcome? = null
+        var touchSlop = 0f
+        var cardWidth = 0
+    }
+
+    private fun setCard(): Harness {
+        val harness = Harness()
+        composeRule.setContent {
+            harness.touchSlop = LocalViewConfiguration.current.touchSlop
+            // Renders FilePreviewImage's placeholder branch instead of issuing a real Coil request,
+            // whose async completion could recompose mid-gesture.
+            CompositionLocalProvider(LocalInspectionMode provides true) {
+                PreviewWrapper {
+                    SwiperDeckCard(
+                        modifier = Modifier.onSizeChanged { harness.cardWidth = it.width },
+                        item = previewSwipeItem(),
+                        isTop = true,
+                        canUndo = true,
+                        swapDirections = false,
+                        showDetails = true,
+                        sessionPosition = 3,
+                        totalItems = 12,
+                        onCommit = { outcome, _, _ -> harness.committed = outcome },
+                        onPreviewClick = { harness.previewClicks++ },
+                        onOpenExternallyClick = { harness.openClicks++ },
+                    )
+                }
+            }
+        }
+        return harness
+    }
+
+    @Test
+    fun `sub-slop movement does not cancel the open-externally click`() {
+        val harness = setCard()
+
+        composeRule.onNodeWithContentDescription("Open in external app").performTouchInput {
+            down(center)
+            moveBy(Offset(1f, 1f))
+            up()
+        }
+
+        composeRule.runOnIdle { assertEquals(1, harness.openClicks) }
+    }
+
+    @Test
+    fun `sub-slop movement does not cancel the fullscreen-preview click`() {
+        val harness = setCard()
+
+        composeRule.onNodeWithContentDescription("View").performTouchInput {
+            down(center)
+            moveBy(Offset(1f, 1f))
+            up()
+        }
+
+        composeRule.runOnIdle { assertEquals(1, harness.previewClicks) }
+    }
+
+    @Test
+    fun `movement just past slop claims the gesture without committing`() {
+        val harness = setCard()
+
+        composeRule.onNodeWithContentDescription("Open in external app").performTouchInput {
+            down(center)
+            moveBy(Offset(harness.touchSlop + 1f, 0f))
+            up()
+        }
+
+        composeRule.runOnIdle {
+            assertEquals(0, harness.openClicks)
+            assertEquals(null, harness.committed)
+        }
+    }
+
+    @Test
+    fun `a slow multi-event drag still commits a swipe`() {
+        val harness = setCard()
+
+        composeRule.onNodeWithContentDescription("Open in external app").performTouchInput {
+            down(center)
+            // Five samples so the Lsq2 velocity tracker has enough data, spaced far enough apart to
+            // stay below SWIPE_VELOCITY_THRESHOLD: the commit comes from the accumulated 0.6x width.
+            moveBy(Offset(harness.cardWidth * 0.12f, 0f), delayMillis = 400)
+            moveBy(Offset(harness.cardWidth * 0.12f, 0f), delayMillis = 400)
+            moveBy(Offset(harness.cardWidth * 0.12f, 0f), delayMillis = 400)
+            moveBy(Offset(harness.cardWidth * 0.12f, 0f), delayMillis = 400)
+            moveBy(Offset(harness.cardWidth * 0.12f, 0f), delayMillis = 400)
+            up()
+        }
+
+        composeRule.runOnIdle {
+            assertEquals(SwipeOutcome.Keep, harness.committed)
+            assertEquals(0, harness.openClicks)
+        }
+    }
+}

--- a/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperDeckCardTest.kt
+++ b/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/swipe/items/SwiperDeckCardTest.kt
@@ -119,4 +119,34 @@ class SwiperDeckCardTest : BaseComposeRobolectricTest() {
             assertEquals(0, harness.openClicks)
         }
     }
+
+    @Test
+    fun `a gesture started during the snap-back is judged on its own drag`() {
+        val harness = setCard()
+        val card = composeRule.onNodeWithContentDescription("Open in external app")
+        composeRule.mainClock.autoAdvance = false
+
+        // Gesture 1: a third of the card in a single move event, so the Lsq2 tracker reports no
+        // velocity and the 0.33x drag stays under the 0.4x threshold. Release starts a snap-back.
+        card.performTouchInput {
+            down(center)
+            moveBy(Offset(harness.touchSlop + harness.cardWidth * 0.33f, 0f), delayMillis = 400)
+            up()
+        }
+
+        // Gesture 2 presses while that spring is in flight, then holds still long enough for it to
+        // finish: the card is drawn back at zero before this drag ever crosses slop.
+        composeRule.mainClock.advanceTimeByFrame()
+        card.performTouchInput { down(center) }
+        composeRule.mainClock.advanceTimeBy(600)
+        card.performTouchInput {
+            moveBy(Offset(harness.touchSlop + harness.cardWidth * 0.1f, 0f), delayMillis = 400)
+            up()
+        }
+
+        composeRule.mainClock.autoAdvance = true
+        composeRule.runOnIdle {
+            assertEquals("0.1x drag must not commit", null, harness.committed)
+        }
+    }
 }


### PR DESCRIPTION
## What changed

On the Swiper screen, the two buttons in a card's top corners — open in another app, and full-screen preview — usually did nothing when tapped. The card's swipe detection claimed the gesture the instant a finger moved even a single pixel, which cancelled the button press before it could fire. Since nobody holds a finger perfectly still, the buttons failed most of the time.

Tapping them works now, and swiping is unchanged: a drag still has to travel the usual distance before the card starts following the finger.

Two more fixes in the same gesture handling:

- Releasing a swipe without committing it and then grabbing the card again while it was springing back could record a Keep or Delete from a tiny second drag, because that drag inherited the distance of the previous one. Each gesture is now judged on its own movement.
- When opening a file in another app failed, the app showed a message but recorded nothing, so that case was indistinguishable from the button never having been pressed. It is logged now.

## Technical Context

- Root cause: the card's `awaitEachGesture` loop consumed the pointer change on any nonzero `positionChange()`, with no touch-slop comparison. `ClickableNode` cancels a pending click when it sees a consumed change on the Final pass; Main dispatches child-first and Final parent-first, so the parent's sub-slop consume reached the corner buttons on every press.
- The pre-drag phase now delegates to `awaitTouchSlopOrCancellation`. Besides consuming nothing below slop, it supplies consumed-drag cancellation, multi-pointer handoff, and a pre-slop Final-pass check that the hand-rolled loop lacked, and it reports the post-slop remainder so the card does not jump at drag start.
- `awaitFirstDown(requireUnconsumed = false)` is load-bearing and deliberately unchanged: `ClickableNode` consumes the down, so requiring an unconsumed down would break dragging a card that is grabbed on top of a button.
- The gesture accumulates its own `dragOffset` rather than reading the `Animatable`s back mid-gesture, since `snapTo` is suspend behind a `MutatorMutex` and dispatches asynchronously. It is seeded inside the slop callback, not at the down event — seeding at down is what allowed a gesture to inherit a running snap-back's position.
- Worth close review: `SwiperDeckCardTest` drives the real Compose gesture pipeline under Robolectric. The multi-event drag case depends on the Lsq2 velocity tracker's three-sample minimum — a single-move drag reports zero velocity there and would quietly exercise a different code path.
