### PR TITLE
General: Keep more class names readable in Google Play debug logs

### DIFF
--- a/app-common-automation/consumer-rules.pro
+++ b/app-common-automation/consumer-rules.pro
@@ -1,1 +1,3 @@
-
+# Input events are logged by class name (InputInjector.inject); keep the names readable in
+# obfuscated gplay logs. Names only, members and shrinking unaffected.
+-keepnames class * extends eu.darken.sdmse.automation.core.input.InputInjector$Event

--- a/app-common-data/consumer-rules.pro
+++ b/app-common-data/consumer-rules.pro
@@ -1,0 +1,3 @@
+# Logged by class name in the dashboard's verbose flow diagnostics (DashboardViewModel); keep the
+# name readable in obfuscated gplay logs. Name only, members and shrinking unaffected.
+-keepnames class eu.darken.sdmse.main.core.DashboardCardConfig

--- a/app-common/consumer-rules.pro
+++ b/app-common/consumer-rules.pro
@@ -1,0 +1,10 @@
+# Task classes are logged by class name (OneTapCleaner, TaskManager's TaskEntry.toString()) and
+# route classes label the unknown-destination fallback screen; keep the names readable in
+# obfuscated gplay builds. Names only, members and shrinking unaffected.
+-keepnames class * implements eu.darken.sdmse.main.core.SDMTool$Task
+-keepnames class * implements eu.darken.sdmse.common.navigation.NavigationDestination
+
+# Loggers are logged by default Object.toString() when installed or removed (Logging.install),
+# upgrade info by class name in the dashboard's verbose flow diagnostics (DashboardViewModel).
+-keepnames class * implements eu.darken.sdmse.common.debug.logging.Logging$Logger
+-keepnames class * implements eu.darken.sdmse.common.upgrade.UpgradeRepo$Info

--- a/app-tool-deduplicator/consumer-rules.pro
+++ b/app-tool-deduplicator/consumer-rules.pro
@@ -1,0 +1,3 @@
+# Arbiter criteria are logged by class name (ArbiterConfigViewModel); keep the names readable in
+# obfuscated gplay logs. Names only, members and shrinking unaffected.
+-keepnames class * implements eu.darken.sdmse.deduplicator.core.arbiter.ArbiterCriterium

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -6,3 +6,11 @@
 
 # Accessed via reflection.
 -keep class eu.darken.sdmse.BuildConfig { *; }
+
+# Setup card items are logged by class name when no card branch handles them (SetupScreen);
+# keep the names readable in obfuscated gplay logs. Names only, members and shrinking unaffected.
+-keepnames class * implements eu.darken.sdmse.setup.SetupCardItem
+
+# Dashboard items are logged by class name in the verbose flow diagnostics (DashboardViewModel);
+# keep the names readable in obfuscated gplay logs. Names only, members and shrinking unaffected.
+-keepnames class * implements eu.darken.sdmse.main.ui.dashboard.cards.DashboardItem


### PR DESCRIPTION
## What changed

No user-facing behavior change. Google Play builds are obfuscated since #2767, and debug logs from those builds still showed short R8 tokens instead of readable names at a few more places: the task names in the one-tap cleaner and the task manager, deduplicator arbiter criteria, automation input events, setup cards, the dashboard's verbose flow diagnostics, installed loggers, and the label of the "unknown destination" fallback screen. Those names are kept now.

## Technical Context

- Same mechanism as the filter keep rules from #2767: `-keepnames` on the implementors of each interface, placed in the consumer rules of the module that declares it. `SetupCardItem` and `DashboardItem` live in the app module, so their rules sit in `app/proguard-rules.pro`.
- The sites write `::class.simpleName` / `javaClass.simpleName` into log text, plus two default `Object.toString()` cases (`Logging.install`/`remove`). Retrace only recovers stack frames, not tokens inside free text.
- Names only: members stay renamed and shrinking is unaffected. FOSS keeps `-dontobfuscate` and is not affected.
- Obfuscation share on gplayRelease drops from 4444 to 4308 renamed classes of 4964, far above Play's 25% threshold.

Refs #2767
