### PR TITLE
General: Enable code obfuscation for Google Play builds

### DIFF
--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -30,7 +30,7 @@ Files updated by every release:
 | `-beta<n>` | `assembleFossBeta` | **pre-release** | `lane :beta` | `beta` | 10% |
 | `-rc<n>` | `assembleFossRelease` | **release** | `lane :production` | **`beta`** | 10% |
 
-Gplay builds are obfuscated; the R8 mapping for retracing Play vitals or user logs is attached to the release-tag workflow run as the artifact r8-mapping-gplay-<tag> (90-day retention) and is also embedded in the uploaded bundle (Play Console → App bundle explorer).
+Gplay builds are obfuscated; the R8 mapping for retracing Play vitals or user logs is embedded in the uploaded bundle and can be downloaded from Play Console (App bundle explorer).
 
 > **Surprising convention:** `lane :production` in the Fastfile uploads to the **beta** track in Play (not `production`). Manual promotion to GA is done via Play Console. `lane :listing_only` is the only path that touches the `production` track and only for metadata refreshes.
 

--- a/.github/RELEASING.md
+++ b/.github/RELEASING.md
@@ -30,6 +30,8 @@ Files updated by every release:
 | `-beta<n>` | `assembleFossBeta` | **pre-release** | `lane :beta` | `beta` | 10% |
 | `-rc<n>` | `assembleFossRelease` | **release** | `lane :production` | **`beta`** | 10% |
 
+Gplay builds are obfuscated; the R8 mapping for retracing Play vitals or user logs is attached to the release-tag workflow run as the artifact r8-mapping-gplay-<tag> (90-day retention) and is also embedded in the uploaded bundle (Play Console → App bundle explorer).
+
 > **Surprising convention:** `lane :production` in the Fastfile uploads to the **beta** track in Play (not `production`). Manual promotion to GA is done via Play Console. `lane :listing_only` is the only path that touches the `production` track and only for metadata refreshes.
 
 ## Validation guards

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -223,13 +223,3 @@ jobs:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
-
-      - name: Upload R8 mapping files
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7.0.0
-        if: always() && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
-        with:
-          name: r8-mapping-gplay-${{ github.ref_name }}
-          path: app/build/outputs/mapping/gplay*/mapping.txt
-          if-no-files-found: error
-          retention-days: 90
-          overwrite: true

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -223,3 +223,12 @@ jobs:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+
+      - name: Upload R8 mapping files
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f #v7.0.0
+        if: always() && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        with:
+          name: r8-mapping-gplay-${{ github.ref_name }}
+          path: app/build/outputs/mapping/gplay*/mapping.txt
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -232,3 +232,4 @@ jobs:
           path: app/build/outputs/mapping/gplay*/mapping.txt
           if-no-files-found: error
           retention-days: 90
+          overwrite: true

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationHostExtensions.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/AutomationHostExtensions.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.automation.core.common.ACSNodeInfo
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
@@ -20,7 +21,7 @@ suspend fun AutomationHost.waitForWindowRoot(delayMs: Long = 250): ACSNodeInfo {
         root = windowRoot()
         if (root != null) break
 
-        if (Bugs.isDebug) log(VERBOSE) { "Waiting for windowRoot..." }
+        if (Bugs.isDebug) log(TAG, VERBOSE) { "Waiting for windowRoot..." }
         delay(delayMs)
     }
 
@@ -39,3 +40,6 @@ suspend fun AutomationHost.dispatchGesture(gesture: GestureDescription): Boolean
             }
         }, null)
     }
+
+
+private val TAG = logTag("Automation", "Host", "Extensions")

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/ScreenState.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/ScreenState.kt
@@ -58,7 +58,7 @@ class ScreenState @Inject constructor(
                         }
                     }
 
-                    else -> log(ERROR) { "Unknown intent: $intent" }
+                    else -> log(TAG, ERROR) { "Unknown intent: $intent" }
                 }
             }
         }

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/AutomationLabelSource.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/common/AutomationLabelSource.kt
@@ -44,13 +44,13 @@ interface AutomationLabelSource {
         val identifier = localizedRes.getIdentifier(stringIdName, "string", pkgId.name).takeIf { it != 0 }
         identifier?.let { localizedRes.getString(it) }.also {
             if (it != null) {
-                log { "Read ${pkgId.name}:${stringIdName} [$locale] from settings APK: $it" }
+                log(TAG) { "Read ${pkgId.name}:${stringIdName} [$locale] from settings APK: $it" }
             } else {
-                log(WARN) { "Failed to read ${pkgId.name}:${stringIdName} [$locale] from settings APK." }
+                log(TAG, WARN) { "Failed to read ${pkgId.name}:${stringIdName} [$locale] from settings APK." }
             }
         }
     } catch (e: Exception) {
-        log(ERROR) { "get3rdPartyString(${pkgId.name}, $stringIdName, $locale) failed: ${e.asLog()}" }
+        log(TAG, ERROR) { "get3rdPartyString(${pkgId.name}, $stringIdName, $locale) failed: ${e.asLog()}" }
         null
     }
 
@@ -59,7 +59,7 @@ interface AutomationLabelSource {
             try {
                 source.invoke().toSet()
             } catch (e: Exception) {
-                log(WARN) { "Failed to source list: ${e.asLog()}" }
+                log(TAG, WARN) { "Failed to source list: ${e.asLog()}" }
                 emptySet()
             }
         ).toSet()

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationCompatibilityException.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationCompatibilityException.kt
@@ -13,6 +13,7 @@ import eu.darken.sdmse.common.error.LocalizedError
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 
 open class AutomationCompatibilityException(
     override val message: String = "SD Maid couldn’t figure out the screen layout. If this keeps happening, your language or setup might not be fully supported. Check for updates or reach out to me so I can fix it.",
@@ -48,9 +49,12 @@ open class AutomationCompatibilityException(
                 }
                 it.startActivity(intent)
             } catch (e: Exception) {
-                log(WARN) { "Failed to open bug report URL: ${e.asLog()}" }
+                log(TAG, WARN) { "Failed to open bug report URL: ${e.asLog()}" }
             }
         }
     )
 
 }
+
+
+private val TAG = logTag("Automation", "Error", "Compatibility")

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationTimeoutException.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/errors/AutomationTimeoutException.kt
@@ -9,6 +9,7 @@ import eu.darken.sdmse.common.error.LocalizedError
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import kotlinx.coroutines.TimeoutCancellationException
 
 open class AutomationTimeoutException(
@@ -31,9 +32,12 @@ open class AutomationTimeoutException(
                 }
                 it.startActivity(intent)
             } catch (e: Exception) {
-                log(WARN) { "Failed to open bug report URL: ${e.asLog()}" }
+                log(TAG, WARN) { "Failed to open bug report URL: ${e.asLog()}" }
             }
         }
     )
 
 }
+
+
+private val TAG = logTag("Automation", "Error", "Timeout")

--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGenerator.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/core/specs/SpecGenerator.kt
@@ -5,6 +5,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.features.Installed
 
@@ -21,13 +22,16 @@ interface SpecGenerator {
         val identifier = appResources.getIdentifier(stringIdName, "string", pkgId.name).takeIf { it != 0 }
         identifier?.let { appResources.getString(it) }.also {
             if (it != null) {
-                log { "Read ${pkgId.name}:${stringIdName} from settings APK: $it" }
+                log(TAG) { "Read ${pkgId.name}:${stringIdName} from settings APK: $it" }
             } else {
-                log(WARN) { "Failed to read ${pkgId.name}:${stringIdName} from settings APK." }
+                log(TAG, WARN) { "Failed to read ${pkgId.name}:${stringIdName} from settings APK." }
             }
         }
     } catch (e: Exception) {
-        log(ERROR) { "get3rdPartyString(${pkgId.name}, $stringIdName) failed: ${e.asLog()}" }
+        log(TAG, ERROR) { "get3rdPartyString(${pkgId.name}, $stringIdName) failed: ${e.asLog()}" }
         null
     }
 }
+
+
+private val TAG = logTag("Automation", "SpecGenerator")

--- a/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/AppIconFetcher.kt
+++ b/app-common-coil/src/main/java/eu/darken/sdmse/common/coil/AppIconFetcher.kt
@@ -13,6 +13,7 @@ import coil.fetch.Fetcher
 import coil.request.Options
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.funnel.IPCFunnel
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.getIcon2
@@ -25,7 +26,7 @@ class AppIconFetcher @Inject constructor(
 ) : Fetcher {
 
     override suspend fun fetch(): FetchResult {
-        log(VERBOSE) { "Fetching $data" }
+        log(TAG, VERBOSE) { "Fetching $data" }
         val baseIcon = ipcFunnel.use {
             data.icon?.invoke(options.context) ?: packageManager.getIcon2(data.id)
         } ?: ContextCompat.getDrawable(options.context, eu.darken.sdmse.common.io.R.drawable.ic_default_app_icon_24)!!
@@ -62,3 +63,6 @@ class AppIconFetcher @Inject constructor(
         ): Fetcher = AppIconFetcher(ipcFunnel, data, options)
     }
 }
