### PR TITLE
General: Fix a shell test that hangs on busy developer machines

### DIFF
--- a/app-common-shell/src/test/java/eu/darken/flowshell/core/FlowShellTest.kt
+++ b/app-common-shell/src/test/java/eu/darken/flowshell/core/FlowShellTest.kt
@@ -111,7 +111,10 @@ class FlowShellTest : BaseTest() {
         val sharedSession = FlowShell().session.replayingShare(this)
         sharedSession.launchIn(this + Dispatchers.IO)
 
-        val loop = 1000
+        // Nothing reads stdout until close() returns, so all echoed lines have to fit in the OS
+        // pipe. Linux hands an unprivileged user as little as 8 KiB per pipe once
+        // fs.pipe-user-pages-soft is exceeded; ~42 bytes/line keeps 100 lines at ~4 KiB.
+        val loop = 100
         val expected = mutableListOf<String>()
         val output = mutableListOf<String>()
 


### PR DESCRIPTION
## What changed

No user-facing behavior change. The FlowShell "slow consumer" unit test no longer hangs for 60 seconds on machines where the kernel hands out small pipes.

## Technical Context

- Root cause: the test wrote 1000 echo lines (~42 KiB) to `sh` before collecting any output, so it only worked with a 64 KiB stdout pipe. Linux shrinks new pipes to 8 KiB for an unprivileged user whose processes already hold more than `fs.pipe-user-pages-soft` pages. On a workstation with many shells, browsers, and agents open, the shell blocked on stdout after ~373 lines, stopped reading stdin, and the test's writer blocked until runTest's timeout killed the shell (the suppressed "Broken pipe" in the failure).
- The payload is now 100 lines (~4 KiB), which fits the smallest pipe the kernel hands out. The test still checks that lines written before any collector exists arrive complete and in order after the process has exited.
- Production code attaches output and error collectors before writing, so nothing outside this test depends on pipe capacity. No change to FlowShell itself.
