### PR TITLE
Deduplicator: Show which copy is kept on grid tiles

### DIFF
--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListScreen.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListScreen.kt
@@ -440,6 +440,16 @@ internal fun DeduplicatorListScreen(
                         val onClusterPreviewTap: (Duplicate.Cluster) -> Unit = { cluster ->
                             if (selection.isEmpty) onClusterPreview(cluster) else toggleCluster(cluster)
                         }
+                        // The grid tile previews the keeper, so its preview button has to open on that
+                        // same file rather than on the cluster's first path.
+                        val onGridPreviewTap: (DeduplicatorListViewModel.DeduplicatorListRow) -> Unit = { row ->
+                            val keeper = row.keeper
+                            when {
+                                !selection.isEmpty -> toggleCluster(row.cluster)
+                                keeper != null -> onDuplicatePreview(row.cluster, keeper)
+                                else -> onClusterPreview(row.cluster)
+                            }
+                        }
                         val applyDupeChange: (Duplicate.Cluster, Duplicate, DupeChange) -> Unit = { cluster, dupe, mode ->
                             val cap = capFor(cluster.count, allowDeleteAll)
                             val result = selection.changeDupe(
@@ -481,7 +491,7 @@ internal fun DeduplicatorListScreen(
                                 selection = selectionHolder,
                                 onThumbnailClick = onClusterDeleteTap,
                                 onCaptionClick = onClusterDetailsTap,
-                                onPreviewButtonClick = onClusterPreviewTap,
+                                onPreviewButtonClick = onGridPreviewTap,
                                 onClusterLongPress = onClusterLongPress,
                             )
                         }
@@ -532,7 +542,7 @@ private fun GridList(
     selection: MixedSelectionHolder,
     onThumbnailClick: (Duplicate.Cluster) -> Unit,
     onCaptionClick: (Duplicate.Cluster) -> Unit,
-    onPreviewButtonClick: (Duplicate.Cluster) -> Unit,
+    onPreviewButtonClick: (DeduplicatorListViewModel.DeduplicatorListRow) -> Unit,
     onClusterLongPress: (Duplicate.Cluster) -> Unit,
 ) {
     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
@@ -552,7 +562,7 @@ private fun GridList(
                     selected = isSelected,
                     onThumbnailClick = { onThumbnailClick(row.cluster) },
                     onCaptionClick = { onCaptionClick(row.cluster) },
-                    onPreviewButtonClick = { onPreviewButtonClick(row.cluster) },
+                    onPreviewButtonClick = { onPreviewButtonClick(row) },
                     onLongClick = { onClusterLongPress(row.cluster) },
                 )
             }

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModel.kt
@@ -158,6 +158,7 @@ class DeduplicatorListViewModel @Inject constructor(
                         cluster = cluster,
                         deleteTargetIds = deleteTargetIds,
                         freeableSize = cluster.freeableSizeOf(deleteTargetIds),
+                        keeper = cluster.survivorOf(deleteTargetIds),
                     )
                 }
             // Null rows mean "loading". Without data and without a scan that could still deliver
@@ -188,6 +189,11 @@ class DeduplicatorListViewModel @Inject constructor(
         val deleteTargetIds: Set<Duplicate.Id>,
         /** Bytes freed by deleting [deleteTargetIds] (the actual delete-target set, not the raw cluster size). */
         val freeableSize: Long,
+        /**
+         * The single file a default keep-one delete leaves behind in this cluster; null when
+         * [deleteTargetIds] leaves none or several.
+         */
+        val keeper: Duplicate?,
     )
 
     data class State(
@@ -404,3 +410,9 @@ private fun Duplicate.Cluster.freeableSizeOf(targets: Set<Duplicate.Id>): Long =
     .flatMap { it.duplicates }
     .filter { it.identifier in targets }
     .sumOf { it.size }
+
+private fun Duplicate.Cluster.survivorOf(targets: Set<Duplicate.Id>): Duplicate? = groups
+    .flatMap { it.duplicates }
+    .filter { it.identifier !in targets }
+    .distinctBy { it.identifier }
+    .singleOrNull()

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/items/DeduplicatorGridRow.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/list/items/DeduplicatorGridRow.kt
@@ -85,7 +85,7 @@ internal fun DeduplicatorGridRow(
         ) {
             // Tapping the thumbnail deletes the cluster's duplicates (confirm dialog); long-press selects.
             FilePreviewImage(
-                lookup = cluster.previewFile,
+                lookup = row.keeper?.lookup ?: cluster.previewFile,
                 contentDescription = stringResource(DeduplicatorR.string.deduplicator_cluster_preview_image),
                 contentScale = ContentScale.Crop,
                 modifier = Modifier
@@ -103,6 +103,9 @@ internal fun DeduplicatorGridRow(
                 onLongClick = onLongClick,
                 modifier = Modifier.align(Alignment.TopStart),
             )
+            if (row.keeper != null) {
+                KeeperBadge(modifier = Modifier.align(Alignment.TopEnd))
+            }
             // Caption overlaid at the bottom: tap = open details; long-press selects.
             Column(
                 modifier = Modifier
@@ -191,6 +194,27 @@ private fun PreviewOverlayButton(
     }
 }
 
+@Composable
+private fun KeeperBadge(modifier: Modifier = Modifier) {
+    // Overlay only: no click modifiers, so taps fall through to the thumbnail's delete/long-press
+    // handling underneath. The start padding keeps a long translation clear of the preview button.
+    Box(
+        modifier = modifier
+            .padding(start = 48.dp)
+            .clip(RoundedCornerShape(bottomStart = 12.dp))
+            .background(MaterialTheme.colorScheme.scrim.copy(alpha = 0.55f))
+            .padding(horizontal = 8.dp, vertical = 6.dp),
+    ) {
+        Text(
+            text = stringResource(DeduplicatorR.string.deduplicator_kept_copy_label),
+            style = MaterialTheme.typography.labelSmall,
+            color = Color.White,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    }
+}
+
 /**
  * Grid cards show detection types as compact icons (no labels) to keep the card to two short lines.
  * All icons share the caption's text color so they stay legible on the scrim; the glyph shapes still
@@ -253,6 +277,24 @@ private fun DeduplicatorGridRowSelectedPreview() {
             DeduplicatorGridRow(
                 row = previewDeduplicatorListRow(),
                 selected = true,
+                onThumbnailClick = {},
+                onCaptionClick = {},
+                onPreviewButtonClick = {},
+                onLongClick = {},
+            )
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun DeduplicatorGridRowKeeperNarrowPreview() {
+    PreviewWrapper {
+        // Narrow tile (3-column layout) with a keeper: the tightest width for the badge.
+        Box(modifier = Modifier.width(115.dp)) {
+            DeduplicatorGridRow(
+                row = previewDeduplicatorListRow(),
+                selected = false,
                 onThumbnailClick = {},
                 onCaptionClick = {},
                 onPreviewButtonClick = {},

--- a/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/preview/DeduplicatorPreviewData.kt
+++ b/app-tool-deduplicator/src/main/java/eu/darken/sdmse/deduplicator/ui/preview/DeduplicatorPreviewData.kt
@@ -118,8 +118,8 @@ internal fun previewCluster(
 
 /**
  * A list-row model for previews/tests: a favorite checksum group of two copies, keeping the first,
- * so one duplicate is a delete target and [DeduplicatorListViewModel.DeduplicatorListRow.freeableSize]
- * reflects that single copy.
+ * so one duplicate is a delete target, [DeduplicatorListViewModel.DeduplicatorListRow.freeableSize]
+ * reflects that single copy and [DeduplicatorListViewModel.DeduplicatorListRow.keeper] is the kept one.
  */
 internal fun previewDeduplicatorListRow(
     identifier: Duplicate.Cluster.Id = Duplicate.Cluster.Id("preview-cluster"),
@@ -152,6 +152,7 @@ internal fun previewDeduplicatorListRow(
         cluster = cluster,
         deleteTargetIds = targets,
         freeableSize = duplicates.filter { it.identifier in targets }.sumOf { it.size },
+        keeper = keeper,
     )
 }
 
@@ -170,5 +171,6 @@ internal fun previewDeduplicatorListRowAllTypes(
         cluster = cluster,
         deleteTargetIds = emptySet(),
         freeableSize = 13L * 1024 * 1024,
+        keeper = null,
     )
 }

--- a/app-tool-deduplicator/src/main/res/values/strings.xml
+++ b/app-tool-deduplicator/src/main/res/values/strings.xml
@@ -48,6 +48,7 @@
     <string name="deduplicator_action_delete_set">Delete duplicate set</string>
     <string name="deduplicator_action_open_preview">Open preview</string>
     <string name="deduplicator_marked_for_deletion">Marked for deletion</string>
+    <string name="deduplicator_kept_copy_label">Kept</string>
     <string name="deduplicator_cluster_preview_image">Duplicate set preview</string>
     <string name="deduplicator_selection_keep_one_required">At least one file per duplicate set must remain. Enable \"Make \'Delete all\' possible\" in settings to override.</string>
     <string name="deduplicator_progress_comparing_files">Comparing files</string>

--- a/app-tool-deduplicator/src/screenshotTest/kotlin/eu/darken/sdmse/deduplicator/screenshots/DeduplicatorScreenshots.kt
+++ b/app-tool-deduplicator/src/screenshotTest/kotlin/eu/darken/sdmse/deduplicator/screenshots/DeduplicatorScreenshots.kt
@@ -88,13 +88,15 @@ private fun mediaGroup(gid: String, dir: String, name: String, sizeMb: Int, n: I
 
 private fun row(cid: String, vararg groups: Duplicate.Group): DeduplicatorListRow {
     val cluster = previewCluster(Duplicate.Cluster.Id(cid), groups.toSet(), favoriteGroupIdentifier = groups.first().identifier)
-    val keeper = groups.first().duplicates.first().identifier
+    val keeper = groups.first().duplicates.first()
+    val keeperId = keeper.identifier
     val all = groups.flatMap { it.duplicates }
-    val targets = all.map { it.identifier }.toSet() - keeper
+    val targets = all.map { it.identifier }.toSet() - keeperId
     return DeduplicatorListRow(
         cluster = cluster,
         deleteTargetIds = targets,
         freeableSize = all.filter { it.identifier in targets }.sumOf { it.size },
+        keeper = keeper,
     )
 }
 

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListScreenTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListScreenTest.kt
@@ -1,5 +1,9 @@
 package eu.darken.sdmse.deduplicator.ui.list
 
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
@@ -12,7 +16,11 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTouchInput
+import eu.darken.sdmse.common.coil.LocalPreviewImageProvider
+import eu.darken.sdmse.common.coil.PreviewImageProvider
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
+import eu.darken.sdmse.common.files.APathLookup
+import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.ui.LayoutMode
 import eu.darken.sdmse.deduplicator.core.Duplicate
 import eu.darken.sdmse.deduplicator.core.scanner.checksum.ChecksumDuplicate
@@ -24,7 +32,11 @@ import testhelpers.compose.BaseComposeRobolectricTest
 
 class DeduplicatorListScreenTest : BaseComposeRobolectricTest() {
 
-    private fun clusterRow(name: String, size: Long = 1024L): DeduplicatorListViewModel.DeduplicatorListRow {
+    private fun clusterRow(
+        name: String,
+        size: Long = 1024L,
+        withKeeper: Boolean = false,
+    ): DeduplicatorListViewModel.DeduplicatorListRow {
         val duplicates = setOf(
             previewChecksumDuplicate(
                 pathSegments = arrayOf("storage", "emulated", "0", "Pictures", "$name-a.jpg"),
@@ -37,19 +49,25 @@ class DeduplicatorListScreenTest : BaseComposeRobolectricTest() {
                 hashSeed = "$name-b",
             ),
         )
+        // The keeper is deliberately the SECOND copy, which differs from `cluster.previewFile`
+        // (the first), so a tile that still shows the arbitrary preview file is detectable.
+        val keeper = if (withKeeper) duplicates.last() else null
         val group = ChecksumDuplicate.Group(
             duplicates = duplicates,
             identifier = Duplicate.Group.Id("$name-group"),
+            keeperIdentifier = keeper?.identifier,
         )
         val cluster = previewCluster(
             identifier = Duplicate.Cluster.Id(name),
             groups = setOf(group),
+            favoriteGroupIdentifier = if (keeper != null) group.identifier else null,
         )
-        val targetIds = duplicates.map { it.identifier }.toSet()
+        val targetIds = duplicates.filter { it.identifier != keeper?.identifier }.map { it.identifier }.toSet()
         return DeduplicatorListViewModel.DeduplicatorListRow(
             cluster = cluster,
             deleteTargetIds = targetIds,
             freeableSize = duplicates.filter { it.identifier in targetIds }.sumOf { it.size },
+            keeper = keeper,
         )
     }
 
@@ -147,6 +165,7 @@ class DeduplicatorListScreenTest : BaseComposeRobolectricTest() {
         onClusterClick: (Duplicate.Cluster) -> Unit = {},
         onClusterPreview: (Duplicate.Cluster) -> Unit = {},
         onDuplicateClick: (Duplicate.Cluster, Duplicate) -> Unit = { _, _ -> },
+        onDuplicatePreview: (Duplicate.Cluster, Duplicate) -> Unit = { _, _ -> },
     ) {
         setContent {
             PreviewWrapper {
@@ -156,6 +175,7 @@ class DeduplicatorListScreenTest : BaseComposeRobolectricTest() {
                     onClusterClick = onClusterClick,
                     onClusterPreview = onClusterPreview,
                     onDuplicateClick = onDuplicateClick,
+                    onDuplicatePreview = onDuplicatePreview,
                 )
             }
         }
@@ -273,5 +293,109 @@ class DeduplicatorListScreenTest : BaseComposeRobolectricTest() {
         composeRule.runOnIdle {
             if (preview != 0) throw AssertionError("preview must not fire during selection, got preview=$preview")
         }
+    }
+
+    // ─────────────────────────── keeper marker ───────────────────────────
+
+    private fun keeperGridState() = DeduplicatorListViewModel.State(
+        rows = listOf(clusterRow("vacation", withKeeper = true)),
+        layoutMode = LayoutMode.GRID,
+    )
+
+    @Test
+    fun `GRID tile shows the Kept badge for a row with a keeper`() {
+        composeRule.setScreen(keeperGridState())
+        composeRule.onNodeWithText("Kept").assertExists()
+    }
+
+    @Test
+    fun `GRID tile shows no Kept badge for a row without a keeper`() {
+        composeRule.setScreen(gridState())
+        composeRule.onAllNodesWithText("Kept").assertCountEquals(0)
+    }
+
+    @Test
+    fun `GRID tile previews the keeper's file`() {
+        // FilePreviewImage only consults LocalPreviewImageProvider under inspection mode, so the
+        // recorder sees exactly the lookup the tile asked for a bitmap of.
+        val requested = mutableListOf<String>()
+        val recorder = object : PreviewImageProvider {
+            @Composable
+            override fun fileImage(lookup: APathLookup<*>): Painter? {
+                requested.add(lookup.path)
+                return null
+            }
+
+            @Composable
+            override fun appIcon(pkg: Pkg): Painter? = null
+        }
+        val row = clusterRow("vacation", withKeeper = true)
+        composeRule.setContent {
+            PreviewWrapper {
+                CompositionLocalProvider(
+                    LocalInspectionMode provides true,
+                    LocalPreviewImageProvider provides recorder,
+                ) {
+                    DeduplicatorListScreen(
+                        stateSource = MutableStateFlow(
+                            DeduplicatorListViewModel.State(rows = listOf(row), layoutMode = LayoutMode.GRID),
+                        ),
+                    )
+                }
+            }
+        }
+        composeRule.runOnIdle {
+            if (requested != listOf(row.keeper!!.lookup.path)) {
+                throw AssertionError("expected the keeper's lookup, got $requested")
+            }
+        }
+    }
+
+    @Test
+    fun `GRID preview button opens the preview on the keeper`() {
+        val row = clusterRow("vacation", withKeeper = true)
+        var clusterPreview = 0
+        val dupePreviews = mutableListOf<Duplicate>()
+        composeRule.setScreen(
+            DeduplicatorListViewModel.State(rows = listOf(row), layoutMode = LayoutMode.GRID),
+            onClusterPreview = { clusterPreview++ },
+            onDuplicatePreview = { _, dupe -> dupePreviews.add(dupe) },
+        )
+        composeRule.onNode(hasClickLabel("Open preview")).performClick()
+        composeRule.runOnIdle {
+            if (clusterPreview != 0) throw AssertionError("clusterPreview=$clusterPreview")
+            if (dupePreviews.map { it.identifier } != listOf(row.keeper!!.identifier)) {
+                throw AssertionError("expected one preview of the keeper, got ${dupePreviews.map { it.identifier }}")
+            }
+        }
+    }
+
+    @Test
+    fun `GRID preview button toggles selection rather than previewing while selecting, with a keeper`() {
+        var clusterPreview = 0
+        var dupePreview = 0
+        composeRule.setScreen(
+            keeperGridState(),
+            onClusterPreview = { clusterPreview++ },
+            onDuplicatePreview = { _, _ -> dupePreview++ },
+        )
+        composeRule.onNode(hasClickLabel("Delete duplicate set")).performTouchInput { longClick() }
+        composeRule.onNode(hasClickLabel("Open preview")).performClick()
+        composeRule.runOnIdle {
+            if (clusterPreview != 0 || dupePreview != 0) {
+                throw AssertionError("clusterPreview=$clusterPreview dupePreview=$dupePreview")
+            }
+        }
+    }
+
+    @Test
+    fun `LINEAR layout shows no Kept badge`() {
+        composeRule.setScreen(
+            DeduplicatorListViewModel.State(
+                rows = listOf(clusterRow("vacation", withKeeper = true)),
+                layoutMode = LayoutMode.LINEAR,
+            ),
+        )
+        composeRule.onAllNodesWithText("Kept").assertCountEquals(0)
     }
 }

--- a/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModelTest.kt
+++ b/app-tool-deduplicator/src/test/java/eu/darken/sdmse/deduplicator/ui/list/DeduplicatorListViewModelTest.kt
@@ -20,6 +20,7 @@ import eu.darken.sdmse.exclusion.core.types.ExclusionId
 import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -431,6 +432,122 @@ class DeduplicatorListViewModelTest : BaseTest() {
         state.rows.single().deleteTargetIds shouldBe emptySet()
     }
 
+    @Test
+    fun `state keeper is the favorite group's kept duplicate`() = runTest2 {
+        val c = cluster("a", keeperOf = "dup1", favoriteOf = "self")
+        val dupes = c.groups.single().duplicates
+        val dup0 = dupes.single { it.lookup.path.endsWith("dup0") }
+        val dup1 = dupes.single { it.lookup.path.endsWith("dup1") }
+        val h = harness(clusters = setOf(c))
+
+        val row = h.vm.state.filterNotNull().first().rows.single()
+        row.deleteTargetIds shouldBe setOf(dup0.identifier)
+        row.keeper?.identifier shouldBe dup1.identifier
+    }
+
+    @Test
+    fun `state keeper is null when the favorite group has no keeper metadata`() = runTest2 {
+        // No targets means both copies survive, so there is no single file to point at.
+        val c = cluster("a", favoriteOf = "self")
+        val h = harness(clusters = setOf(c))
+
+        val row = h.vm.state.filterNotNull().first().rows.single()
+        row.deleteTargetIds shouldBe emptySet()
+        row.keeper shouldBe null
+    }
+
+    @Test
+    fun `state keeper is null for a keeper-less non-favorite group`() = runTest2 {
+        // Everything is a target, so nothing survives a keep-one delete of this cluster.
+        val c = cluster("a")
+        val h = harness(clusters = setOf(c))
+
+        val row = h.vm.state.filterNotNull().first().rows.single()
+        row.deleteTargetIds shouldBe c.groups.flatMap { it.duplicates }.map { it.identifier }.toSet()
+        row.keeper shouldBe null
+    }
+
+    @Test
+    fun `state keeper is the sole member of a single-member favorite group`() = runTest2 {
+        // The scanner assigns no keeperIdentifier to a one-member group, yet that member IS the
+        // copy a keep-one delete leaves behind.
+        val soloDupe = previewChecksumDuplicate(
+            pathSegments = arrayOf("storage", "s", "solo"),
+            size = 100L,
+            hashSeed = "s-solo",
+        )
+        val favoriteGroup = ChecksumDuplicate.Group(
+            duplicates = setOf(soloDupe),
+            identifier = Duplicate.Group.Id("fav"),
+            keeperIdentifier = null,
+        )
+        val secondaryDupes = listOf(100L, 200L).mapIndexed { idx, size ->
+            previewChecksumDuplicate(
+                pathSegments = arrayOf("storage", "s", "sec$idx"),
+                size = size,
+                hashSeed = "s-sec-$idx",
+            )
+        }.toSet()
+        val secondaryGroup = ChecksumDuplicate.Group(
+            duplicates = secondaryDupes,
+            identifier = Duplicate.Group.Id("sec"),
+            keeperIdentifier = secondaryDupes.first().identifier,
+        )
+        val c = previewCluster(
+            identifier = Duplicate.Cluster.Id("s"),
+            groups = setOf(favoriteGroup, secondaryGroup),
+            favoriteGroupIdentifier = favoriteGroup.identifier,
+        )
+        val h = harness(clusters = setOf(c))
+
+        val row = h.vm.state.filterNotNull().first().rows.single()
+        row.deleteTargetIds shouldBe secondaryDupes.map { it.identifier }.toSet()
+        row.keeper?.identifier shouldBe soloDupe.identifier
+    }
+
+    @Test
+    fun `state keeper does not depend on group order`() = runTest2 {
+        // The favorite group is the SECOND entry: a survivor derived from "the first group" would
+        // pick the wrong file here.
+        val secondaryDupes = listOf(100L, 100L).mapIndexed { idx, size ->
+            previewChecksumDuplicate(
+                pathSegments = arrayOf("storage", "o", "sec$idx"),
+                size = size,
+                hashSeed = "o-sec-$idx",
+            )
+        }.toSet()
+        val secondaryGroup = ChecksumDuplicate.Group(
+            duplicates = secondaryDupes,
+            identifier = Duplicate.Group.Id("sec"),
+            keeperIdentifier = null,
+        )
+        val favoriteDupes = listOf(100L, 100L).mapIndexed { idx, size ->
+            previewChecksumDuplicate(
+                pathSegments = arrayOf("storage", "o", "fav$idx"),
+                size = size,
+                hashSeed = "o-fav-$idx",
+            )
+        }.toSet()
+        val favoriteKeeper = favoriteDupes.last()
+        val favoriteGroup = ChecksumDuplicate.Group(
+            duplicates = favoriteDupes,
+            identifier = Duplicate.Group.Id("fav"),
+            keeperIdentifier = favoriteKeeper.identifier,
+        )
+        val c = previewCluster(
+            identifier = Duplicate.Cluster.Id("o"),
+            groups = setOf(secondaryGroup, favoriteGroup),
+            favoriteGroupIdentifier = favoriteGroup.identifier,
+        )
+        val h = harness(clusters = setOf(c))
+
+        val row = h.vm.state.filterNotNull().first().rows.single()
+        row.keeper?.identifier shouldBe favoriteKeeper.identifier
+        row.deleteTargetIds shouldBe
+            secondaryDupes.map { it.identifier }.toSet() +
+            (favoriteDupes - favoriteKeeper).map { it.identifier }.toSet()
+    }
+
     // ─────────────────────────── navUp on drain ───────────────────────────
 
     @Test
@@ -776,6 +893,26 @@ class DeduplicatorListViewModelTest : BaseTest() {
         val event = nav.list.single()
         event.shouldBeInstanceOf<NavEvent.GoTo>()
         event.destination.shouldBeInstanceOf<PreviewRoute>()
+        nav.cancel()
+    }
+
+    @Test
+    fun `previewDuplicate positions the preview on the given duplicate`() = runTest2 {
+        val c = cluster("c", keeperOf = "dup1", favoriteOf = "self")
+        val dup1 = c.groups.single().duplicates.single { it.lookup.path.endsWith("dup1") }
+        val paths = c.groups.flatMap { gr -> gr.duplicates.map { it.path } }
+        val h = harness(clusters = setOf(c))
+        val nav = collectNavEvents(h.vm)
+
+        h.vm.previewDuplicate(c, dup1)
+        advanceUntilIdle()
+
+        val event = nav.list.single()
+        event.shouldBeInstanceOf<NavEvent.GoTo>()
+        val route = event.destination.shouldBeInstanceOf<PreviewRoute>()
+        route.options.position shouldBe paths.indexOf(dup1.path)
+        // Non-zero: position 0 is what previewCluster would have opened.
+        route.options.position shouldNotBe 0
         nav.cancel()
     }
 


### PR DESCRIPTION
## What changed

The Deduplicator's grid view (the default layout) now shows which copy of a duplicate set stays. Each tile previews the file that a "delete all but one" run keeps and carries a small "Kept" label in its top corner. The list view and the details screen already marked the copies that get deleted; the grid showed an arbitrary member of the set with no marker at all.

Tapping a tile's preview button now opens the full-screen preview on that kept file, so what you see on the tile is what opens.

## Technical Context

- The kept file is derived from the row's existing delete-target set (the single member not targeted), not from the group's keeper id. That covers a single-member favorite group, which has no keeper id yet is exactly the copy that survives.
- `Duplicate.Cluster.previewFile` and the dashboard delete confirmation are deliberately unchanged; only the grid tile switches to the kept file.
- The "Kept" overlay carries no click handling, so the tile's tap-to-delete and long-press-to-select behavior underneath is untouched.
- Tests pin the thumbnail choice with a keeper that differs from the old arbitrary preview file, and cover the single-member favorite group and group-order cases.
- Verified on an API 34 emulator with two identical photos, including font scale 2.0 and a per-app RTL locale, which CI cannot cover.