+
+
+private val TAG = logTag("Coil", "AppIconFetcher")

--- a/app-common-data/src/main/java/eu/darken/sdmse/common/pkgs/InstalledPathAreaMapping.kt
+++ b/app-common-data/src/main/java/eu/darken/sdmse/common/pkgs/InstalledPathAreaMapping.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.common.pkgs
 import eu.darken.sdmse.common.areas.DataArea
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.APath
 import eu.darken.sdmse.common.pkgs.features.Installed
 
@@ -11,7 +12,10 @@ fun Installed.getPrivateDataDirs(areas: Collection<DataArea>): Collection<APath>
         .filter { it.type == DataArea.Type.PRIVATE_DATA }
         .filter { it.userHandle == userHandle }
 
-    if (privateAreas.isEmpty()) log(WARN) { "No PRIVATE_DATA areas provided" }
+    if (privateAreas.isEmpty()) log(TAG, WARN) { "No PRIVATE_DATA areas provided" }
 
     return privateAreas.map { it.path.child(packageName) }
 }
+
+
+private val TAG = logTag("Pkg", "InstalledPathAreaMapping")

--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/PathExclusion.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/PathExclusion.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.exclusion.core.types
 
+import androidx.annotation.Keep
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
@@ -11,6 +12,7 @@ import eu.darken.sdmse.common.serialization.APathSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@Keep // simpleName is part of the persisted ExclusionId, see createId()
 @Serializable
 data class PathExclusion(
     @SerialName("path") @Serializable(with = APathSerializer::class) val path: APath,

--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/PkgExclusion.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/PkgExclusion.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.exclusion.core.types
 
+import androidx.annotation.Keep
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
@@ -10,6 +11,7 @@ import eu.darken.sdmse.common.pkgs.getLabel2
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@Keep // simpleName is part of the persisted ExclusionId, see createId()
 @Serializable
 data class PkgExclusion(
     @SerialName("pkgId") val pkgId: Pkg.Id,

--- a/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/SegmentExclusion.kt
+++ b/app-common-exclusion/src/main/java/eu/darken/sdmse/exclusion/core/types/SegmentExclusion.kt
@@ -1,5 +1,6 @@
 package eu.darken.sdmse.exclusion.core.types
 
+import androidx.annotation.Keep
 import eu.darken.sdmse.common.ca.CaString
 import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
@@ -12,6 +13,7 @@ import eu.darken.sdmse.common.files.joinSegments
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@Keep // simpleName is part of the persisted ExclusionId, see createId()
 @Serializable
 data class SegmentExclusion(
     @SerialName("segments") val segments: Segments,

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PathExclusionTest.kt
@@ -31,6 +31,12 @@ class PathExclusionTest : BaseTest() {
     }
 
     @Test
+    fun `id keeps the persisted prefix`() {
+        // Persisted in exclusion.default.removed; renaming the class needs a migration.
+        PathExclusion(LocalPath.build("test", "path")).id shouldBe "PathExclusion-/test/path"
+    }
+
+    @Test
     fun `custom tags`() {
         testFile.tryMkFile()
         val original = PathExclusion(

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PkgExclusionTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/PkgExclusionTest.kt
@@ -31,6 +31,12 @@ class PkgExclusionTest : BaseTest() {
     }
 
     @Test
+    fun `id keeps the persisted prefix`() {
+        // Persisted in exclusion.default.removed; renaming the class needs a migration.
+        PkgExclusion("com.example.app".toPkgId()).id shouldBe "PkgExclusion-com.example.app"
+    }
+
+    @Test
     fun `custom tags`() {
         testFile.tryMkFile()
         val original = PkgExclusion(

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/SegmentExclusionTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/SegmentExclusionTest.kt
@@ -21,6 +21,16 @@ class SegmentExclusionTest : BaseTest() {
         testFile.delete()
     }
 
+    @Test
+    fun `id keeps the persisted prefix`() {
+        // Persisted in exclusion.default.removed; renaming the class needs a migration.
+        SegmentExclusion(
+            segments = segs("some", "dir"),
+            allowPartial = false,
+            ignoreCase = false,
+        ).id shouldBe "SegmentExclusion-some/dir"
+    }
+
 
     @Test
     fun `custom tags`() {

--- a/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/SegmentExclusionTest.kt
+++ b/app-common-exclusion/src/test/java/eu/darken/sdmse/exclusion/core/types/SegmentExclusionTest.kt
@@ -31,7 +31,6 @@ class SegmentExclusionTest : BaseTest() {
         ).id shouldBe "SegmentExclusion-some/dir"
     }
 
-
     @Test
     fun `custom tags`() {
         testFile.tryMkFile()

--- a/app-common-io/consumer-rules.pro
+++ b/app-common-io/consumer-rules.pro
@@ -1,8 +1,12 @@
 -keep class android.content.pm.IPackageDataObserver { *; }
 
--keepclassmembers class eu.darken.sdmse.common.root.service.RootServiceConnection$Stub$Proxy {
-  *;
-}
--keepclassmembers class eu.darken.sdmse.common.adb.AdbServiceConnection** {
-  *;
-}
+# BinderExtensions.getInterface() resolves these AIDL interfaces by name:
+# Class.forName("<interface>$Stub").getField("DESCRIPTOR") and
+# Class.forName("<interface>$Stub$Proxy").getDeclaredConstructor(IBinder).
+# Generated code, so @Keep is not an option.
+-keep class eu.darken.sdmse.common.root.service.RootServiceConnection { public static final java.lang.String DESCRIPTOR; }
+-keep class eu.darken.sdmse.common.root.service.RootServiceConnection$Stub
+-keep class eu.darken.sdmse.common.root.service.RootServiceConnection$Stub$Proxy { <init>(android.os.IBinder); }
+-keep class eu.darken.sdmse.common.adb.AdbServiceConnection { public static final java.lang.String DESCRIPTOR; }
+-keep class eu.darken.sdmse.common.adb.AdbServiceConnection$Stub
+-keep class eu.darken.sdmse.common.adb.AdbServiceConnection$Stub$Proxy { <init>(android.os.IBinder); }

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathExtensions.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.common.files
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.files.local.LocalPath
 import eu.darken.sdmse.common.files.local.crumbsTo
 import eu.darken.sdmse.common.files.local.isAncestorOf
@@ -77,7 +78,7 @@ suspend fun <T : APath> T.requireNotExists(gateway: APathGateway<T, out APathLoo
 suspend fun <T : APath> T.createFileIfNecessary(gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>): T {
     if (exists(gateway)) {
         if (gateway.lookup(this).fileType == FileType.FILE) {
-            log(VERBOSE) { "File already exists, not creating: $this" }
+            log(TAG, VERBOSE) { "File already exists, not creating: $this" }
             return this
         } else {
             throw IOException("Exists, but is not a file: $this")
@@ -89,14 +90,14 @@ suspend fun <T : APath> T.createFileIfNecessary(gateway: APathGateway<T, out APa
 
 suspend fun <T : APath> T.createFile(gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>): T {
     gateway.createFile(this)
-    log(VERBOSE) { "File created: $this" }
+    log(TAG, VERBOSE) { "File created: $this" }
     return this
 }
 
 suspend fun <T : APath> T.createDirIfNecessary(gateway: APathGateway<T, out APathLookup<T>, out APathLookupExtended<T>>): T {
     if (exists(gateway)) {
         if (gateway.lookup(this).isDirectory) {
-            log(VERBOSE) { "Directory already exists, not creating: $this" }
+            log(TAG, VERBOSE) { "Directory already exists, not creating: $this" }
             return this
         } else {
             throw IOException("Exists, but is not a directory: $this")
@@ -104,7 +105,7 @@ suspend fun <T : APath> T.createDirIfNecessary(gateway: APathGateway<T, out APat
     }
 
     gateway.createDir(this)
-    log(VERBOSE) { "Directory created: $this" }
+    log(TAG, VERBOSE) { "Directory created: $this" }
     return this
 }
 
@@ -116,7 +117,7 @@ suspend fun <T : APath> T.delete(
         this,
         recursive = recursive
     )
-    log(VERBOSE) { "APath.delete(recursive=$recursive): Deleted $this" }
+    log(TAG, VERBOSE) { "APath.delete(recursive=$recursive): Deleted $this" }
 }
 
 suspend fun <T : APath> T.deleteWalk(
@@ -136,13 +137,13 @@ suspend fun <T : APath> T.deleteWalk(
         }
 
         if (!filter(lookup)) {
-            log(VERBOSE) { "Skipped due to filter: $this" }
+            log(TAG, VERBOSE) { "Skipped due to filter: $this" }
             return
         }
     } catch (e: PathException) {
         val exists = gateway.exists(this)
         if (!exists) {
-            log(WARN) { "Path failed to delete, but no longer exists: $this" }
+            log(TAG, WARN) { "Path failed to delete, but no longer exists: $this" }
             return
         } else {
             throw e
@@ -304,3 +305,6 @@ val APath.extension: String?
     get() = name.substringAfterLast('.', "").takeIf { it.isNotEmpty() }
 
 fun APath.child(segs: Segments) = child(*segs.toTypedArray())
+
+
+private val TAG = logTag("APath", "Extensions")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/files/APathLookupExtensions.kt
@@ -2,6 +2,7 @@ package eu.darken.sdmse.common.files
 
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import kotlinx.coroutines.flow.Flow
 import okio.FileHandle
 
@@ -97,15 +98,18 @@ fun APathLookup<*>.removePrefix(prefix: APath, overlap: Int = 0) =
     lookedUp.removePrefix(prefix, overlap)
 
 fun Collection<APathLookup<*>>.filterDistinctRoots(): Set<APathLookup<*>> {
-    log(VERBOSE) { "Creating lookup map..." }
+    log(TAG, VERBOSE) { "Creating lookup map..." }
     val lookupMap = this.associateBy { it.lookedUp }
-    log(VERBOSE) { "Lookup map created with ${lookupMap.size} entries, now filtering..." }
+    log(TAG, VERBOSE) { "Lookup map created with ${lookupMap.size} entries, now filtering..." }
     return lookupMap.keys
         .filterDistinctRoots()
         .map { lookupMap.getValue(it) }
         .toSet()
-        .also { log(VERBOSE) { "After filtering we got ${it.size} distinct roots" } }
+        .also { log(TAG, VERBOSE) { "After filtering we got ${it.size} distinct roots" } }
 }
 
 val APathLookup<*>.extension: String?
     get() = lookedUp.extension
+
+
+private val TAG = logTag("APath", "Lookup", "Extensions")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteFileHandleExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteFileHandleExtensions.kt
@@ -8,6 +8,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import okio.FileHandle
 import okio.FileSystem
 import okio.IOException
@@ -34,18 +35,18 @@ internal fun FileHandle.remoteFileHandle(): RemoteFileHandle.Stub = object : Rem
     override fun read(fileOffset: Long, array: ByteArray, arrayOffset: Int, byteCount: Int): Int = try {
         this@remoteFileHandle.read(fileOffset, array, arrayOffset, byteCount).also {
             if (Bugs.isTrace) {
-                log(VERBOSE) { "read(rootside-p): $fileOffset, ${array.size}, $arrayOffset, $byteCount, read $it into ${array.toHex()}" }
+                log(TAG, VERBOSE) { "read(rootside-p): $fileOffset, ${array.size}, $arrayOffset, $byteCount, read $it into ${array.toHex()}" }
             }
         }
     } catch (e: IOException) {
-        log(ERROR) { "read() failed: ${e.asLog()}" }
+        log(TAG, ERROR) { "read() failed: ${e.asLog()}" }
         -2
     }
 
     override fun write(fileOffset: Long, array: ByteArray, arrayOffset: Int, byteCount: Int) = try {
         this@remoteFileHandle.write(fileOffset, array, arrayOffset, byteCount)
     } catch (e: IOException) {
-        log(ERROR) { "write() failed: ${e.asLog()}" }
+        log(TAG, ERROR) { "write() failed: ${e.asLog()}" }
     }
 
     override fun flush() = this@remoteFileHandle.flush()
@@ -55,7 +56,7 @@ internal fun FileHandle.remoteFileHandle(): RemoteFileHandle.Stub = object : Rem
     override fun size(): Long = try {
         this@remoteFileHandle.size()
     } catch (e: IOException) {
-        log(ERROR) { "size() failed: ${e.asLog()}" }
+        log(TAG, ERROR) { "size() failed: ${e.asLog()}" }
         -2
     }
 
@@ -74,7 +75,7 @@ internal fun RemoteFileHandle.fileHandle(readWrite: Boolean): FileHandle = objec
     override fun protectedRead(fileOffset: Long, array: ByteArray, arrayOffset: Int, byteCount: Int): Int = try {
         this@fileHandle.read(fileOffset, array, arrayOffset, byteCount).also {
             if (Bugs.isTrace) {
-                log(VERBOSE) { "read(appside-p): $fileOffset, ${array.size}, $arrayOffset, $byteCount, read $it into ${array.toHex()}" }
+                log(TAG, VERBOSE) { "read(appside-p): $fileOffset, ${array.size}, $arrayOffset, $byteCount, read $it into ${array.toHex()}" }
             }
             if (it == -2) throw IOException("Remote Exception")
         }
@@ -118,3 +119,6 @@ internal fun RemoteFileHandle.fileHandle(readWrite: Boolean): FileHandle = objec
     }
 
 }
+
+
+private val TAG = logTag("IPC", "RemoteFileHandle")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteInputStreamExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteInputStreamExtensions.kt
@@ -5,6 +5,7 @@ import android.os.RemoteException
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import okio.Source
 import okio.source
 import java.io.IOException
@@ -34,21 +35,21 @@ internal fun InputStream.remoteInputStream(): RemoteInputStream.Stub = object : 
     override fun available(): Int = try {
         this@remoteInputStream.available()
     } catch (e: IOException) {
-        log(ERROR) { "available() failed: ${e.asLog()}" }
+        log(TAG, ERROR) { "available() failed: ${e.asLog()}" }
         -2
     }
 
     override fun read(): Int = try {
         this@remoteInputStream.read()
     } catch (e: IOException) {
-        log(ERROR) { "read() failed: ${e.asLog()}" }
+        log(TAG, ERROR) { "read() failed: ${e.asLog()}" }
         -2
     }
 
     override fun readBuffer(b: ByteArray, off: Int, len: Int): Int = try {
         this@remoteInputStream.read(b, off, len)
     } catch (e: IOException) {
-        log(ERROR) { "readBuffer() failed: ${e.asLog()}" }
+        log(TAG, ERROR) { "readBuffer() failed: ${e.asLog()}" }
         -2
     }
 
@@ -113,3 +114,6 @@ internal fun RemoteInputStream.inputStream(): InputStream = object : InputStream
 }
 
 fun RemoteInputStream.source(): Source = inputStream().source()
+
+
+private val TAG = logTag("IPC", "RemoteInputStream")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteOutputStreamExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/ipc/RemoteOutputStreamExtensions.kt
@@ -5,6 +5,7 @@ import android.os.RemoteException
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import okio.Sink
 import okio.sink
 import java.io.IOException
@@ -18,19 +19,19 @@ internal fun OutputStream.toRemoteOutputStream(): RemoteOutputStream.Stub = obje
     override fun write(b: Int) = try {
         this@toRemoteOutputStream.write(b)
     } catch (e: IOException) {
-        log(ERROR) { "write() failed: ${e.asLog()}" }
+        log(TAG, ERROR) { "write() failed: ${e.asLog()}" }
     }
 
     override fun writeBuffer(b: ByteArray, off: Int, len: Int) = try {
         this@toRemoteOutputStream.write(b, off, len)
     } catch (e: IOException) {
-        log(ERROR) { "writeBuffer() failed: ${e.asLog()}" }
+        log(TAG, ERROR) { "writeBuffer() failed: ${e.asLog()}" }
     }
 
     override fun flush() = try {
         this@toRemoteOutputStream.flush()
     } catch (e: IOException) {
-        log(ERROR) { "flush() failed: ${e.asLog()}" }
+        log(TAG, ERROR) { "flush() failed: ${e.asLog()}" }
     }
 
     override fun close() = try {
@@ -74,3 +75,6 @@ internal fun RemoteOutputStream.outputStream(): OutputStream = object : OutputSt
 }
 
 fun RemoteOutputStream.sink(): Sink = outputStream().sink()
+
+
+private val TAG = logTag("IPC", "RemoteOutputStream")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
@@ -14,6 +14,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.user.UserHandle2
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -62,7 +63,7 @@ fun PackageManager.getPackageInfosAsUser(
     )
     method.invoke(this, packageName, flags.toInt(), userHandle.handleId) as PackageInfo?
 } catch (e: Exception) {
-    log(ERROR) { e.asLog() }
+    log(TAG, ERROR) { e.asLog() }
     null
 }
 
@@ -98,7 +99,7 @@ fun PackageManager.getInstalledPackagesAsUser(
         (method.invoke(this, flags.toInt(), userHandle.handleId) as List<PackageInfo>)
     }
 } catch (e: Exception) {
-    log(ERROR) { e.asLog() }
+    log(TAG, ERROR) { e.asLog() }
     throw e
 }
 
@@ -115,7 +116,7 @@ fun PackageManager.toggleSelfComponent(
     component: ComponentName,
     enabled: Boolean,
 ) {
-    log { "toggleSelfComponent($component,$enabled)" }
+    log(TAG) { "toggleSelfComponent($component,$enabled)" }
     setComponentEnabledSetting(
         component,
         when {
@@ -164,13 +165,13 @@ suspend fun PackageManager.freeStorageAndNotify(
                             // package to the accessibility fallback, minutes of automation for
                             // work that already succeeded. Judge the outcome by re-reading the
                             // cache sizes instead, as InaccessibleDeleter does.
-                            log(VERBOSE) { "freeStorageAndNotify() $packageName -> $succeeded" }
+                            log(TAG, VERBOSE) { "freeStorageAndNotify() $packageName -> $succeeded" }
                             continuation.resume(true)
                         }
                     }
                 )
             } catch (e: Exception) {
-                log(WARN) { "freeStorageAndNotify($desiredBytes,$storageId) failed: ${e.asLog()}" }
+                log(TAG, WARN) { "freeStorageAndNotify($desiredBytes,$storageId) failed: ${e.asLog()}" }
                 continuation.resume(false)
             }
         }
@@ -200,13 +201,13 @@ suspend fun PackageManager.deleteApplicationCacheFiles(
                     object : IPackageDataObserver.Stub() {
                         @Throws(RemoteException::class)
                         override fun onRemoveCompleted(packageName: String?, succeeded: Boolean) {
-                            log(VERBOSE) { "deleteApplicationCacheFiles() $packageName -> $succeeded" }
+                            log(TAG, VERBOSE) { "deleteApplicationCacheFiles() $packageName -> $succeeded" }
                             continuation.resume(succeeded)
                         }
                     }
                 )
             } catch (e: Exception) {
-                log(WARN) { "deleteApplicationCacheFiles($packageName) failed: ${e.asLog()}" }
+                log(TAG, WARN) { "deleteApplicationCacheFiles($packageName) failed: ${e.asLog()}" }
                 continuation.resume(false)
             }
         }
@@ -239,15 +240,18 @@ suspend fun PackageManager.deleteApplicationCacheFilesAsUser(
                     object : IPackageDataObserver.Stub() {
                         @Throws(RemoteException::class)
                         override fun onRemoveCompleted(packageName: String?, succeeded: Boolean) {
-                            log(VERBOSE) { "deleteApplicationCacheFilesAsUser() $packageName -> $succeeded" }
+                            log(TAG, VERBOSE) { "deleteApplicationCacheFilesAsUser() $packageName -> $succeeded" }
                             continuation.resume(succeeded)
                         }
                     }
                 )
             } catch (e: Exception) {
-                log(WARN) { "deleteApplicationCacheFilesAsUser($packageName,$userId) failed: ${e.asLog()}" }
+                log(TAG, WARN) { "deleteApplicationCacheFilesAsUser($packageName,$userId) failed: ${e.asLog()}" }
                 continuation.resume(false)
             }
         }
     }
 }
+
+
+private val TAG = logTag("PackageManager", "Extensions")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/features/InstallerInfo.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/features/InstallerInfo.kt
@@ -12,6 +12,7 @@ import androidx.core.content.ContextCompat
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.io.R
 import eu.darken.sdmse.common.pkgs.AKnownPkg
@@ -119,7 +120,7 @@ private fun PackageInfo.getInstallerInfoLegacy(packageManager: PackageManager): 
             ?.let { Pkg.Id(it) }
             ?.let { it.toKnownPkg() ?: it.toStub() }
     } catch (e: IllegalArgumentException) {
-        log(WARN) { "OS race condition, package ($packageName) was uninstalled?: ${e.asLog()}" }
+        log(TAG, WARN) { "OS race condition, package ($packageName) was uninstalled?: ${e.asLog()}" }
         null
     }
 
@@ -127,3 +128,6 @@ private fun PackageInfo.getInstallerInfoLegacy(packageManager: PackageManager): 
         installingPkg = installingPkg,
     )
 }
+
+
+private val TAG = logTag("Pkg", "InstallerInfo")

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/storage/DiskInfoX.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/storage/DiskInfoX.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import java.lang.reflect.Method
 
 
@@ -19,7 +20,7 @@ class DiskInfoX(private val diskInfoObject: Any) {
         try {
             volumeInfoClass.getMethod("getId")
         } catch (e: Exception) {
-            log(WARN) { "volumeInfoClass.getMethod(\"getId\"): ${e.asLog()}" }
+            log(TAG, WARN) { "volumeInfoClass.getMethod(\"getId\"): ${e.asLog()}" }
             null
         }
     }
@@ -27,7 +28,7 @@ class DiskInfoX(private val diskInfoObject: Any) {
         get() = try {
             methodGetId?.invoke(diskInfoObject) as? String
         } catch (e: ReflectiveOperationException) {
-            log(WARN) { "DiskInfoX.id reflection failed" }
+            log(TAG, WARN) { "DiskInfoX.id reflection failed" }
             null
         }
 
@@ -35,7 +36,7 @@ class DiskInfoX(private val diskInfoObject: Any) {
         try {
             volumeInfoClass.getMethod("getDescription")
         } catch (e: Exception) {
-            log(WARN) { "volumeInfoClass.getMethod(\"getDescription\"): ${e.asLog()}" }
+            log(TAG, WARN) { "volumeInfoClass.getMethod(\"getDescription\"): ${e.asLog()}" }
             null
         }
     }
@@ -43,7 +44,7 @@ class DiskInfoX(private val diskInfoObject: Any) {
         get() = try {
             methodGetDescription?.invoke(diskInfoObject) as? String?
         } catch (e: ReflectiveOperationException) {
-            log(WARN) { "DiskInfoX.description reflection failed" }
+            log(TAG, WARN) { "DiskInfoX.description reflection failed" }
             null
         }
 
@@ -51,7 +52,7 @@ class DiskInfoX(private val diskInfoObject: Any) {
         try {
             volumeInfoClass.getMethod("isAdoptable")
         } catch (e: Exception) {
-            log(WARN) { "volumeInfoClass.getMethod(\"isAdoptable\"): ${e.asLog()}" }
+            log(TAG, WARN) { "volumeInfoClass.getMethod(\"isAdoptable\"): ${e.asLog()}" }
             null
         }
     }
@@ -59,7 +60,7 @@ class DiskInfoX(private val diskInfoObject: Any) {
         get() = try {
             methodIsAdoptable?.invoke(diskInfoObject) as? Boolean
         } catch (e: ReflectiveOperationException) {
-            log(WARN) { "DiskInfoX.isAdoptable reflection failed" }
+            log(TAG, WARN) { "DiskInfoX.isAdoptable reflection failed" }
             null
         }
 
@@ -67,7 +68,7 @@ class DiskInfoX(private val diskInfoObject: Any) {
         try {
             volumeInfoClass.getMethod("isDefaultPrimary")
         } catch (e: Exception) {
-            log(WARN) { "volumeInfoClass.getMethod(\"isDefaultPrimary\"): ${e.asLog()}" }
+            log(TAG, WARN) { "volumeInfoClass.getMethod(\"isDefaultPrimary\"): ${e.asLog()}" }
             null
         }
     }
@@ -75,7 +76,7 @@ class DiskInfoX(private val diskInfoObject: Any) {
         get() = try {
             methodIsDefaultPrimary?.invoke(diskInfoObject) as? Boolean
         } catch (e: ReflectiveOperationException) {
-            log(WARN) { "DiskInfoX.isDefaultPrimary reflection failed" }
+            log(TAG, WARN) { "DiskInfoX.isDefaultPrimary reflection failed" }
             null
         }
 
@@ -83,7 +84,7 @@ class DiskInfoX(private val diskInfoObject: Any) {
         try {
             volumeInfoClass.getMethod("isSd")
         } catch (e: Exception) {
-            log(WARN) { "volumeInfoClass.getMethod(\"isSd\"): ${e.asLog()}" }
+            log(TAG, WARN) { "volumeInfoClass.getMethod(\"isSd\"): ${e.asLog()}" }
             null
         }
     }
@@ -91,7 +92,7 @@ class DiskInfoX(private val diskInfoObject: Any) {
         get() = try {
             methodIsSd?.invoke(diskInfoObject) as? Boolean
         } catch (e: ReflectiveOperationException) {
-            log(WARN) { "DiskInfoX.isSd reflection failed" }
+            log(TAG, WARN) { "DiskInfoX.isSd reflection failed" }
             null
         }
 
@@ -99,7 +100,7 @@ class DiskInfoX(private val diskInfoObject: Any) {
         try {
             volumeInfoClass.getMethod("isUsb")
         } catch (e: Exception) {
-            log(WARN) { "volumeInfoClass.getMethod(\"isUsb\"): ${e.asLog()}" }
+            log(TAG, WARN) { "volumeInfoClass.getMethod(\"isUsb\"): ${e.asLog()}" }
             null
         }
     }
@@ -107,10 +108,13 @@ class DiskInfoX(private val diskInfoObject: Any) {
         get() = try {
             methodIsUsb?.invoke(diskInfoObject) as? Boolean
         } catch (e: ReflectiveOperationException) {
-            log(WARN) { "DiskInfoX.isUsb reflection failed" }
+            log(TAG, WARN) { "DiskInfoX.isUsb reflection failed" }
             null
         }
 
     override fun toString(): String = "DiskInfoX($diskInfoObject)"
 
 }
+
+
+private val TAG = logTag("Storage", "DiskInfoX")

--- a/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/AppStoreTool.kt
+++ b/app-common-pkgs/src/main/java/eu/darken/sdmse/common/pkgs/AppStoreTool.kt
@@ -7,6 +7,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.WebpageTool
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.hasApiLevel
 import eu.darken.sdmse.common.pkgs.features.AppStore
 import javax.inject.Inject
@@ -28,19 +29,19 @@ class AppStoreTool @Inject constructor(
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
             if (specific != null) {
-                log { "Using resovled app store intent: $specific" }
+                log(TAG) { "Using resovled app store intent: $specific" }
                 context.startActivity(specific)
                 return
             }
         }
         if (installer is AppStore) {
             installer.urlGenerator?.invoke(target.id)?.let {
-                log { "Using urlgenerator from known app store: $it" }
+                log(TAG) { "Using urlgenerator from known app store: $it" }
                 webpageTool.open(it)
                 return
             }
         }
-        log(WARN) { "No known way to open $target in $installer" }
+        log(TAG, WARN) { "No known way to open $target in $installer" }
     }
 
     private fun Intent.resolveToActivity(): Intent? = context.packageManager.resolveActivity(this, 0)?.let { result ->
@@ -48,3 +49,6 @@ class AppStoreTool @Inject constructor(
             .apply { setClassName(result.activityInfo.packageName, result.activityInfo.name) }
     }
 }
+
+
+private val TAG = logTag("AppStoreTool")

--- a/app-common-root/consumer-rules.pro
+++ b/app-common-root/consumer-rules.pro
@@ -1,3 +1,0 @@
--keepclassmembers class eu.darken.sdmse.common.root.service.RootServiceConnection {
-    public static final java.lang.String DESCRIPTOR;
-}

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/BaseRootHost.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/BaseRootHost.kt
@@ -116,7 +116,7 @@ abstract class BaseRootHost(
                     @Suppress("DEPRECATION")
                     Looper.prepareMainLooper()
                 } catch (e: Exception) {
-                    log(ERROR) { "Failed prepareMainLooper() for systemContext" }
+                    log(iTag, ERROR) { "Failed prepareMainLooper() for systemContext" }
                 }
             }
             val cActivityThread = Class.forName("android.app.ActivityThread")
@@ -124,10 +124,10 @@ abstract class BaseRootHost(
             val mGetSystemContext = cActivityThread.getMethod("getSystemContext")
             val oActivityThread = mSystemMain.invoke(null)
             val oContext = mGetSystemContext.invoke(oActivityThread)
-            log { "Grabbed context $oContext" }
+            log(iTag) { "Grabbed context $oContext" }
             oContext as Context
         } catch (e: Exception) {
-            log(ERROR) { "Failed to obtain system context: ${e.asLog()}" }
+            log(iTag, ERROR) { "Failed to obtain system context: ${e.asLog()}" }
             throw RuntimeException("Unexpected exception in getSystemContext()")
         }
     }

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/ReflectionBroadcast.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/ReflectionBroadcast.kt
@@ -65,15 +65,15 @@ class ReflectionBroadcast @Inject constructor() {
      * ActivityManager.broadcastIntent() method
      */
     private val broadcastIntent: Method by lazy<Method> {
-        log { "broadcastIntent - init" }
+        log(TAG) { "broadcastIntent - init" }
         for (m in activityManager.javaClass.methods) {
             if (m.name == "broadcastIntent" && m.parameterTypes.size == 13) {
-                log { "broadcastIntent - size=13" }
+                log(TAG) { "broadcastIntent - size=13" }
                 // API 24+
                 return@lazy m
             }
             if (m.name == "broadcastIntent" && m.parameterTypes.size == 12) {
-                log { "broadcastIntent - size=12" }
+                log(TAG) { "broadcastIntent - size=12" }
                 // API 21+
                 return@lazy m
             }
@@ -93,15 +93,15 @@ class ReflectionBroadcast @Inject constructor() {
     @SuppressLint("PrivateApi")
     fun sendBroadcast(intent: Intent, userId: Int) {
         try {
-            log { "sendBroadcast(userId=$userId, intent=${intent})..." }
+            log(TAG) { "sendBroadcast(userId=$userId, intent=${intent})..." }
             // Prevent system from complaining about unprotected broadcast, if the field exists
             intent.flags = flagReceiverFromShell
-            log { "sendBroadcast(...) flags prepared" }
+            log(TAG) { "sendBroadcast(...) flags prepared" }
 
             // API 24+
             // https://cs.android.com/android/platform/superproject/+/master:frameworks/base/services/core/java/com/android/server/am/ActivityManagerService.java;l=14427
             if (broadcastIntent.parameterTypes.size == 13) {
-                log { "sendBroadcast(...) sending (type=13)" }
+                log(TAG) { "sendBroadcast(...) sending (type=13)" }
 
                 broadcastIntent.invoke(
                     activityManager,
@@ -119,12 +119,12 @@ class ReflectionBroadcast @Inject constructor() {
                     false, // boolean sticky
                     userId, // int userId
                 )
-                log { "sendBroadcast(..) (type=13) done." }
+                log(TAG) { "sendBroadcast(..) (type=13) done." }
                 return
             }
 
             if (broadcastIntent.parameterTypes.size == 12) {
-                log { "sendBroadcast(...) sending (type=12)" }
+                log(TAG) { "sendBroadcast(...) sending (type=12)" }
                 // API 21+
                 broadcastIntent.invoke(
                     activityManager,
@@ -141,7 +141,7 @@ class ReflectionBroadcast @Inject constructor() {
                     false,
                     userId,
                 )
-                log { "sendBroadcast(..) (type=12) done." }
+                log(TAG) { "sendBroadcast(..) (type=12) done." }
                 return
             }
         } catch (e: Exception) {

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostCmdBuilder.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootHostCmdBuilder.kt
@@ -184,7 +184,7 @@ class RootHostCmdBuilder<Host : BaseRootHost>(
         withRelocation: Boolean,
         initialOptions: RootHostInitArgs,
     ): FlowCmd {
-        log { "build(relocate=$withRelocation, ${initialOptions})" }
+        log(TAG) { "build(relocate=$withRelocation, ${initialOptions})" }
         val cmds = mutableListOf<String>()
 
         val processPath: String = if (withRelocation) {

--- a/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootIPC.kt
+++ b/app-common-root/src/main/java/eu/darken/sdmse/common/root/service/internal/RootIPC.kt
@@ -202,10 +202,10 @@ class RootIPC @AssistedInject constructor(
             if (connections.size == 0) return
             connections.removeAll { con ->
                 !con.binder.isBinderAlive.also {
-                    log { "pruneConnections() $con: isBinderAlive=$it" }
+                    log(TAG) { "pruneConnections() $con: isBinderAlive=$it" }
                 }
             }
-            connections.forEach { log { "Remaining connection after pruning: $it" } }
+            connections.forEach { log(TAG) { "Remaining connection after pruning: $it" } }
             if (!connectionSeen && connections.size > 0) {
                 connectionSeen = true
                 synchronized(helloWaiter) { helloWaiter.notifyAll() }

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/ButtonExtensions.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/ButtonExtensions.kt
@@ -5,6 +5,7 @@ import android.widget.CompoundButton.OnCheckedChangeListener
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.reflection.getField
 
 fun CompoundButton.setChecked2(checked: Boolean, animate: Boolean = true) {
@@ -21,6 +22,9 @@ fun CompoundButton.getOnCheckedChangeListener(): OnCheckedChangeListener? = try 
     val field = CompoundButton::class.getField("mOnCheckedChangeListener")
     field.get(this) as? OnCheckedChangeListener
 } catch (e: Exception) {
-    log(WARN) { "Failed to access CompoundButton.mOnCheckedChangeListener: ${e.asLog()}" }
+    log(TAG, WARN) { "Failed to access CompoundButton.mOnCheckedChangeListener: ${e.asLog()}" }
     null
 }
+
+
+private val TAG = logTag("Button", "Extensions")

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/ContextUiExtensions.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/ContextUiExtensions.kt
@@ -8,6 +8,7 @@ import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
 import androidx.core.content.ContextCompat
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import kotlin.math.max
 
 
@@ -40,6 +41,9 @@ fun Context.getSpanCount(widthDp: Int = 390): Int {
     val screenWidthDp = displayMetrics.widthPixels / displayMetrics.density
     val count = (screenWidthDp / widthDp + 0.5).toInt()
     return max(count, 1).also {
-        log { "getSpanCount($screenWidthDp/$widthDp)=$it" }
+        log(TAG) { "getSpanCount($screenWidthDp/$widthDp)=$it" }
     }
 }
+
+
+private val TAG = logTag("Context", "UI", "Extensions")

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/ui/SizeParser.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/ui/SizeParser.kt
@@ -6,6 +6,7 @@ import android.icu.util.Measure
 import android.icu.util.MeasureUnit
 import android.text.format.Formatter
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import java.text.DecimalFormatSymbols
 
 class SizeParser(private val context: Context) {
@@ -52,13 +53,13 @@ class SizeParser(private val context: Context) {
                         val key = unit.uppercase()
                         val existing = get(key)
                         if (existing != null && existing != multiplier) {
-                            log { "Unit collision: '$key' existing=${existing} vs new=$multiplier (width=$width)" }
+                            log(TAG) { "Unit collision: '$key' existing=${existing} vs new=$multiplier (width=$width)" }
                         }
                         put(key, multiplier)
                     }
                 }
             }
-        }.also { log { "Size lookup map: $it" } }
+        }.also { log(TAG) { "Size lookup map: $it" } }
     }
 
     private fun normalizeDigits(input: String): String = input.map {
@@ -71,7 +72,7 @@ class SizeParser(private val context: Context) {
     fun parse(input: String): Long? {
         val trimmed = input.trim()
         val match = sizeUnitsRegex.matchEntire(trimmed) ?: run {
-            log { "No regex match for '$input' (hex=${trimmed.map { "%04x".format(it.code) }})" }
+            log(TAG) { "No regex match for '$input' (hex=${trimmed.map { "%04x".format(it.code) }})" }
             return null
         }
         val (value, unit) = match.destructured
@@ -79,11 +80,14 @@ class SizeParser(private val context: Context) {
             .replace(decimalSeperator, '.')
             .toDoubleOrNull()
         val factor = sizeUnitsLocalized[unit.uppercase()] ?: run {
-            log { "Unknown unit '$unit' in '$input'" }
+            log(TAG) { "Unknown unit '$unit' in '$input'" }
             return null
         }
         return valueNormalized
             ?.times(factor)?.toLong()
-            .also { log { "Parsed size '$input' to: $it Byte" } }
+            .also { log(TAG) { "Parsed size '$input' to: $it Byte" } }
     }
 }
+
+
+private val TAG = logTag("SizeParser")

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/uix/ViewModel2.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/uix/ViewModel2.kt
@@ -6,6 +6,7 @@ import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.setupCommonEventHandlers
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -49,6 +50,6 @@ abstract class ViewModel2(
         .launchIn(vmScope)
 
     companion object {
-        private fun defaultTag(): String = this::class.simpleName ?: "VM2"
+        private fun defaultTag(): String = logTag("ViewModel")
     }
 }

--- a/app-common-ui/src/main/java/eu/darken/sdmse/common/uix/ViewModel4.kt
+++ b/app-common-ui/src/main/java/eu/darken/sdmse/common/uix/ViewModel4.kt
@@ -4,6 +4,7 @@ import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.asLog
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.SingleEventFlow
 import eu.darken.sdmse.common.navigation.NavEvent
 import eu.darken.sdmse.common.navigation.NavigationDestination
@@ -77,6 +78,6 @@ abstract class ViewModel4(
         )
 
     companion object {
-        private fun defaultTag(): String = this::class.simpleName ?: "VM4"
+        private fun defaultTag(): String = logTag("ViewModel")
     }
 }

--- a/app-common/src/main/java/eu/darken/sdmse/common/WebpageTool.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/WebpageTool.kt
@@ -11,6 +11,7 @@ import dagger.Reusable
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import javax.inject.Inject
 
 @Reusable
@@ -30,7 +31,7 @@ class WebpageTool @Inject constructor(
             // Android TV has no browser, a system stub consumes browser intents and shows an unhelpful toast.
             val handler = intent.resolveActivity(context.packageManager)
             if (handler != null && handler.packageName in STUB_PACKAGES) {
-                log(ERROR) { "Failed to launch. Only stub handler ($handler) available for $address" }
+                log(TAG, ERROR) { "Failed to launch. Only stub handler ($handler) available for $address" }
                 showNoAppToast(context, address)
                 return false
             }
@@ -38,13 +39,13 @@ class WebpageTool @Inject constructor(
                 context.startActivity(intent)
                 true
             } catch (e: ActivityNotFoundException) {
-                log(ERROR) { "Failed to launch. No compatible activity for $address" }
+                log(TAG, ERROR) { "Failed to launch. No compatible activity for $address" }
                 showNoAppToast(context, address)
                 false
             } catch (e: SecurityException) {
                 // Permission Denial: starting Intent { act=android.intent.action.VIEW dat=https://github.com/...
                 // flg=0x10000000 cmp=com.mxtech.videoplayer.pro/com.mxtech.videoplayer.ActivityWebBrowser }
-                log(ERROR) { "Failed to launch activity due to $e" }
+                log(TAG, ERROR) { "Failed to launch activity due to $e" }
                 false
             }
         }
@@ -62,3 +63,6 @@ class WebpageTool @Inject constructor(
         )
     }
 }
+
+
+private val TAG = logTag("WebpageTool")

--- a/app-common/src/main/java/eu/darken/sdmse/common/files/core/local/FileExtensionsBase.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/files/core/local/FileExtensionsBase.kt
@@ -4,6 +4,7 @@ import android.system.Os
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.io.File
@@ -22,7 +23,7 @@ fun File(vararg crumbs: String): File {
 fun File.tryMkDirs(): File {
     if (exists()) {
         if (isDirectory) {
-            log(VERBOSE) { "Directory already exists, not creating: $this" }
+            log(TAG, VERBOSE) { "Directory already exists, not creating: $this" }
             return this
         } else {
             throw IllegalStateException("Directory exists, but is not a directory: $this")
@@ -30,7 +31,7 @@ fun File.tryMkDirs(): File {
     }
 
     if (mkdirs()) {
-        log(VERBOSE) { "Directory created: $this" }
+        log(TAG, VERBOSE) { "Directory created: $this" }
         return this
     } else {
         throw IllegalStateException("Couldn't create Directory: $this")
@@ -40,7 +41,7 @@ fun File.tryMkDirs(): File {
 fun File.tryMkFile(): File {
     if (exists()) {
         if (isFile) {
-            log(VERBOSE) { "File already exists, not creating: $this" }
+            log(TAG, VERBOSE) { "File already exists, not creating: $this" }
             return this
         } else {
             throw IllegalStateException("Path exists but is not a file: $this")
@@ -50,7 +51,7 @@ fun File.tryMkFile(): File {
     if (parentFile?.exists() == false) parentFile?.tryMkDirs()
 
     if (createNewFile()) {
-        log(VERBOSE) { "File created: $this" }
+        log(TAG, VERBOSE) { "File created: $this" }
         return this
     } else {
         throw IllegalStateException("Couldn't create file: $this")
@@ -63,7 +64,7 @@ fun File.deleteRecursivelySafe(): Boolean {
     // as non-root, permission errors also block listFiles()/delete(), so recursion goes nowhere.
     val linkTarget = readLink()
     if (linkTarget != null) {
-        log(WARN) { "deleteRecursivelySafe(): Symlink detected, deleting link only: $this -> $linkTarget" }
+        log(TAG, WARN) { "deleteRecursivelySafe(): Symlink detected, deleting link only: $this -> $linkTarget" }
         return delete()
     }
     var success = true
@@ -158,3 +159,6 @@ val File.parents: Sequence<File>
 
 val File.parentsInclusive: Sequence<File>
     get() = sequenceOf(this) + parents
+
+
+private val TAG = logTag("File", "Extensions")

--- a/app-common/src/main/java/eu/darken/sdmse/common/funnel/IPCFunnel.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/funnel/IPCFunnel.kt
@@ -31,7 +31,7 @@ class IPCFunnel @Inject constructor(
             hasApiLevel(31) -> 3
             hasApiLevel(29) -> 2
             else -> 1
-        }.also { log { "IPCFunnel init with parallelization set to $it" } }
+        }.also { log(TAG) { "IPCFunnel init with parallelization set to $it" } }
     )
 
     private val funnelEnv by lazy {

--- a/app-common/src/main/java/eu/darken/sdmse/common/ipc/BinderExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ipc/BinderExtensions.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.common.ipc
 import android.os.IBinder
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import kotlin.reflect.KClass
 
 /**
@@ -20,19 +21,19 @@ fun <T : Any> IBinder.getInterface(clazz: KClass<T>): T? {
         .apply { isAccessible = true }
 
     val intf = queryLocalInterface(fDescriptor[this] as String)
-    log(VERBOSE) { "Queried interface is $intf" }
+    log(TAG, VERBOSE) { "Queried interface is $intf" }
 
     if (clazz.isInstance(intf)) {
-        log(VERBOSE) { "Using local instance" }
+        log(TAG, VERBOSE) { "Using local instance" }
         return intf as T?
     }
 
-    log(VERBOSE) { "Creating remote instance" }
+    log(TAG, VERBOSE) { "Creating remote instance" }
     val className = clazz.qualifiedName + "\$Stub\$Proxy"
 
     // PROGUARD RULE REQUIRED: the `Proxy` class and its IBinder constructor are otherwise removed/renamed
     // see app-common-io/consumer-rules.pro
-    log(VERBOSE) { "Creating class $className" }
+    log(TAG, VERBOSE) { "Creating class $className" }
     val ctorProxy = Class
         .forName(className)
         .getDeclaredConstructor(IBinder::class.java)
@@ -40,3 +41,6 @@ fun <T : Any> IBinder.getInterface(clazz: KClass<T>): T? {
 
     return ctorProxy.newInstance(this) as T
 }
+
+
+private val TAG = logTag("IPC", "Binder", "Extensions")

--- a/app-common/src/main/java/eu/darken/sdmse/common/ipc/BinderExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ipc/BinderExtensions.kt
@@ -12,8 +12,8 @@ import kotlin.reflect.KClass
  */
 @Suppress("UNCHECKED_CAST")
 fun <T : Any> IBinder.getInterface(clazz: KClass<T>): T? {
-    // PROGUARD RULE REQUIRED: DESCRIPTOR field is otherwise removed
-    // e.g. eu.darken.sdmse.common.root.service.RootServiceConnection.DESCRIPTOR
+    // PROGUARD RULE REQUIRED: the `Stub` class and its DESCRIPTOR field are otherwise removed/renamed
+    // see app-common-io/consumer-rules.pro
     val fDescriptor = Class
         .forName(clazz.qualifiedName + "\$Stub")
         .getField("DESCRIPTOR")
@@ -30,8 +30,8 @@ fun <T : Any> IBinder.getInterface(clazz: KClass<T>): T? {
     log(VERBOSE) { "Creating remote instance" }
     val className = clazz.qualifiedName + "\$Stub\$Proxy"
 
-    // PROGUARD RULE REQUIRED: `Proxy` constructor is otherwise removed
-    // e.g. eu.darken.sdmse.common.shizuku.ShizukuServiceConnection$Stub$Proxy.<init> [interface android.os.IBinder]
+    // PROGUARD RULE REQUIRED: the `Proxy` class and its IBinder constructor are otherwise removed/renamed
+    // see app-common-io/consumer-rules.pro
     log(VERBOSE) { "Creating class $className" }
     val ctorProxy = Class
         .forName(className)

--- a/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcHostModule.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/ipc/IpcHostModule.kt
@@ -3,6 +3,7 @@ package eu.darken.sdmse.common.ipc
 import eu.darken.sdmse.common.debug.Bugs
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import java.io.ByteArrayOutputStream
 import java.io.ObjectOutputStream
 import kotlin.io.encoding.Base64
@@ -31,7 +32,7 @@ interface IpcHostModule {
         }
 
         if (Bugs.isDebug) {
-            log(VERBOSE) { "Encoding stacktrace..." }
+            log(TAG, VERBOSE) { "Encoding stacktrace..." }
             // TODO Find better way to pass trace, see IpcClientModule
             val encodedTrace = stackTrace.encodeBase64()
             if (encodedTrace != null) {
@@ -49,3 +50,6 @@ interface IpcHostModule {
         const val STACK_MARKER = "#STACK#:"
     }
 }
+
+
+private val TAG = logTag("IPC", "HostModule")

--- a/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
@@ -7,6 +7,7 @@ import eu.darken.sdmse.common.ca.caString
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
@@ -81,7 +82,7 @@ fun <T : Progress.Client> T.increaseProgress(value: Int = 1) {
             is Progress.Count.Counter -> it.copy(count = (it.count as Progress.Count.Counter).increment(value))
             is Progress.Count.Percent -> it.copy(count = (it.count as Progress.Count.Percent).increment(value))
             else -> {
-                log(VERBOSE) { "Can't increaseProgress() on type: ${it?.count}" }
+                log(TAG, VERBOSE) { "Can't increaseProgress() on type: ${it?.count}" }
                 it
             }
         }
@@ -119,3 +120,6 @@ suspend fun <T : Progress.Host, R> T.withProgress(
         client.updateProgress { onCompletion(it) }
     }
 }
+
+
+private val TAG = logTag("Progress", "Extensions")

--- a/app-tool-appcleaner/consumer-rules.pro
+++ b/app-tool-appcleaner/consumer-rules.pro
@@ -1,1 +1,3 @@
-
+# AppScanner logs matches by the filter's KClass.simpleName; keep the names readable in
+# obfuscated gplay logs. Names only, members and shrinking unaffected.
+-keepnames class * implements eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter

--- a/app-tool-appcleaner/consumer-rules.pro
+++ b/app-tool-appcleaner/consumer-rules.pro
@@ -1,3 +1,4 @@
-# AppScanner logs matches by the filter's KClass.simpleName; keep the names readable in
-# obfuscated gplay logs. Names only, members and shrinking unaffected.
+# Stock filters and their factories are logged by class name (KClass.simpleName / default Object.toString());
+# keep the names readable in obfuscated gplay logs. Names only, members and shrinking unaffected.
 -keepnames class * implements eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter
+-keepnames class * implements eu.darken.sdmse.appcleaner.core.forensics.ExpendablesFilter$Factory

--- a/app-tool-corpsefinder/consumer-rules.pro
+++ b/app-tool-corpsefinder/consumer-rules.pro
@@ -1,3 +1,4 @@
-# CorpseFilter.toString() uses ::class.simpleName; keep the names readable in obfuscated
-# gplay logs. Names only, members and shrinking unaffected.
+# Stock filters and their factories are logged by class name (toString() / default Object.toString());
+# keep the names readable in obfuscated gplay logs. Names only, members and shrinking unaffected.
 -keepnames class * implements eu.darken.sdmse.corpsefinder.core.filter.CorpseFilter
+-keepnames class * implements eu.darken.sdmse.corpsefinder.core.filter.CorpseFilter$Factory

--- a/app-tool-corpsefinder/consumer-rules.pro
+++ b/app-tool-corpsefinder/consumer-rules.pro
@@ -1,0 +1,3 @@
+# CorpseFilter.toString() uses ::class.simpleName; keep the names readable in obfuscated
+# gplay logs. Names only, members and shrinking unaffected.
+-keepnames class * implements eu.darken.sdmse.corpsefinder.core.filter.CorpseFilter

--- a/app-tool-systemcleaner/consumer-rules.pro
+++ b/app-tool-systemcleaner/consumer-rules.pro
@@ -1,3 +1,4 @@
-# Stock filters log themselves by class name (toString() uses ::class.simpleName); keep the
-# names readable in obfuscated gplay logs. Names only, members and shrinking unaffected.
+# Stock filters and their factories are logged by class name (toString() / default Object.toString());
+# keep the names readable in obfuscated gplay logs. Names only, members and shrinking unaffected.
 -keepnames class * implements eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter
+-keepnames class * implements eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter$Factory

--- a/app-tool-systemcleaner/consumer-rules.pro
+++ b/app-tool-systemcleaner/consumer-rules.pro
@@ -1,0 +1,3 @@
+# Stock filters log themselves by class name (toString() uses ::class.simpleName); keep the
+# names readable in obfuscated gplay logs. Names only, members and shrinking unaffected.
+-keepnames class * implements eu.darken.sdmse.systemcleaner.core.filter.SystemCleanerFilter

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,7 @@ android {
         create("foss") {
             dimension = "version"
             signingConfig = signingConfigs["releaseFoss"]
+            proguardFiles("proguard-foss.pro")
             // The info block is encrypted and can only be read by Google
             dependenciesInfo {
                 includeInApk = false
@@ -72,6 +73,7 @@ android {
         create("gplay") {
             dimension = "version"
             signingConfig = signingConfigs["releaseGplay"]
+            proguardFiles("proguard-gplay.pro")
         }
     }
 

--- a/app/proguard-foss.pro
+++ b/app/proguard-foss.pro
@@ -1,0 +1,4 @@
+# FOSS builds stay unobfuscated. The source is public, and readable stack traces in
+# user-submitted logs matter more than Play's optimization score, which only
+# applies to the gplay flavor.
+-dontobfuscate

--- a/app/proguard-gplay.pro
+++ b/app/proguard-gplay.pro
@@ -1,0 +1,5 @@
+# Play scores obfuscation as part of app optimization (threshold 25%), so this flavor is
+# obfuscated. Keep file/line attributes so R8 retrace with the mapping file recovers the
+# original frames from Play vitals and user-submitted logs.
+-keepattributes SourceFile,LineNumberTable
+-renamesourcefileattribute SourceFile

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,4 +1,3 @@
--dontobfuscate
 
 # Play Core KTX references this compile-time-only GMS annotation not on the runtime classpath
 -dontwarn com.google.android.gms.common.annotation.NoNullnessRewrite

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,4 +1,3 @@
-
 # Play Core KTX references this compile-time-only GMS annotation not on the runtime classpath
 -dontwarn com.google.android.gms.common.annotation.NoNullnessRewrite
 

--- a/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -27,7 +27,7 @@ class UpgradeViewModel @Inject constructor(
     private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
     private val upgradeRepo: UpgradeRepoFoss,
-) : ViewModel4(dispatcherProvider = dispatcherProvider) {
+) : ViewModel4(dispatcherProvider = dispatcherProvider, tag = TAG) {
 
     // Route is bound from the Host via bindRoute(); SavedStateHandle.toRoute<>() crashes under Nav3.
     private val routeFlow = MutableStateFlow<UpgradeRoute?>(null)

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/GplayServiceUnavailableException.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/core/billing/GplayServiceUnavailableException.kt
@@ -8,6 +8,7 @@ import eu.darken.sdmse.R
 import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.error.HasLocalizedError
 import eu.darken.sdmse.common.error.LocalizedError
 
@@ -48,10 +49,13 @@ class GplayServiceUnavailableException(cause: Throwable) :
     )
 
     private fun onLaunchFailed(e: Exception) {
-        log(ERROR) { "Can't launch settings intent for Google Play: $e" }
+        log(TAG, ERROR) { "Can't launch settings intent for Google Play: $e" }
     }
 
     companion object {
         private const val GPLAY_PKG = "com.android.vending"
     }
 }
+
+
+private val TAG = logTag("Upgrade", "Gplay", "ServiceUnavailable")

--- a/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/sdmse/common/upgrade/ui/UpgradeViewModel.kt
@@ -48,7 +48,7 @@ class UpgradeViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val upgradeRepo: UpgradeRepoGplay,
     private val webpageTool: WebpageTool,
-) : ViewModel4(dispatcherProvider = dispatcherProvider) {
+) : ViewModel4(dispatcherProvider = dispatcherProvider, tag = TAG) {
 
     // Route is bound from the Host via bindRoute(); SavedStateHandle.toRoute<>() crashes under Nav3.
     private val routeFlow = MutableStateFlow<UpgradeRoute?>(null)

--- a/app/src/main/java/eu/darken/sdmse/common/locale/LocaleManager.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/locale/LocaleManager.kt
@@ -52,7 +52,7 @@ class LocaleManager @Inject constructor(
                 when (intent.action) {
                     Intent.ACTION_LOCALE_CHANGED -> updateLocales()
 
-                    else -> log(ERROR) { "Unknown intent: $intent" }
+                    else -> log(TAG, ERROR) { "Unknown intent: $intent" }
                 }
             }
 
@@ -68,7 +68,7 @@ class LocaleManager @Inject constructor(
         updateLocales()
 
         awaitClose {
-            log { "unregisterReceiver($receiver)" }
+            log(TAG) { "unregisterReceiver($receiver)" }
             context.unregisterReceiver(receiver)
         }
     }

--- a/app/src/main/java/eu/darken/sdmse/common/updater/UpdaterExtensions.kt
+++ b/app/src/main/java/eu/darken/sdmse/common/updater/UpdaterExtensions.kt
@@ -13,7 +13,7 @@ fun UpdateChecker.Update.isNewer(): Boolean = try {
     val latest = Version.parse(versionName, strict = false)
     latest > current
 } catch (e: Exception) {
-    log(ERROR) { "Failed version check: ${e.asLog()}" }
+    log(TAG, ERROR) { "Failed version check: ${e.asLog()}" }
     false
 }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/MainViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/MainViewModel.kt
@@ -48,7 +48,7 @@ class MainViewModel @Inject constructor(
     private val generalSettings: GeneralSettings,
     private val oneTapCleaner: OneTapCleaner,
     private val appScope: AppCoroutineScope,
-) : ViewModel4(dispatcherProvider = dispatcherProvider) {
+) : ViewModel4(dispatcherProvider = dispatcherProvider, tag = TAG) {
 
     val startRoute: NavigationDestination = if (generalSettings.isOnboardingCompleted.valueBlocking) {
         DashboardRoute

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/DashboardMainActionEngine.kt
@@ -718,7 +718,7 @@ class DashboardMainActionEngine(
         }
         launchMainBranch(isTracked = startsRun, isCleanup = isCleanup) {
             if (!generalSettings.oneClickCorpseFinderEnabled.value()) {
-                log(VERBOSE) { "CorpseFinder is disabled one-click mode." }
+                log(TAG, VERBOSE) { "CorpseFinder is disabled one-click mode." }
                 return@launchMainBranch
             }
 
@@ -735,7 +735,7 @@ class DashboardMainActionEngine(
         }
         launchMainBranch(isTracked = startsRun, isCleanup = isCleanup) {
             if (!generalSettings.oneClickSystemCleanerEnabled.value()) {
-                log(VERBOSE) { "SystemCleaner is disabled one-click mode." }
+                log(TAG, VERBOSE) { "SystemCleaner is disabled one-click mode." }
                 return@launchMainBranch
             }
 
@@ -752,7 +752,7 @@ class DashboardMainActionEngine(
         }
         launchMainBranch(isTracked = startsRun, isCleanup = isCleanup) {
             if (!generalSettings.oneClickAppCleanerEnabled.value()) {
-                log(VERBOSE) { "AppCleaner is disabled one-click mode." }
+                log(TAG, VERBOSE) { "AppCleaner is disabled one-click mode." }
                 return@launchMainBranch
             }
 
@@ -779,7 +779,7 @@ class DashboardMainActionEngine(
         }
         launchMainBranch(isTracked = startsRun, isCleanup = isCleanup) {
             if (!generalSettings.oneClickDeduplicatorEnabled.value()) {
-                log(VERBOSE) { "Deduplicator is disabled one-click mode." }
+                log(TAG, VERBOSE) { "Deduplicator is disabled one-click mode." }
                 return@launchMainBranch
             }
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/onboarding/privacy/OnboardingPrivacyViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/onboarding/privacy/OnboardingPrivacyViewModel.kt
@@ -26,7 +26,7 @@ class OnboardingPrivacyViewModel @Inject constructor(
     private val motdSettings: MotdSettings,
     private val webpageTool: WebpageTool,
     private val updateChecker: UpdateChecker,
-) : ViewModel4(dispatcherProvider = dispatcherProvider) {
+) : ViewModel4(dispatcherProvider = dispatcherProvider, tag = TAG) {
 
     val state: StateFlow<State> = combine(
         motdSettings.isMotdEnabled.flow,

--- a/app/src/main/java/eu/darken/sdmse/main/ui/onboarding/setup/OnboardingSetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/onboarding/setup/OnboardingSetupViewModel.kt
@@ -24,7 +24,7 @@ class OnboardingSetupViewModel @Inject constructor(
     dispatcherProvider: DispatcherProvider,
     private val generalSettings: GeneralSettings,
     private val navController: NavigationController,
-) : ViewModel4(dispatcherProvider = dispatcherProvider) {
+) : ViewModel4(dispatcherProvider = dispatcherProvider, tag = TAG) {
 
     // Authoritative, synchronous source of truth for the onboarding choice. Seeded from the persisted
     // value (default true on first run) and persisted blocking in finishOnboarding() BEFORE navigation —

--- a/app/src/main/java/eu/darken/sdmse/main/ui/onboarding/versus/VersusSetupViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/onboarding/versus/VersusSetupViewModel.kt
@@ -12,7 +12,7 @@ import javax.inject.Inject
 class VersusSetupViewModel @Inject constructor(
     @Suppress("unused") private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
-) : ViewModel4(dispatcherProvider = dispatcherProvider) {
+) : ViewModel4(dispatcherProvider = dispatcherProvider, tag = TAG) {
 
     fun onContinue() {
         navTo(OnboardingPrivacyRoute)

--- a/app/src/main/java/eu/darken/sdmse/main/ui/onboarding/welcome/OnboardingWelcomeViewModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/onboarding/welcome/OnboardingWelcomeViewModel.kt
@@ -13,7 +13,7 @@ import javax.inject.Inject
 class OnboardingWelcomeViewModel @Inject constructor(
     @Suppress("unused") private val handle: SavedStateHandle,
     dispatcherProvider: DispatcherProvider,
-) : ViewModel4(dispatcherProvider = dispatcherProvider) {
+) : ViewModel4(dispatcherProvider = dispatcherProvider, tag = TAG) {
 
     fun onContinue(isLegacySdmInstalled: Boolean) {
         if (isLegacySdmInstalled) {


### PR DESCRIPTION
## What changed

Google Play builds of SD Maid SE are now obfuscated by R8. Google Play scores apps on code obfuscation as part of its app optimisation requirement and flagged our bundle at 0%, with visibility and publishing restrictions from February 2027. The FOSS builds are unchanged and stay unobfuscated.

Nothing changes for users in day to day use. Root, Shizuku, scans and exclusions work as before. Debug logs from Google Play builds keep readable log tags and filter names so support requests stay diagnosable; stack traces inside them need the mapping file, which the uploaded bundle carries.

## Technical Context

- The only lever was the shared `-dontobfuscate` rule. It moved into a FOSS-only ProGuard file wired via the flavor's `proguardFiles`; the gplay flavor gets its own file keeping source-file and line attributes for retrace. Minification and R8 full mode were already on for both flavors.
- `BinderExtensions.getInterface()` resolves the root and ADB service AIDL interfaces by string (`Class.forName(name + "$Stub")`), so their interface, `Stub` and `Stub$Proxy` classes are kept by name in the module that owns the `.aidl` files. The previous members-only rules could not pin class names.
- The three exclusion classes build persisted ids from `simpleName`, so they are `@Keep` and tests pin the exact id strings. Filter classes and their factories for SystemCleaner, AppCleaner and CorpseFinder keep their names only (no shrinking impact) because they are logged by class name.
- The receiver-typed `log { }` overload derived its tag from the caller's class; all 104 production call sites now pass an explicit tag, and the ViewModel base classes stop deriving a default tag from their companion object.
- The mapping is not archived by CI; AGP embeds it in the bundle and Play Console offers it for download per release. Verified on an API 34 emulator (Shizuku) and a rooted Pixel 7a: host launches, AIDL proxy resolution, typed exception reconstruction over IPC, scans and process-death restore all behave the same as unobfuscated builds.
