### PR TITLE
SystemCleaner: Fix Shizuku scans failing on huge nested folder trees

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathIPCFlow.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathIPCFlow.kt
@@ -30,6 +30,7 @@ import java.io.PipedOutputStream
 
 private const val CHUNK_COUNT = 100
 private const val PATH_SIZE = 1024
+private const val HOST_PIPE_SIZE = 32 * 1024
 
 fun RemoteInputStream.toLocalPathFlow(): Flow<LocalPath> = flow {
     if (Bugs.isTrace) log(FileOpsClient.TAG, VERBOSE) { "RemoteInputStream.toLocalPathFlow() starting..." }
@@ -84,26 +85,23 @@ fun RemoteInputStream.toLocalPathFlow(): Flow<LocalPath> = flow {
 fun Flow<LocalPath>.toRemoteInputStream(scope: CoroutineScope): RemoteInputStream {
     if (Bugs.isTrace) log(FileOpsHost.TAG, VERBOSE) { "Flow<LocalPath>.toRemoteInputStream()..." }
 
-    val inputStream = PipedInputStream(2 * CHUNK_COUNT * PATH_SIZE)
+    val inputStream = PipedInputStream(HOST_PIPE_SIZE)
     val outputStream = PipedOutputStream()
     inputStream.connect(outputStream)
 
-    val buffer = outputStream.writer().buffered(CHUNK_COUNT * PATH_SIZE)
+    val buffer = outputStream.writer().buffered()
 
     val resultFlow: Flow<LocalPathResult> = flow {
-        try {
-            this@toRemoteInputStream.collect { path ->
-                emit(LocalPathResult.Success(path))
-            }
-            // Terminal marker: tells the consumer the stream ended cleanly rather than being
-            // truncated by a dying host process.
-            emit(LocalPathResult.Complete)
-        } catch (exception: CancellationException) {
-            // Cancellation is not a stream error — let it unwind instead of fabricating an Error frame.
-            throw exception
-        } catch (exception: Exception) {
-            emit(LocalPathResult.Error(exception))
+        this@toRemoteInputStream.collect { path ->
+            emit(LocalPathResult.Success(path))
         }
+        // Terminal marker: tells the consumer the stream ended cleanly rather than being
+        // truncated by a dying host process.
+        emit(LocalPathResult.Complete)
+    }.catch { exception ->
+        // Cancellation is not a stream error — let it unwind instead of fabricating an Error frame.
+        if (exception !is Exception || exception is CancellationException) throw exception
+        emit(LocalPathResult.Error(exception))
     }
 
     resultFlow

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupExtendedIPCFlow.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupExtendedIPCFlow.kt
@@ -30,6 +30,7 @@ import java.io.PipedOutputStream
 
 private const val CHUNK_COUNT = 100
 private const val LOOKUP_SIZE = 1024
+private const val HOST_PIPE_SIZE = 32 * 1024
 
 fun RemoteInputStream.toLocalPathLookupExtendedFlow(): Flow<LocalPathLookupExtended> = flow {
     if (Bugs.isTrace) log(FileOpsClient.TAG, VERBOSE) { "RemoteInputStream.toLocalPathLookupExtendedFlow() starting..." }
@@ -84,26 +85,23 @@ fun RemoteInputStream.toLocalPathLookupExtendedFlow(): Flow<LocalPathLookupExten
 fun Flow<LocalPathLookupExtended>.toRemoteInputStream(scope: CoroutineScope): RemoteInputStream {
     if (Bugs.isTrace) log(FileOpsHost.TAG, VERBOSE) { "Flow<LocalPathLookupExtended>.toRemoteInputStream()..." }
 
-    val inputStream = PipedInputStream(2 * CHUNK_COUNT * LOOKUP_SIZE)
+    val inputStream = PipedInputStream(HOST_PIPE_SIZE)
     val outputStream = PipedOutputStream()
     inputStream.connect(outputStream)
 
-    val buffer = outputStream.writer().buffered(CHUNK_COUNT * LOOKUP_SIZE)
+    val buffer = outputStream.writer().buffered()
 
     val resultFlow: Flow<LocalPathLookupExtendedResult> = flow {
-        try {
-            this@toRemoteInputStream.collect { lookup ->
-                emit(LocalPathLookupExtendedResult.Success(lookup))
-            }
-            // Terminal marker: tells the consumer the stream ended cleanly rather than being
-            // truncated by a dying host process.
-            emit(LocalPathLookupExtendedResult.Complete)
-        } catch (exception: CancellationException) {
-            // Cancellation is not a stream error — let it unwind instead of fabricating an Error frame.
-            throw exception
-        } catch (exception: Exception) {
-            emit(LocalPathLookupExtendedResult.Error(exception))
+        this@toRemoteInputStream.collect { lookup ->
+            emit(LocalPathLookupExtendedResult.Success(lookup))
         }
+        // Terminal marker: tells the consumer the stream ended cleanly rather than being
+        // truncated by a dying host process.
+        emit(LocalPathLookupExtendedResult.Complete)
+    }.catch { exception ->
+        // Cancellation is not a stream error — let it unwind instead of fabricating an Error frame.
+        if (exception !is Exception || exception is CancellationException) throw exception
+        emit(LocalPathLookupExtendedResult.Error(exception))
     }
 
     resultFlow

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupIPCFlow.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupIPCFlow.kt
@@ -30,6 +30,7 @@ import java.io.PipedOutputStream
 
 private const val CHUNK_COUNT = 100
 private const val LOOKUP_SIZE = 1024
+private const val HOST_PIPE_SIZE = 32 * 1024
 
 fun RemoteInputStream.toLocalPathLookupFlow(): Flow<LocalPathLookup> = flow {
     if (Bugs.isTrace) log(FileOpsClient.TAG, VERBOSE) { "RemoteInputStream.toLocalPathLookupResultFlow() starting..." }
@@ -84,26 +85,23 @@ fun RemoteInputStream.toLocalPathLookupFlow(): Flow<LocalPathLookup> = flow {
 fun Flow<LocalPathLookup>.toRemoteInputStream(scope: CoroutineScope): RemoteInputStream {
     if (Bugs.isTrace) log(FileOpsHost.TAG, VERBOSE) { "Flow<LocalPathLookup>.toRemoteInputStreamWithExceptions()..." }
 
-    val inputStream = PipedInputStream(2 * CHUNK_COUNT * LOOKUP_SIZE)
+    val inputStream = PipedInputStream(HOST_PIPE_SIZE)
     val outputStream = PipedOutputStream()
     inputStream.connect(outputStream)
 
-    val buffer = outputStream.writer().buffered(CHUNK_COUNT * LOOKUP_SIZE)
+    val buffer = outputStream.writer().buffered()
 
     val resultFlow: Flow<LocalPathLookupResult> = flow {
-        try {
-            this@toRemoteInputStream.collect { lookup ->
-                emit(LocalPathLookupResult.Success(lookup))
-            }
-            // Terminal marker: tells the consumer the stream ended cleanly rather than being
-            // truncated by a dying host process.
-            emit(LocalPathLookupResult.Complete)
-        } catch (exception: CancellationException) {
-            // Cancellation is not a stream error — let it unwind instead of fabricating an Error frame.
-            throw exception
-        } catch (exception: Exception) {
-            emit(LocalPathLookupResult.Error(exception))
+        this@toRemoteInputStream.collect { lookup ->
+            emit(LocalPathLookupResult.Success(lookup))
         }
+        // Terminal marker: tells the consumer the stream ended cleanly rather than being
+        // truncated by a dying host process.
+        emit(LocalPathLookupResult.Complete)
+    }.catch { exception ->
+        // Cancellation is not a stream error — let it unwind instead of fabricating an Error frame.
+        if (exception !is Exception || exception is CancellationException) throw exception
+        emit(LocalPathLookupResult.Error(exception))
     }
 
     resultFlow

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteInputStreamExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteInputStreamExtensions.kt
@@ -29,34 +29,52 @@ import java.io.InputStream
 /**
  * Use this on the root side
  */
-internal fun InputStream.remoteInputStream(): RemoteInputStream.Stub = object : RemoteInputStream.Stub() {
+internal fun InputStream.remoteInputStream(): RemoteInputStream.Stub = RemoteInputStreamStub(this)
 
-    override fun available(): Int = try {
-        this@remoteInputStream.available()
-    } catch (e: IOException) {
-        log(ERROR) { "available() failed: ${e.asLog()}" }
-        -2
+private class RemoteInputStreamStub(initial: InputStream) : RemoteInputStream.Stub() {
+
+    // Dropped on close() so the Stub, which the client may hold on to, stops pinning the stream
+    // and whatever buffer it owns.
+    @Volatile private var stream: InputStream? = initial
+
+    override fun available(): Int {
+        val s = stream ?: return -2
+        return try {
+            s.available()
+        } catch (e: IOException) {
+            log(ERROR) { "available() failed: ${e.asLog()}" }
+            -2
+        }
     }
 
-    override fun read(): Int = try {
-        this@remoteInputStream.read()
-    } catch (e: IOException) {
-        log(ERROR) { "read() failed: ${e.asLog()}" }
-        -2
+    override fun read(): Int {
+        val s = stream ?: return -2
+        return try {
+            s.read()
+        } catch (e: IOException) {
+            log(ERROR) { "read() failed: ${e.asLog()}" }
+            -2
+        }
     }
 
-    override fun readBuffer(b: ByteArray, off: Int, len: Int): Int = try {
-        this@remoteInputStream.read(b, off, len)
-    } catch (e: IOException) {
-        log(ERROR) { "readBuffer() failed: ${e.asLog()}" }
-        -2
+    override fun readBuffer(b: ByteArray, off: Int, len: Int): Int {
+        val s = stream ?: return -2
+        return try {
+            s.read(b, off, len)
+        } catch (e: IOException) {
+            log(ERROR) { "readBuffer() failed: ${e.asLog()}" }
+            -2
+        }
     }
 
-    override fun close() = try {
-        this@remoteInputStream.close()
-    } catch (_: IOException) {
+    override fun close() {
+        val s = stream ?: return
+        stream = null
+        try {
+            s.close()
+        } catch (_: IOException) {
+        }
     }
-
 }
 
 /**

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathIPCFlowTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathIPCFlowTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -239,5 +240,24 @@ class LocalPathIPCFlowTest : BaseTest() {
         val reconstructed = LocalPathResult.Error("com.example.DoesNotExist", "boom", null).toException()
         reconstructed.javaClass shouldBe Exception::class.java
         reconstructed.message shouldBe "com.example.DoesNotExist: boom"
+    }
+
+    @Test
+    fun `a chunk larger than the host pipe streams without deadlock`() {
+        // One full chunk of oversized items encodes to a base64 line of >100KB, several times the
+        // host pipe. The producer has to block until the client drains the pipe, not deadlock.
+        val items = (0 until 100).map { path("file$it".padEnd(1024, 'x')) }
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val stream = items.asFlow().toRemoteInputStream(scope)
+                // The decoder's readLine() is a blocking read that cancellation can't interrupt,
+                // so collect off the test thread and bound the wait with a timeout.
+                val collected = scope.async(Dispatchers.IO) { stream.toLocalPathFlow().toList() }
+                withTimeout(10_000) { collected.await() } shouldContainExactly items
+            }
+        } finally {
+            scope.cancel()
+        }
     }
 }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupExtendedIPCFlowTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupExtendedIPCFlowTest.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -207,6 +208,25 @@ class LocalPathLookupExtendedIPCFlowTest : BaseTest() {
             val collected = ByteArrayInputStream(bytes).remoteInputStream()
                 .toLocalPathLookupExtendedFlow().toList()
             collected shouldContainExactly listOf(lookup("before"))
+        }
+    }
+
+    @Test
+    fun `a chunk larger than the host pipe streams without deadlock`() {
+        // One full chunk of oversized items encodes to a base64 line of >100KB, several times the
+        // host pipe. The producer has to block until the client drains the pipe, not deadlock.
+        val items = (0 until 100).map { lookup("file$it".padEnd(1024, 'x')) }
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val stream = items.asFlow().toRemoteInputStream(scope)
+                // The decoder's readLine() is a blocking read that cancellation can't interrupt,
+                // so collect off the test thread and bound the wait with a timeout.
+                val collected = scope.async(Dispatchers.IO) { stream.toLocalPathLookupExtendedFlow().toList() }
+                withTimeout(10_000) { collected.await() } shouldContainExactly items
+            }
+        } finally {
+            scope.cancel()
         }
     }
 }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupIPCFlowTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/files/local/ipc/LocalPathLookupIPCFlowTest.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
@@ -243,6 +244,25 @@ class LocalPathLookupIPCFlowTest : BaseTest() {
         runBlocking {
             val collected = ByteArrayInputStream(bytes).remoteInputStream().toLocalPathLookupFlow().toList()
             collected shouldContainExactly listOf(lookup("before"))
+        }
+    }
+
+    @Test
+    fun `a chunk larger than the host pipe streams without deadlock`() {
+        // One full chunk of oversized items encodes to a base64 line of >100KB, several times the
+        // host pipe. The producer has to block until the client drains the pipe, not deadlock.
+        val items = (0 until 100).map { lookup("file$it".padEnd(1024, 'x')) }
+        val scope = makeScope()
+        try {
+            runBlocking {
+                val stream = items.asFlow().toRemoteInputStream(scope)
+                // The decoder's readLine() is a blocking read that cancellation can't interrupt,
+                // so collect off the test thread and bound the wait with a timeout.
+                val collected = scope.async(Dispatchers.IO) { stream.toLocalPathLookupFlow().toList() }
+                withTimeout(10_000) { collected.await() } shouldContainExactly items
+            }
+        } finally {
+            scope.cancel()
         }
     }
 }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/ipc/RemoteInputStreamExtensionsTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/ipc/RemoteInputStreamExtensionsTest.kt
@@ -1,0 +1,70 @@
+package eu.darken.sdmse.common.ipc
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.io.ByteArrayInputStream
+import java.io.InputStream
+import java.io.PipedInputStream
+import java.lang.ref.Reference
+import java.lang.ref.WeakReference
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class RemoteInputStreamExtensionsTest : BaseTest() {
+
+    @Test
+    fun `reads delegate to the wrapped stream until close`() {
+        val stub = ByteArrayInputStream(byteArrayOf(1, 2, 3)).remoteInputStream()
+        val buffer = ByteArray(4)
+
+        stub.read() shouldBe 1
+        stub.readBuffer(buffer, 0, 4) shouldBe 2
+        buffer[0] shouldBe 2.toByte()
+        buffer[1] shouldBe 3.toByte()
+        stub.available() shouldBe 0
+
+        stub.close()
+
+        stub.read() shouldBe -2
+        stub.readBuffer(buffer, 0, 4) shouldBe -2
+        stub.available() shouldBe -2
+        stub.close()
+    }
+
+    // Built in its own frame so no local of the test method keeps the stream reachable.
+    private fun wrap(): Pair<RemoteInputStream.Stub, WeakReference<InputStream>> {
+        val stream = PipedInputStream(32 * 1024)
+        return stream.remoteInputStream() to WeakReference<InputStream>(stream)
+    }
+
+    @Test
+    fun `close releases the wrapped stream`() {
+        val (stub, weak) = wrap()
+
+        var attempts = 0
+        while (attempts < 50 && weak.get() != null) {
+            System.gc()
+            Thread.sleep(100)
+            attempts++
+        }
+        weak.get() shouldNotBe null
+
+        stub.close()
+
+        attempts = 0
+        while (attempts < 50 && weak.get() != null) {
+            System.gc()
+            Thread.sleep(100)
+            attempts++
+        }
+        weak.get() shouldBe null
+
+        Reference.reachabilityFence(stub)
+    }
+}

--- a/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilter.kt
+++ b/app-tool-systemcleaner/src/main/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilter.kt
@@ -16,6 +16,7 @@ import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.datastore.value
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APathLookup
@@ -31,7 +32,10 @@ import eu.darken.sdmse.systemcleaner.core.SystemCleanerSettings
 import eu.darken.sdmse.systemcleaner.core.filter.BaseSystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
 import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.flow.firstOrNull
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Provider
 
@@ -88,6 +92,8 @@ class EmptyDirectoryFilter @Inject constructor(
         "cache",
     )
 
+    private val subtreeCache = ConcurrentHashMap<String, CompletableDeferred<Boolean>>()
+
     override suspend fun initialize() {
         val config = SystemCrawlerSieve.Config(
             targetTypes = setOf(TypeCriterium.DIRECTORY),
@@ -126,22 +132,43 @@ class EmptyDirectoryFilter @Inject constructor(
             return null
         }
 
-        // Check for nested empty directories. Stream the children and stop at the first file:
-        // huge directories (e.g. 30k+ files in AnkiDroid's collection.media) would otherwise be
-        // fully listed over IPC just to determine "not empty".
-        val subDirs = mutableListOf<APathLookup<*>>()
-        val blockingChild = item.lookupFilesFlow(gatewaySwitch).firstOrNull { child ->
-            if (child.fileType == FileType.DIRECTORY) {
-                subDirs.add(child)
-                false
-            } else {
-                true
-            }
+        return if (isEmptyTree(item)) SystemCleanerFilter.Match.Deletion(item) else null
+    }
+
+    /**
+     * The crawler hands an ancestor and its descendants to parallel slots, so evaluations of the
+     * same directory overlap. Whoever gets there first owns the listing, everyone else awaits it.
+     * Read failures stay cached: every ancestor rethrows the same error instead of relisting.
+     */
+    private suspend fun isEmptyTree(item: APathLookup<*>): Boolean {
+        if (subtreeCache.size >= MAX_CACHE_ENTRIES) {
+            log(TAG, WARN) { "Subtree cache full, clearing" }
+            subtreeCache.clear()
         }
-        return when {
-            blockingChild != null -> null
-            subDirs.all { match(it) != null } -> SystemCleanerFilter.Match.Deletion(item)
-            else -> null
+
+        val mine = CompletableDeferred<Boolean>()
+        subtreeCache.putIfAbsent(item.path, mine)?.let { return it.await() }
+
+        try {
+            // Check for nested empty directories. Stream the children and stop at the first file:
+            // huge directories (e.g. 30k+ files in AnkiDroid's collection.media) would otherwise be
+            // fully listed over IPC just to determine "not empty".
+            val subDirs = mutableListOf<APathLookup<*>>()
+            val blockingChild = item.lookupFilesFlow(gatewaySwitch).firstOrNull { child ->
+                if (child.fileType == FileType.DIRECTORY) {
+                    subDirs.add(child)
+                    false
+                } else {
+                    true
+                }
+            }
+            val result = blockingChild == null && subDirs.all { match(it) != null }
+            mine.complete(result)
+            return result
+        } catch (e: Throwable) {
+            if (e is CancellationException) subtreeCache.remove(item.path, mine)
+            mine.completeExceptionally(e)
+            throw e
         }
     }
 
@@ -170,5 +197,6 @@ class EmptyDirectoryFilter @Inject constructor(
 
     companion object {
         private val TAG = logTag("SystemCleaner", "Filter", "EmptyDirectories")
+        private const val MAX_CACHE_ENTRIES = 100_000
     }
 }

--- a/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilterTest.kt
+++ b/app-tool-systemcleaner/src/test/java/eu/darken/sdmse/systemcleaner/core/filter/stock/EmptyDirectoryFilterTest.kt
@@ -5,12 +5,21 @@ import eu.darken.sdmse.common.areas.DataArea.Type.PUBLIC_MEDIA
 import eu.darken.sdmse.common.areas.DataArea.Type.SDCARD
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.files.FileType
+import eu.darken.sdmse.common.files.ReadException
 import eu.darken.sdmse.common.files.isChildOf
 import eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilterTest
 import eu.darken.sdmse.systemcleaner.core.sieve.SystemCrawlerSieve
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.mockk.coEvery
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -33,6 +42,26 @@ class EmptyDirectoryFilterTest : SystemCleanerFilterTest() {
         },
         gatewaySwitch = gatewaySwitch,
     )
+
+    private val counts = mutableMapOf<String, Int>()
+
+    /**
+     * Re-stubs an already mocked directory so every listing is counted. The `yield()` gives a
+     * second coroutine the chance to interleave while this listing is in flight.
+     */
+    private suspend fun countListings(dir: APathLookup<*>) {
+        val children = gatewaySwitch.lookupFiles(dir.lookedUp).toList()
+        coEvery { gatewaySwitch.lookupFiles(dir.lookedUp) } coAnswers {
+            counts.merge(dir.path, 1, Int::plus)
+            flow {
+                yield()
+                children.forEach { emit(it) }
+            }
+        }
+    }
+
+    private fun Collection<APathLookup<*>>.pick(areaPath: String, suffix: String): APathLookup<*> =
+        single { it.path.startsWith("$areaPath/") && it.path.endsWith("/$suffix") }
 
     @Test fun `test basic protected dirs`() = runTest {
         neg(SDCARD, "afile", Flag.File)
@@ -131,5 +160,91 @@ class EmptyDirectoryFilterTest : SystemCleanerFilterTest() {
         pos(SDCARD, "empty", Flag.Dir)
 
         confirm(create())
+    }
+
+    @Test fun `nested directories are listed once per scan, not once per ancestor`() = runTest {
+        pos(SDCARD, "tree", Flag.Dir)
+        pos(SDCARD, "tree/a", Flag.Dir)
+        pos(SDCARD, "tree/a/b", Flag.Dir)
+        pos(SDCARD, "tree/a/b/c", Flag.Dir)
+
+        neg(SDCARD, "full", Flag.Dir)
+        neg(SDCARD, "full/a", Flag.Dir)
+        neg(SDCARD, "full/a/b", Flag.Dir)
+        neg(SDCARD, "full/a/b/file", Flag.File)
+
+        val dirs = (positives + negatives).filter { it.fileType == FileType.DIRECTORY }
+        dirs.forEach { countListings(it) }
+
+        val filter = create()
+        filter.initialize()
+
+        val crawlOrder = listOf("tree", "tree/a", "tree/a/b", "tree/a/b/c", "full", "full/a", "full/a/b")
+        listOf(storageSdcard1, storageSdcard2).forEach { area ->
+            crawlOrder.forEach { suffix ->
+                val candidate = dirs.pick(area.path.path, suffix)
+                val result = filter.match(candidate)
+                withClue(candidate.path) {
+                    if (suffix.startsWith("tree")) result shouldNotBe null else result shouldBe null
+                }
+            }
+        }
+
+        dirs.forEach { withClue(it.path) { counts[it.path] shouldBe 1 } }
+    }
+
+    @Test fun `an unreadable directory is listed once and blocks every ancestor`() = runTest {
+        neg(SDCARD, "broken", Flag.Dir)
+        neg(SDCARD, "broken/a", Flag.Dir)
+        neg(SDCARD, "broken/a/b", Flag.Dir)
+
+        val dirs = negatives.filter { it.fileType == FileType.DIRECTORY }
+        val (unreadable, readable) = dirs.partition { it.path.endsWith("/broken/a/b") }
+        readable.forEach { countListings(it) }
+        unreadable.forEach { b ->
+            coEvery { gatewaySwitch.lookupFiles(b.lookedUp) } coAnswers {
+                counts.merge(b.path, 1, Int::plus)
+                flow { throw ReadException(path = b.lookedUp) }
+            }
+        }
+
+        val filter = create()
+        filter.initialize()
+
+        listOf(storageSdcard1, storageSdcard2).forEach { area ->
+            listOf("broken", "broken/a", "broken/a/b").forEach { suffix ->
+                val candidate = dirs.pick(area.path.path, suffix)
+                withClue(candidate.path) {
+                    shouldThrow<ReadException> { filter.match(candidate) }
+                }
+            }
+        }
+
+        dirs.forEach { withClue(it.path) { counts[it.path] shouldBe 1 } }
+    }
+
+    @Test fun `concurrent evaluations of an ancestor and its child share one listing`() = runTest {
+        pos(SDCARD, "tree", Flag.Dir)
+        pos(SDCARD, "tree/a", Flag.Dir)
+        pos(SDCARD, "tree/a/b", Flag.Dir)
+
+        val dirs = positives.filter { it.fileType == FileType.DIRECTORY }
+        dirs.forEach { countListings(it) }
+
+        val filter = create()
+        filter.initialize()
+
+        val areaPath = storageSdcard1.path.path
+        val tree = dirs.pick(areaPath, "tree")
+        val treeA = dirs.pick(areaPath, "tree/a")
+        val treeAB = dirs.pick(areaPath, "tree/a/b")
+
+        val outer = async { filter.match(tree) }
+        val inner = async { filter.match(treeA) }
+
+        outer.await() shouldNotBe null
+        inner.await() shouldNotBe null
+
+        listOf(tree, treeA, treeAB).forEach { withClue(it.path) { counts[it.path] shouldBe 1 } }
     }
 }


### PR DESCRIPTION
## What changed

SystemCleaner scans that run through Shizuku (ADB mode, no root) could end with "Service Connection Lost" on storage that contains a game's Unity cache tree with thousands of nested empty directories. The Shizuku helper ran out of memory partway through the scan, and every scan failed the same way. The scan now completes, the "Empty directories" filter still finds the whole tree, and deleting it works as before.

## Technical Context

- Root cause, part one: `EmptyDirectoryFilter.match()` listed the directory it was handed and recursed into every directory child, while the crawler hands in every directory of the walk. A subtree of N nested directories was therefore listed once per ancestor. The filter now caches per scan with single-flight semantics (`ConcurrentHashMap<String, CompletableDeferred<Boolean>>`): the crawler runs four `match()` calls in parallel and the walker emits a directory right before its children, so an ancestor and its child are routinely evaluated at the same time. A plain result cache still listed most of the tree twice in that shape; with the deferred, the second evaluator waits for the first. Read failures stay cached so an unreadable leaf does not re-list its ancestor chain, and every ancestor still sees the `ReadException`, so nothing above an unreadable directory is offered for deletion.
- Root cause, part two: every privileged listing allocated a 200 KB `PipedInputStream` and a 200 KB `BufferedWriter` on the helper before reading a single entry, regardless of directory size, and the helper's `RemoteInputStream.Stub` kept the pipe reachable after `close()` for as long as the binder runtime held the Stub. The pipe is now 32 KB (the client drains 8 KB per binder round trip), the writer uses the default buffer, and the Stub drops its stream reference on `close()`. The Stub is a named class so the wrapped stream is a constructor parameter rather than a captured receiver.
- Same functions, also observed in the report's log: `emit(Error)` inside a `catch` block violated Flow exception transparency whenever the writer failed downstream ("Pipe closed"). The builder now uses `Flow.catch`, which only intercepts upstream failures, so a listing error becomes an Error frame and a downstream write failure is rethrown to the outer handler as before.
- Worth close review: the cache's cancellation branch (`isEmptyTree`), which evicts only `CancellationException` and keeps failures; and the three IPC flow files, which carry the identical edit.
- On-device testing with Shizuku on an API 34 emulator and a seeded 1,803-directory tree showed the filter's privileged listings drop from 6,303 to 1,802 (one per eligible directory), with the scan completing and the tree deletable; the emulator itself did not reproduce the helper OOM.
