### PR TITLE
General: Detect Shizuku+ instead of reporting Shizuku as not installed

### DIFF
--- a/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapper.kt
+++ b/app-common-adb/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapper.kt
@@ -35,29 +35,35 @@ class ShizukuWrapper @Inject constructor(
 ) {
 
     /**
-     * Package that declares the Shizuku permission, or null if no installed app declares it.
+     * Packages that declare a Shizuku manager permission, in [MANAGER_PERMISSIONS] order.
      *
-     * Detects Shizuku via its permission ([ShizukuProvider.PERMISSION]) instead of a fixed package
-     * name. The permission name is shared across Shizuku forks, so this keeps working when a fork
-     * hides its package from enumeration ("Hide Shizuku from other apps") or ships under a different
-     * package name. Permissions live in a global namespace, so the lookup isn't subject to the
-     * package-visibility filtering that hides the app itself.
+     * Detects Shizuku via its permissions instead of a fixed package name. The permission names are
+     * shared across Shizuku forks, so this keeps working when a fork hides its package from
+     * enumeration ("Hide Shizuku from other apps") or ships under a different package name.
+     * Permissions live in a global namespace, so the lookup isn't subject to the package-visibility
+     * filtering that hides the app itself. Every name is tried because Shizuku+'s Plus flavor
+     * declares only its own permission and just requests the stock one.
      */
-    suspend fun getManagerPackage(): String? = withContext(dispatcherProvider.IO) {
-        try {
-            context.packageManager
-                .getPermissionInfo(ShizukuProvider.PERMISSION, 0)
-                .packageName
-                ?.takeUnless { it.isBlank() }
-        } catch (e: PackageManager.NameNotFoundException) {
-            log(TAG) { "getManagerPackage(): Shizuku permission not declared by any app" }
-            null
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            log(TAG, WARN) { "getManagerPackage(): Lookup failed: ${e.asLog()}" }
-            null
-        }
+    suspend fun getManagerPackages(): List<String> = withContext(dispatcherProvider.IO) {
+        MANAGER_PERMISSIONS.mapNotNull { resolvePermissionOwner(it) }.distinct()
+    }
+
+    /** The manager package to treat as *the* Shizuku app, see [getManagerPackages]. */
+    suspend fun getManagerPackage(): String? = getManagerPackages().firstOrNull()
+
+    private fun resolvePermissionOwner(permission: String): String? = try {
+        context.packageManager
+            .getPermissionInfo(permission, 0)
+            .packageName
+            ?.takeUnless { it.isBlank() }
+    } catch (e: PackageManager.NameNotFoundException) {
+        log(TAG) { "resolvePermissionOwner($permission): not declared by any app" }
+        null
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "resolvePermissionOwner($permission): Lookup failed: ${e.asLog()}" }
+        null
     }
 
     private val handlerThread: HandlerThread by lazy {
@@ -188,6 +194,12 @@ class ShizukuWrapper @Inject constructor(
 
     companion object {
         private val TAG = logTag("ADB", "Shizuku", "Wrapper")
+
+        internal const val SHIZUKU_PLUS_PERMISSION = "af.shizuku.plus.permission.API_V23"
+
+        // Priority order: the stock permission first, so an install that defines both (Shizuku+ Drop-In,
+        // or Shizuku+ Plus next to its Compat Hub) keeps resolving to the same package it does today.
+        internal val MANAGER_PERMISSIONS: List<String> = listOf(ShizukuProvider.PERMISSION, SHIZUKU_PLUS_PERMISSION)
 
         /**
          * Combined budget for the two binder round-trips behind [isGranted].

--- a/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapperTest.kt
+++ b/app-common-adb/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuWrapperTest.kt
@@ -25,13 +25,17 @@ import kotlin.time.Duration.Companion.seconds
 
 /**
  * Covers [ShizukuWrapper.getManagerPackage] — permission-based Shizuku detection that survives
- * "Hide Shizuku from other apps" mode and forks that rename their package (issue #2405) — and
- * [ShizukuWrapper.isGranted]'s binder-liveness gate.
+ * "Hide Shizuku from other apps" mode, forks that rename their package (issue #2405) and forks that
+ * declare their own permission name instead of the stock one — and [ShizukuWrapper.isGranted]'s
+ * binder-liveness gate.
  */
 class ShizukuWrapperTest {
 
     private val context = mockk<Context>()
     private val packageManager = mockk<PackageManager>()
+
+    private val stockPermission = "moe.shizuku.manager.permission.API_V23"
+    private val plusPermission = "af.shizuku.plus.permission.API_V23"
 
     private val dispatcherProvider = object : DispatcherProvider {
         override val IO: CoroutineDispatcher = Dispatchers.Unconfined
@@ -48,6 +52,14 @@ class ShizukuWrapperTest {
     // mockk gives us a real (Objenesis-instantiated) PermissionInfo whose inherited public
     // packageName field we can set directly, without invoking the Android constructor.
     private fun permissionInfo(pkg: String?) = mockk<PermissionInfo>().apply { packageName = pkg }
+
+    private fun definePermission(name: String, owner: String?) {
+        every { packageManager.getPermissionInfo(name, any<Int>()) } returns permissionInfo(owner)
+    }
+
+    private fun undefinePermission(name: String) {
+        every { packageManager.getPermissionInfo(name, any<Int>()) } throws PackageManager.NameNotFoundException()
+    }
 
     @Test
     fun `resolves the declaring package when the Shizuku permission exists`() = runTest {
@@ -85,6 +97,50 @@ class ShizukuWrapperTest {
         every { packageManager.getPermissionInfo(any(), any<Int>()) } returns permissionInfo("")
 
         wrapper().getManagerPackage() shouldBe null
+    }
+
+    @Test
+    fun `falls back to the Shizuku+ permission when the stock permission is undefined`() = runTest {
+        undefinePermission(stockPermission)
+        definePermission(plusPermission, "af.shizuku.plus.api")
+
+        wrapper().getManagerPackage() shouldBe "af.shizuku.plus.api"
+    }
+
+    @Test
+    fun `prefers the stock permission owner when both are defined`() = runTest {
+        definePermission(stockPermission, "moe.shizuku.privileged.api")
+        definePermission(plusPermission, "af.shizuku.plus.api")
+        val wrapper = wrapper()
+
+        wrapper.getManagerPackage() shouldBe "moe.shizuku.privileged.api"
+        wrapper.getManagerPackages() shouldBe listOf("moe.shizuku.privileged.api", "af.shizuku.plus.api")
+    }
+
+    @Test
+    fun `collapses one app defining both permissions to a single entry`() = runTest {
+        definePermission(stockPermission, "moe.shizuku.privileged.api")
+        definePermission(plusPermission, "moe.shizuku.privileged.api")
+
+        wrapper().getManagerPackages() shouldBe listOf("moe.shizuku.privileged.api")
+    }
+
+    @Test
+    fun `getManagerPackages is empty when no permission is defined`() = runTest {
+        undefinePermission(stockPermission)
+        undefinePermission(plusPermission)
+        val wrapper = wrapper()
+
+        wrapper.getManagerPackages() shouldBe emptyList()
+        wrapper.getManagerPackage() shouldBe null
+    }
+
+    @Test
+    fun `a failing lookup for one permission does not hide the other`() = runTest {
+        every { packageManager.getPermissionInfo(stockPermission, any<Int>()) } throws RuntimeException("OEM quirk")
+        definePermission(plusPermission, "af.shizuku.plus.api")
+
+        wrapper().getManagerPackage() shouldBe "af.shizuku.plus.api"
     }
 
     @Test

--- a/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManager.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManager.kt
@@ -42,9 +42,10 @@ class ShizukuManager @Inject constructor(
     val serviceClient: AdbServiceClient,
 ) {
 
-    // The reference package plus, if a fork under a different package name is installed, its package too.
+    // The reference package plus every installed app that defines a Shizuku manager permission
+    // (a renamed fork, Shizuku+ next to its Compat Hub).
     // Consumers (e.g. AppCleaner) use this to recognize the Shizuku manager app.
-    suspend fun managerIds(): Set<Pkg.Id> = setOf(PKG_ID) + listOfNotNull(getManagerId())
+    suspend fun managerIds(): Set<Pkg.Id> = setOf(PKG_ID) + shizukuWrapper.getManagerPackages().map { it.toPkgId() }
 
     val permissionGrantEvents: Flow<ShizukuWrapper.ShizukuPermissionRequest> = shizukuWrapper.permissionGrantEvents
         .setupCommonEventHandlers(TAG) { "grantEvents" }

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManagerTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/adb/shizuku/ShizukuManagerTest.kt
@@ -72,12 +72,13 @@ class ShizukuManagerTest : BaseTest() {
         serviceClient = serviceClient,
     )
 
-    private fun setShizukuPackage(pkg: String?) {
-        coEvery { shizukuWrapper.getManagerPackage() } returns pkg
+    private fun setShizukuPackages(vararg pkgs: String) {
+        coEvery { shizukuWrapper.getManagerPackages() } returns pkgs.toList()
+        coEvery { shizukuWrapper.getManagerPackage() } returns pkgs.firstOrNull()
     }
 
     @Test fun `binder is not probed when Shizuku is not installed`() {
-        setShizukuPackage(null)
+        setShizukuPackages()
         val mgr = manager()
 
         val collector = mgr.shizukuBinder.test(tag = "binder", scope = scope)
@@ -90,7 +91,7 @@ class ShizukuManagerTest : BaseTest() {
     }
 
     @Test fun `binder is probed when Shizuku is installed`() {
-        setShizukuPackage(ShizukuManager.PKG_ID.name)
+        setShizukuPackages(ShizukuManager.PKG_ID.name)
         val mgr = manager()
 
         val collector = mgr.shizukuBinder.test(tag = "binder", scope = scope)
@@ -102,7 +103,7 @@ class ShizukuManagerTest : BaseTest() {
     }
 
     @Test fun `binder stays closed when user opted out even if installed`() {
-        setShizukuPackage(ShizukuManager.PKG_ID.name)
+        setShizukuPackages(ShizukuManager.PKG_ID.name)
         useShizukuFlow.value = false
         val mgr = manager()
 
@@ -118,27 +119,27 @@ class ShizukuManagerTest : BaseTest() {
     @Test fun `isInstalled is not cached and re-evaluates each call`() {
         val mgr = manager()
 
-        setShizukuPackage(null)
+        setShizukuPackages()
         runBlocking { mgr.isInstalled() } shouldBe false
 
         // Shizuku gets installed afterwards: the next call must reflect it (no stale cache).
-        setShizukuPackage(ShizukuManager.PKG_ID.name)
+        setShizukuPackages(ShizukuManager.PKG_ID.name)
         runBlocking { mgr.isInstalled() } shouldBe true
     }
 
     @Test fun `getManagerId resolves the detected package`() {
         val mgr = manager()
 
-        setShizukuPackage(null)
+        setShizukuPackages()
         runBlocking { mgr.getManagerId() } shouldBe null
 
-        setShizukuPackage(ShizukuManager.PKG_ID.name)
+        setShizukuPackages(ShizukuManager.PKG_ID.name)
         runBlocking { mgr.getManagerId() } shouldBe ShizukuManager.PKG_ID
     }
 
     @Test fun `getManagerId resolves a fork under a different package name`() {
         val forkPkg = "com.example.shizuku.fork"
-        setShizukuPackage(forkPkg)
+        setShizukuPackages(forkPkg)
         val mgr = manager()
 
         runBlocking { mgr.getManagerId() } shouldBe forkPkg.toPkgId()
@@ -167,13 +168,22 @@ class ShizukuManagerTest : BaseTest() {
         val mgr = manager()
 
         // Nothing installed: just the reference package.
-        setShizukuPackage(null)
+        setShizukuPackages()
         runBlocking { mgr.managerIds() } shouldBe setOf(ShizukuManager.PKG_ID)
 
         // Fork installed under a different package: both the reference and the fork are protected.
         val forkPkg = "com.example.shizuku.fork"
-        setShizukuPackage(forkPkg)
+        setShizukuPackages(forkPkg)
         runBlocking { mgr.managerIds() } shouldBe setOf(ShizukuManager.PKG_ID, forkPkg.toPkgId())
+    }
+
+    @Test fun `managerIds includes every detected manager package`() {
+        // Shizuku+ next to its Compat Hub: the binder comes from Shizuku+, so its package has to be
+        // covered too, not just the first one the permission lookup resolves.
+        setShizukuPackages("moe.shizuku.privileged.api", "af.shizuku.plus.api")
+        val mgr = manager()
+
+        runBlocking { mgr.managerIds() } shouldBe setOf(ShizukuManager.PKG_ID, "af.shizuku.plus.api".toPkgId())
     }
 
     // --- getServiceState -----------------------------------------------------------------------

--- a/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModule.kt
@@ -1,8 +1,10 @@
 package eu.darken.sdmse.setup.shizuku
 
+import android.content.Context
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.sdmse.common.adb.AdbSettings
@@ -20,6 +22,7 @@ import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.replayingShare
 import eu.darken.sdmse.common.pkgs.Pkg
+import eu.darken.sdmse.common.pkgs.getLaunchIntent
 import eu.darken.sdmse.common.rngString
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.setup.SetupModule
@@ -39,6 +42,7 @@ import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.transformLatest
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Instant
 import javax.inject.Inject
@@ -46,6 +50,7 @@ import javax.inject.Singleton
 
 @Singleton
 class ShizukuSetupModule @Inject constructor(
+    @ApplicationContext private val context: Context,
     @AppScope private val appScope: CoroutineScope,
     private val dispatcherProvider: DispatcherProvider,
     private val adbSettings: AdbSettings,
@@ -81,8 +86,15 @@ class ShizukuSetupModule @Inject constructor(
         rootManager.useRoot,
     ) { _, useShizuku, useRoot ->
         val managerId = shizukuManager.getManagerId()
+        // The card's open action launches this package. The detected manager can be Shizuku+'s Compat Hub,
+        // which has no launcher activity, so prefer the first manager app that can actually be opened.
+        val openable = managerId?.let {
+            withContext(dispatcherProvider.IO) {
+                shizukuManager.managerIds().firstOrNull { pkg -> pkg.getLaunchIntent(context) != null }
+            }
+        }
         val baseState = Result(
-            pkg = managerId ?: shizukuManager.shizukuPkgId,
+            pkg = openable ?: managerId ?: shizukuManager.shizukuPkgId,
             useShizuku = useShizuku,
             isInstalled = managerId != null,
             isCompatible = shizukuManager.isCompatible(),

--- a/app/src/test/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModuleTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/shizuku/ShizukuSetupModuleTest.kt
@@ -1,5 +1,8 @@
 package eu.darken.sdmse.setup.shizuku
 
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
 import eu.darken.sdmse.common.adb.AdbSettings
 import eu.darken.sdmse.common.adb.shizuku.ShizukuManager
 import eu.darken.sdmse.common.adb.shizuku.ShizukuServiceState
@@ -16,6 +19,7 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -35,6 +39,8 @@ import java.util.concurrent.CountDownLatch
 
 class ShizukuSetupModuleTest : BaseTest() {
 
+    private val context: Context = mockk()
+    private val packageManager: PackageManager = mockk()
     private val adbSettings: AdbSettings = mockk()
     private val shizukuManager: ShizukuManager = mockk()
     private val dataAreaManager: DataAreaManager = mockk(relaxed = true)
@@ -51,6 +57,9 @@ class ShizukuSetupModuleTest : BaseTest() {
         useShizukuFlow = MutableStateFlow(true)
         scope = CoroutineScope(Dispatchers.Unconfined + SupervisorJob())
 
+        every { context.packageManager } returns packageManager
+        every { packageManager.getLaunchIntentForPackage(any()) } returns mockk<Intent>()
+
         every { adbSettings.useShizuku } returns useShizukuValue
         every { useShizukuValue.flow } returns useShizukuFlow
 
@@ -58,6 +67,7 @@ class ShizukuSetupModuleTest : BaseTest() {
         every { shizukuManager.shizukuBinder } returns flowOf(null)
         every { shizukuManager.permissionGrantEvents } returns emptyFlow()
         coEvery { shizukuManager.getManagerId() } returns "moe.shizuku.privileged.api".toPkgId()
+        coEvery { shizukuManager.managerIds() } returns setOf("moe.shizuku.privileged.api".toPkgId())
         coEvery { shizukuManager.isCompatible() } returns true
         coEvery { shizukuManager.isGranted() } returns true
         coEvery { shizukuManager.getServiceState() } coAnswers { probeCount++; ShizukuServiceState.Available }
@@ -73,7 +83,15 @@ class ShizukuSetupModuleTest : BaseTest() {
     private fun module(
         moduleScope: CoroutineScope = scope,
         dispatchers: DispatcherProvider = TestDispatcherProvider(),
-    ) = ShizukuSetupModule(moduleScope, dispatchers, adbSettings, shizukuManager, dataAreaManager, rootManager)
+    ) = ShizukuSetupModule(
+        context,
+        moduleScope,
+        dispatchers,
+        adbSettings,
+        shizukuManager,
+        dataAreaManager,
+        rootManager,
+    )
 
     @Test fun `first subscription emits Loading then Result`() {
         val mod = module()
@@ -270,6 +288,49 @@ class ShizukuSetupModuleTest : BaseTest() {
         settled.isChecking shouldBe false
 
         runBlocking { collector.cancelAndJoin() }
+    }
+
+    // --- card package --------------------------------------------------------------------------
+
+    private fun firstResult(mod: ShizukuSetupModule): ShizukuSetupModule.Result {
+        val collector = mod.state.test(tag = "pkg", scope = scope)
+        collector.await { values, _ -> values.any { it is ShizukuSetupModule.Result } }
+        val result = collector.latestValues.filterIsInstance<ShizukuSetupModule.Result>().first()
+        runBlocking { collector.cancelAndJoin() }
+        return result
+    }
+
+    @Test fun `card package prefers the first manager that can be opened`() {
+        // Shizuku+ next to its Compat Hub: the Hub owns the stock permission but has no launcher
+        // activity, so opening it from the card would do nothing.
+        coEvery { shizukuManager.getManagerId() } returns "moe.shizuku.privileged.api".toPkgId()
+        coEvery { shizukuManager.managerIds() } returns setOf(
+            "moe.shizuku.privileged.api".toPkgId(),
+            "af.shizuku.plus.api".toPkgId(),
+        )
+        every { packageManager.getLaunchIntentForPackage("moe.shizuku.privileged.api") } returns null
+        every { packageManager.getLaunchIntentForPackage("af.shizuku.plus.api") } returns mockk<Intent>()
+
+        firstResult(module()).pkg shouldBe "af.shizuku.plus.api".toPkgId()
+    }
+
+    @Test fun `card package falls back to the detected manager when none can be opened`() {
+        coEvery { shizukuManager.getManagerId() } returns "moe.shizuku.privileged.api".toPkgId()
+        coEvery { shizukuManager.managerIds() } returns setOf(
+            "moe.shizuku.privileged.api".toPkgId(),
+            "af.shizuku.plus.api".toPkgId(),
+        )
+        every { packageManager.getLaunchIntentForPackage(any()) } returns null
+
+        firstResult(module()).pkg shouldBe "moe.shizuku.privileged.api".toPkgId()
+    }
+
+    @Test fun `card package is the reference package when nothing is installed`() {
+        coEvery { shizukuManager.getManagerId() } returns null
+
+        firstResult(module()).pkg shouldBe "moe.shizuku.privileged.api".toPkgId()
+
+        verify(exactly = 0) { packageManager.getLaunchIntentForPackage(any()) }
     }
 
 }


### PR DESCRIPTION
## What changed

Users of the Shizuku+ fork (the "Plus" flavor, which installs as its own app next to stock Shizuku) no longer see "The Shizuku app is not installed." in the setup screen. SD Maid now recognises Shizuku+ as a Shizuku manager, the Shizuku card reaches "Shizuku link is ready.", and the tools use the link. When Shizuku+ is installed together with its Compat Hub, the Shizuku button on the setup card now opens Shizuku+ instead of doing nothing.

## Technical Context

- Root cause: Shizuku+'s Plus flavor declares its own permission `af.shizuku.plus.permission.API_V23` and only requests the stock `moe.shizuku.manager.permission.API_V23`, so the permission-owner lookup that detects the manager app found nothing. Everything after the binder arrives is package-agnostic, so extending that lookup is enough for detection.
- The lookup now tries a priority list, stock permission first, then Shizuku+'s. Installs that define both (Shizuku+ Drop-In, or Plus next to the Compat Hub) keep resolving to the same package as before. The manager id set used by AppCleaner's exclusion includes every owner, so the fork is protected when the Compat Hub owns the stock permission.
- The Compat Hub has no launcher activity, so the setup module picks the first manager package that has a launch intent for the card's open action; detection itself is unchanged.
- Verified on an Android 16 emulator with Shizuku+ 13.6.0.r2431: permission dialog, ready state, AppCleaner scanning over the link with the fork excluded, the open button with the Compat Hub installed, and the no-manager negative control.
- Review focus: the openable-package selection in the setup module, and the permission priority order.
