### PR TITLE
Swiper: Fix the scan spinner overlapping the Cancel button

### DIFF
--- a/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/items/SwiperSessionRow.kt
+++ b/app-tool-swiper/src/main/java/eu/darken/sdmse/swiper/ui/sessions/items/SwiperSessionRow.kt
@@ -2,7 +2,6 @@ package eu.darken.sdmse.swiper.ui.sessions.items
 
 import android.text.format.DateUtils
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -46,11 +45,16 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import eu.darken.sdmse.common.R as CommonR
+import eu.darken.sdmse.common.compose.preview.Preview2
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.swiper.R
 import eu.darken.sdmse.swiper.core.FileTypeCategory
 import eu.darken.sdmse.swiper.core.SessionState
 import eu.darken.sdmse.swiper.core.SortOrder
+import eu.darken.sdmse.swiper.core.SwipeSession
 import eu.darken.sdmse.swiper.core.Swiper
+import java.time.Instant
 
 private const val MAX_VISIBLE_PATHS = 5
 
@@ -308,7 +312,10 @@ fun SwiperSessionRow(
                     }
                 }
                 Spacer(Modifier.weight(1f))
-                Box(contentAlignment = Alignment.Center) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
                     if (isScanning || isRefreshing) {
                         CircularProgressIndicator(modifier = Modifier.size(20.dp))
                     }
@@ -391,5 +398,41 @@ private fun SessionActionButton(
             Spacer(Modifier.width(8.dp))
             Text(stringResource(CommonR.string.general_scan_action))
         }
+    }
+}
+
+@Preview2
+@Composable
+private fun SwiperSessionRowScanningPreview() {
+    PreviewWrapper {
+        SwiperSessionRow(
+            sessionWithStats = Swiper.SessionWithStats(
+                session = SwipeSession(
+                    sessionId = "session-1",
+                    sourcePaths = listOf(LocalPath.build("storage", "emulated", "0", "DCIM")),
+                    currentIndex = 0,
+                    totalItems = 0,
+                    createdAt = Instant.parse("2025-01-01T00:00:00Z"),
+                    lastModifiedAt = Instant.parse("2025-01-01T00:00:00Z"),
+                    state = SessionState.CREATED,
+                ),
+                keepCount = 0,
+                deleteCount = 0,
+                undecidedCount = 0,
+                deletedCount = 0,
+                deleteFailedCount = 0,
+            ),
+            position = 1,
+            isScanning = true,
+            isCancelling = false,
+            isRefreshing = false,
+            onScan = {},
+            onContinue = {},
+            onRemove = {},
+            onRename = {},
+            onCancel = {},
+            onFilter = {},
+            onSortOrder = {},
+        )
     }
 }

--- a/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/items/SwiperSessionRowTest.kt
+++ b/app-tool-swiper/src/test/java/eu/darken/sdmse/swiper/ui/sessions/items/SwiperSessionRowTest.kt
@@ -1,0 +1,87 @@
+package eu.darken.sdmse.swiper.ui.sessions.items
+
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.test.getBoundsInRoot
+import androidx.compose.ui.test.hasProgressBarRangeInfo
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.unit.DpRect
+import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.files.local.LocalPath
+import eu.darken.sdmse.swiper.core.SessionState
+import eu.darken.sdmse.swiper.core.SwipeSession
+import eu.darken.sdmse.swiper.core.Swiper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+import java.time.Instant
+
+class SwiperSessionRowTest : BaseComposeRobolectricTest() {
+
+    private fun unscannedSession(): Swiper.SessionWithStats = Swiper.SessionWithStats(
+        session = SwipeSession(
+            sessionId = "session-1",
+            sourcePaths = listOf(LocalPath.build("storage", "emulated", "0", "DCIM")),
+            currentIndex = 0,
+            totalItems = 0,
+            createdAt = Instant.parse("2025-01-01T00:00:00Z"),
+            lastModifiedAt = Instant.parse("2025-01-01T00:00:00Z"),
+            state = SessionState.CREATED,
+        ),
+        keepCount = 0,
+        deleteCount = 0,
+        undecidedCount = 0,
+        deletedCount = 0,
+        deleteFailedCount = 0,
+    )
+
+    private fun setRow(
+        isScanning: Boolean = false,
+        isRefreshing: Boolean = false,
+    ) {
+        composeRule.setContent {
+            PreviewWrapper {
+                SwiperSessionRow(
+                    sessionWithStats = unscannedSession(),
+                    position = 1,
+                    isScanning = isScanning,
+                    isCancelling = false,
+                    isRefreshing = isRefreshing,
+                    onScan = {},
+                    onContinue = {},
+                    onRemove = {},
+                    onRename = {},
+                    onCancel = {},
+                    onFilter = {},
+                    onSortOrder = {},
+                )
+            }
+        }
+    }
+
+    private fun spinnerBounds(): DpRect = composeRule
+        .onNode(hasProgressBarRangeInfo(ProgressBarRangeInfo.Indeterminate))
+        .getBoundsInRoot()
+
+    // Layout-level overlap check: Robolectric's text metrics are stubs, but node bounds come
+    // from Compose's own measure/place pass, so two siblings intersecting is a real layout fact.
+    private infix fun DpRect.overlaps(other: DpRect): Boolean =
+        left < other.right && other.left < right && top < other.bottom && other.top < bottom
+
+    @Test
+    fun `scanning spinner does not overlap the cancel button`() {
+        setRow(isScanning = true)
+
+        val cancel = composeRule.onNodeWithText("Cancel").getBoundsInRoot()
+
+        spinnerBounds() overlaps cancel shouldBe false
+    }
+
+    @Test
+    fun `refreshing spinner does not overlap the loading button`() {
+        setRow(isRefreshing = true)
+
+        val loading = composeRule.onNodeWithText("Loading").getBoundsInRoot()
+
+        spinnerBounds() overlaps loading shouldBe false
+    }
+}


### PR DESCRIPTION
## What changed

While a Swiper session is being scanned, the small loading spinner was drawn on top of the Cancel button, so the button was hard to read and easy to miss. The same overlap hit the greyed-out "Loading" button that shows while a session's files are re-read before swiping. The spinner now sits next to the button with a small gap, the way the previous version of this screen laid it out.

## Technical Context

- Root cause: the Compose port of the session row wrapped the spinner and the action button in a centering `Box`, which stacks its children. The legacy XML placed them side by side in a horizontal layout with an 8dp gap; a `Row` with `spacedBy(8.dp)` restores that.
- The show/hide conditions were already correct and match the legacy view holder, so this is placement only, no state changes.
- The new Robolectric test asserts the spinner and button bounds do not intersect for both the scanning and refreshing states. It reads node bounds from Compose's layout pass rather than text metrics, so Robolectric's stubbed fonts do not affect the verdict. It failed before the layout change and passes after.
- Adds the scanning-state preview the row composable was missing.
