### PR TITLE
AppControl: Fix force stop getting stuck on OnePlus devices

### DIFF
--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/AppControlAutomation.kt
@@ -20,6 +20,7 @@ import eu.darken.sdmse.appcontrol.core.automation.specs.hyperos.HyperOsSpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.miui.MIUISpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.oneui.OneUISpecs
 import eu.darken.sdmse.appcontrol.core.automation.specs.originos.OriginOSSpecs
+import eu.darken.sdmse.appcontrol.core.automation.specs.oxygenos.OxygenOSSpecs
 import eu.darken.sdmse.automation.core.ForceStopAutomationTask
 import eu.darken.sdmse.appcontrol.core.restore.RestoreAutomationTask
 import eu.darken.sdmse.automation.core.AutomationHost
@@ -98,6 +99,7 @@ class AppControlAutomation @AssistedInject constructor(
                 is OriginOSSpecs -> 80
                 is AndroidTVSpecs -> 70
 //                is NubiaSpecs -> 60
+                is OxygenOSSpecs -> 30
 //                is OnePlusSpecs -> 30
 //                is HonorSpecs -> 20
                 is AOSPSpecs -> -5

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oxygenos/OxygenOSSpecs.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/automation/specs/oxygenos/OxygenOSSpecs.kt
@@ -1,0 +1,214 @@
+package eu.darken.sdmse.appcontrol.core.automation.specs.oxygenos
+
+import dagger.Binds
+import dagger.Module
+import dagger.Reusable
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.sdmse.appcontrol.core.automation.specs.AppControlSpecGenerator
+import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPLabels
+import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPSpecs
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.crawl
+import eu.darken.sdmse.automation.core.common.idMatches
+import eu.darken.sdmse.automation.core.common.isClickyButton
+import eu.darken.sdmse.automation.core.common.isEmpty
+import eu.darken.sdmse.automation.core.common.pkgId
+import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
+import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.common.stepper.clickNormal
+import eu.darken.sdmse.automation.core.common.stepper.findClickableParent
+import eu.darken.sdmse.automation.core.common.stepper.findColumnAlignedClickable
+import eu.darken.sdmse.automation.core.common.stepper.findNode
+import eu.darken.sdmse.automation.core.common.textMatchesAny
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.automation.core.specs.defaultNodeRecovery
+import eu.darken.sdmse.automation.core.specs.windowCheck
+import eu.darken.sdmse.automation.core.specs.windowCheckDefaultSettings
+import eu.darken.sdmse.automation.core.specs.windowLauncherDefaultSettings
+import eu.darken.sdmse.automation.core.waitForWindowRoot
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.datastore.value
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.withProgress
+import eu.darken.sdmse.main.core.GeneralSettings
+import javax.inject.Inject
+
+@Reusable
+class OxygenOSSpecs @Inject constructor(
+    private val ipcFunnel: IPCFunnel,
+    private val deviceDetective: DeviceDetective,
+    private val aospLabels: AOSPLabels,
+    private val aospSpecs: AOSPSpecs,
+    private val generalSettings: GeneralSettings,
+    private val stepper: Stepper,
+) : AppControlSpecGenerator {
+
+    override val tag: String = TAG
+
+    override suspend fun isResponsible(pkg: Installed): Boolean {
+        val romType = generalSettings.romTypeDetection.value()
+        if (romType == RomType.OXYGENOS) return true
+        if (romType != RomType.AUTO) return false
+
+        return deviceDetective.getROMType() == RomType.OXYGENOS
+    }
+
+    override suspend fun getForceStop(pkg: Installed): AutomationSpec = object : AutomationSpec.Explorer {
+        override val tag: String = TAG
+        override suspend fun createPlan(): suspend AutomationExplorer.Context.() -> Unit = {
+            forceStopPlan(pkg)
+        }
+    }
+
+    override suspend fun getArchive(pkg: Installed): AutomationSpec = aospSpecs.getArchive(pkg)
+
+    override suspend fun getRestore(pkg: Installed): AutomationSpec = aospSpecs.getRestore(pkg)
+
+    private val forceStopPlan: suspend AutomationExplorer.Context.(Installed) -> Unit = plan@{ pkg ->
+        log(TAG, INFO) { "Executing plan for ${pkg.installId} with context $this" }
+
+        val forceStopLabels = aospLabels.getForceStopButtonDynamic(this)
+        var wasDisabled = false
+
+        run {
+            val action: suspend StepContext.() -> Boolean = action@{
+                val candidate = findNode { node ->
+                    node.textMatchesAny(forceStopLabels)
+                } ?: return@action false
+
+                var target = findClickableParent(maxNesting = 3, includeSelf = true, node = candidate)
+
+                // Android 15+: the action button's icon and label can be separate, unclickable
+                // nodes with the tappable wrapper as a sibling (AOSP action-row layout). Match ONLY
+                // a clickable in the SAME column as the label, so we never grab an adjacent action
+                // such as Uninstall.
+                if (target == null && hasApiLevel(35)) {
+                    log(TAG, WARN) { "No clickable parent found for $candidate" }
+                    target = findColumnAlignedClickable(candidate)
+                    if (target != null) {
+                        log(TAG, INFO) { "Column-aligned clickable found: $target" }
+                    } else if (!candidate.getScreenBounds().isEmpty()) {
+                        // On this action row a button is clickable iff enabled. A well-bounded Force
+                        // stop label with no column-aligned clickable therefore means the button is
+                        // disabled -> the app is already stopped. Bail cleanly instead of clicking a
+                        // neighbouring action.
+                        log(TAG, WARN) { "No Force stop button in its column, treating as already-stopped: $candidate" }
+                        wasDisabled = true
+                        return@action true
+                    }
+                }
+
+                if (target == null) {
+                    log(TAG, WARN) { "No clickable target found for $candidate" }
+                    return@action false
+                }
+
+                if (!target.isEnabled) {
+                    wasDisabled = true
+                    return@action true
+                }
+
+                clickNormal(node = target)
+            }
+
+            val step = AutomationStep(
+                source = TAG,
+                descriptionInternal = "Force stop button for $pkg",
+                label = eu.darken.sdmse.appcontrol.R.string.appcontrol_automation_progress_find_force_stop.toCaString(forceStopLabels),
+                windowLaunch = windowLauncherDefaultSettings(pkg),
+                windowCheck = windowCheckDefaultSettings(SETTINGS_PKG, ipcFunnel, pkg),
+                nodeRecovery = defaultNodeRecovery(pkg),
+                nodeAction = action,
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+
+        if (wasDisabled) {
+            log(TAG) { "Force stop button was disabled, app is already stopped." }
+            return@plan
+        }
+
+        run {
+            val titleLbl = aospLabels.getForceStopDialogTitleDynamic(this) + forceStopLabels.map { "$it?" }
+            val okLbl = aospLabels.getForceStopDialogOkDynamic(this)
+            val cancelLbl = aospLabels.getForceStopDialogCancelDynamic(this)
+
+            val windowCheck = windowCheck { _, root ->
+                if (root.pkgId != SETTINGS_PKG) return@windowCheck false
+                root.crawl().map { it.node }.any { it.isForceStopConfirmDialogNode(titleLbl, forceStopLabels) }
+            }
+
+            val action: suspend StepContext.() -> Boolean = action@{
+                val root = host.waitForWindowRoot()
+                if (root.pkgId != SETTINGS_PKG) return@action false
+                val nodes = root.crawl().map { it.node }.toList()
+                // The window check ran against an earlier root: without re-checking here, a dialog
+                // that vanished mid-retry would let us click App info's own Force stop button,
+                // reopen the dialog and report success while the app is still running.
+                if (nodes.none { it.isForceStopConfirmDialogNode(titleLbl, forceStopLabels) }) return@action false
+
+                val labels = when (Bugs.isDryRun) {
+                    true -> cancelLbl
+                    false -> okLbl + forceStopLabels
+                }
+                // The dialog title can carry the same verb as the confirm button, so prefer an
+                // actual button; COUI's own button classes are covered by the isClickable pass.
+                val candidate = nodes.firstOrNull { it.isClickyButton() && it.textMatchesAny(labels) }
+                    ?: nodes.firstOrNull { it.isClickable && it.textMatchesAny(labels) }
+                    ?: nodes.firstOrNull { it.textMatchesAny(labels) && !it.textMatchesAny(titleLbl) }
+                    ?: return@action false
+                val mapped = findClickableParent(includeSelf = true, node = candidate) ?: return@action false
+                clickNormal(isDryRun = Bugs.isDryRun, node = mapped)
+            }
+
+            val step = AutomationStep(
+                source = TAG,
+                descriptionInternal = "Confirm force stop for $pkg",
+                label = eu.darken.sdmse.automation.R.string.automation_progress_find_ok_confirmation.toCaString(titleLbl + okLbl + forceStopLabels),
+                windowCheck = windowCheck,
+                nodeAction = action,
+            )
+            stepper.withProgress(this) { process(this@plan, step) }
+        }
+    }
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class DIM {
+        @Binds @IntoSet abstract fun mod(mod: OxygenOSSpecs): AppControlSpecGenerator
+    }
+
+    companion object {
+        val SETTINGS_PKG = "com.android.settings".toPkgId()
+
+        val TAG: String = logTag("AppControl", "Automation", "OxygenOS", "Specs")
+    }
+
+}
+
+private const val DIALOG_CONFIRM_BUTTON_ID = "android:id/button1"
+
+/**
+ * The OxygenOS force-stop dialog has no title node, only a message and two buttons. Recognize it
+ * either by an AOSP-style title, or by the framework AlertDialog positive button carrying the
+ * force-stop verb: the id alone would also match unrelated Settings dialogs, the text alone would
+ * also match the App info screen's own Force stop button.
+ */
+private fun ACSNodeInfo.isForceStopConfirmDialogNode(
+    titleLabels: Collection<String>,
+    forceStopLabels: Collection<String>,
+): Boolean = textMatchesAny(titleLabels) ||
+        (isClickable && idMatches(DIALOG_CONFIRM_BUTTON_ID) && textMatchesAny(forceStopLabels))

--- a/app/src/test/java/eu/darken/sdmse/appcontrol/core/automation/specs/oxygenos/OxygenOSSpecsTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/appcontrol/core/automation/specs/oxygenos/OxygenOSSpecsTest.kt
@@ -1,0 +1,433 @@
+package eu.darken.sdmse.appcontrol.core.automation.specs.oxygenos
+
+import android.graphics.Rect
+import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPLabels
+import eu.darken.sdmse.appcontrol.core.automation.specs.aosp.AOSPSpecs
+import eu.darken.sdmse.automation.core.common.ACSNodeInfo
+import eu.darken.sdmse.automation.core.common.stepper.AutomationStep
+import eu.darken.sdmse.automation.core.common.stepper.StepContext
+import eu.darken.sdmse.automation.core.common.stepper.Stepper
+import eu.darken.sdmse.automation.core.specs.AutomationExplorer
+import eu.darken.sdmse.automation.core.specs.AutomationSpec
+import eu.darken.sdmse.common.debug.Bugs
+import eu.darken.sdmse.common.device.DeviceDetective
+import eu.darken.sdmse.common.device.RomType
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.pkgs.features.InstallId
+import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.main.core.GeneralSettings
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestACSNodeInfo
+import testhelpers.TestApplication
+import testhelpers.mockDataStoreValue
+import testhelpers.automation.TestAutomationHost
+
+/**
+ * Regression coverage for the OxygenOS force-stop confirmation dialog: a COUI dialog with no title
+ * node at all, whose positive button (`android:id/button1`) repeats the action verb instead of
+ * carrying the AOSP "OK" label. Under the AOSP fallback the confirmation step's window check never
+ * matched and the step timed out.
+ *
+ * Robolectric so `android.graphics.Rect` (node bounds) actually works.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class OxygenOSSpecsTest : BaseTest() {
+
+    private val ipcFunnel: IPCFunnel = mockk(relaxed = true)
+    private val deviceDetective: DeviceDetective = mockk(relaxed = true)
+    private val generalSettings: GeneralSettings = mockk(relaxed = true)
+    private val stepper: Stepper = mockk(relaxed = true)
+    private val aospSpecs: AOSPSpecs = mockk(relaxed = true)
+    private val labels: AOSPLabels = mockk {
+        every { getForceStopButtonDynamic(any()) } returns setOf("Force stop")
+        every { getForceStopDialogTitleDynamic(any()) } returns setOf("Force stop?")
+        every { getForceStopDialogOkDynamic(any()) } returns setOf("OK")
+        every { getForceStopDialogCancelDynamic(any()) } returns setOf("Cancel")
+    }
+
+    @After
+    fun resetDryRun() {
+        Bugs.isDryRun = false
+    }
+
+    private fun createSpec() = OxygenOSSpecs(
+        ipcFunnel = ipcFunnel,
+        deviceDetective = deviceDetective,
+        aospLabels = labels,
+        aospSpecs = aospSpecs,
+        generalSettings = generalSettings,
+        stepper = stepper,
+    )
+
+    private fun createTestPkg(packageName: String = "com.superthomaslab.hueessentials"): Installed = mockk {
+        every { installId } returns InstallId(
+            pkgId = packageName.toPkgId(),
+            userHandle = mockk<UserHandle2> { every { handleId } returns 0 },
+        )
+        every { this@mockk.packageName } returns packageName
+        every { id } returns packageName.toPkgId()
+    }
+
+    private fun settingsRoot() = TestACSNodeInfo(
+        viewIdResourceName = "root",
+        packageName = "com.android.settings",
+        bounds = Rect(0, 0, 1080, 2400),
+    )
+
+    /** App-info screen: the Force stop action is a plain clickable Button (id/middle_button). */
+    private fun appInfoScreen(): Pair<TestACSNodeInfo, TestACSNodeInfo> {
+        val root = settingsRoot()
+        val forceStop = TestACSNodeInfo(
+            text = "Force stop",
+            className = "android.widget.Button",
+            viewIdResourceName = "com.android.settings:id/middle_button",
+            isClickable = true,
+            bounds = Rect(58, 691, 540, 755),
+        )
+        root.addChild(forceStop)
+        return root to forceStop
+    }
+
+    private data class PlanRun(
+        val processed: List<String>,
+        val confirmWindowCheckPassed: Boolean,
+        val confirmActionResult: Boolean?,
+    )
+
+    /**
+     * Runs the real force-stop plan: the App-info step's nodeAction runs against [appInfoRoot],
+     * then the window root swaps to [dialogRoot] and the confirmation step's windowCheck and
+     * nodeAction both run against it.
+     */
+    private suspend fun runForceStopPlan(
+        scope: TestScope,
+        appInfoRoot: TestACSNodeInfo,
+        dialogRoot: TestACSNodeInfo,
+        pkg: Installed,
+    ): PlanRun {
+        val testHost = TestAutomationHost(scope).apply { setWindowRoot(appInfoRoot) }
+        val context = object : AutomationExplorer.Context {
+            override val host get() = testHost
+            override val progress = emptyFlow<Progress.Data?>()
+            override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {}
+        }
+
+        val processed = mutableListOf<String>()
+        var windowCheckPassed = false
+        var actionResult: Boolean? = null
+
+        coEvery { stepper.process(any(), any()) } coAnswers {
+            val step = secondArg<AutomationStep>()
+            processed += step.descriptionInternal
+            val stepContext = StepContext(hostContext = context, tag = "test", stepAttempts = 0)
+            if (step.descriptionInternal.startsWith("Confirm force stop")) {
+                // windowCheck never emits while its condition is unmet, so a verdict needs a bound.
+                windowCheckPassed = withTimeoutOrNull(1000) { step.windowCheck!!.invoke(stepContext) } != null
+                actionResult = step.nodeAction?.invoke(stepContext)
+            } else {
+                step.nodeAction?.invoke(stepContext)
+            }
+            if (step.descriptionInternal.startsWith("Force stop button")) {
+                testHost.setWindowRoot(dialogRoot)
+            }
+            Unit
+        }
+
+        val plan = (createSpec().getForceStop(pkg) as AutomationSpec.Explorer).createPlan()
+        plan.invoke(context)
+        return PlanRun(processed, windowCheckPassed, actionResult)
+    }
+
+    @Test
+    fun `titleless COUI dialog is recognized and its force-stop button clicked`() = runTest {
+        val (appInfoRoot, _) = appInfoScreen()
+
+        val dialogRoot = settingsRoot()
+        val message = TestACSNodeInfo(
+            text = "Force stopping an app may cause it to misbehave.",
+            className = "android.widget.TextView",
+            viewIdResourceName = "android:id/message",
+            bounds = Rect(100, 900, 980, 1040),
+        )
+        val confirm = TestACSNodeInfo(
+            text = "Force stop",
+            className = "android.widget.Button",
+            viewIdResourceName = "android:id/button1",
+            isClickable = true,
+            bounds = Rect(580, 1100, 980, 1180),
+        )
+        val divider = TestACSNodeInfo(className = "android.widget.ImageView", bounds = Rect(540, 1100, 542, 1180))
+        val cancel = TestACSNodeInfo(
+            text = "Cancel",
+            className = "android.widget.Button",
+            viewIdResourceName = "android:id/button2",
+            isClickable = true,
+            bounds = Rect(100, 1100, 500, 1180),
+        )
+        dialogRoot.addChildren(message, confirm, divider, cancel)
+
+        val run = runForceStopPlan(this, appInfoRoot, dialogRoot, createTestPkg())
+
+        run.confirmWindowCheckPassed shouldBe true
+        confirm.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+        cancel.performedActions shouldBe emptyList()
+        message.performedActions shouldBe emptyList()
+        run.processed.size shouldBe 2
+        run.processed[1].startsWith("Confirm force stop") shouldBe true
+    }
+
+    @Test
+    fun `titled dialog with a stock OK button still works`() = runTest {
+        val (appInfoRoot, _) = appInfoScreen()
+
+        val dialogRoot = settingsRoot()
+        val title = TestACSNodeInfo(text = "Force stop?", className = "android.widget.TextView", bounds = Rect(100, 900, 980, 980))
+        val confirm = TestACSNodeInfo(
+            text = "OK",
+            className = "android.widget.Button",
+            viewIdResourceName = "android:id/button1",
+            isClickable = true,
+            bounds = Rect(580, 1100, 980, 1180),
+        )
+        val cancel = TestACSNodeInfo(
+            text = "Cancel",
+            className = "android.widget.Button",
+            viewIdResourceName = "android:id/button2",
+            isClickable = true,
+            bounds = Rect(100, 1100, 500, 1180),
+        )
+        dialogRoot.addChildren(title, confirm, cancel)
+
+        val run = runForceStopPlan(this, appInfoRoot, dialogRoot, createTestPkg())
+
+        run.confirmWindowCheckPassed shouldBe true
+        confirm.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+        cancel.performedActions shouldBe emptyList()
+        title.performedActions shouldBe emptyList()
+        run.processed.size shouldBe 2
+    }
+
+    @Test
+    fun `a title alone is enough to recognize the dialog`() = runTest {
+        val (appInfoRoot, _) = appInfoScreen()
+
+        val dialogRoot = settingsRoot()
+        val title = TestACSNodeInfo(text = "Force stop?", className = "android.widget.TextView", bounds = Rect(100, 900, 980, 980))
+        val cancel = TestACSNodeInfo(
+            text = "Cancel",
+            className = "android.widget.Button",
+            viewIdResourceName = "android:id/button2",
+            isClickable = true,
+            bounds = Rect(100, 1100, 500, 1180),
+        )
+        dialogRoot.addChildren(title, cancel)
+
+        val run = runForceStopPlan(this, appInfoRoot, dialogRoot, createTestPkg())
+
+        run.confirmWindowCheckPassed shouldBe true
+    }
+
+    @Test
+    fun `the app info screen is not mistaken for the confirmation dialog`() = runTest {
+        val (appInfoRoot, _) = appInfoScreen()
+
+        // Same screen as step 1: a Force stop Button, but on id/middle_button and with no button1.
+        val stillAppInfo = settingsRoot()
+        val header = TestACSNodeInfo(text = "App info", className = "android.widget.TextView", bounds = Rect(100, 200, 980, 280))
+        val forceStop = TestACSNodeInfo(
+            text = "Force stop",
+            className = "android.widget.Button",
+            viewIdResourceName = "com.android.settings:id/middle_button",
+            isClickable = true,
+            bounds = Rect(58, 691, 540, 755),
+        )
+        stillAppInfo.addChildren(header, forceStop)
+
+        val run = runForceStopPlan(this, appInfoRoot, stillAppInfo, createTestPkg())
+
+        run.confirmWindowCheckPassed shouldBe false
+        run.confirmActionResult shouldBe false
+        forceStop.performedActions shouldBe emptyList()
+        header.performedActions shouldBe emptyList()
+    }
+
+    @Test
+    fun `an unrelated settings dialog is not recognized`() = runTest {
+        val (appInfoRoot, _) = appInfoScreen()
+
+        val dialogRoot = settingsRoot()
+        val message = TestACSNodeInfo(
+            text = "Reset all app preferences?",
+            className = "android.widget.TextView",
+            viewIdResourceName = "android:id/message",
+            bounds = Rect(100, 900, 980, 1040),
+        )
+        val confirm = TestACSNodeInfo(
+            text = "OK",
+            className = "android.widget.Button",
+            viewIdResourceName = "android:id/button1",
+            isClickable = true,
+            bounds = Rect(580, 1100, 980, 1180),
+        )
+        val cancel = TestACSNodeInfo(
+            text = "Cancel",
+            className = "android.widget.Button",
+            viewIdResourceName = "android:id/button2",
+            isClickable = true,
+            bounds = Rect(100, 1100, 500, 1180),
+        )
+        dialogRoot.addChildren(message, confirm, cancel)
+
+        val run = runForceStopPlan(this, appInfoRoot, dialogRoot, createTestPkg())
+
+        run.confirmWindowCheckPassed shouldBe false
+    }
+
+    @Test
+    fun `a title carrying the exact button text does not shadow the confirm button`() = runTest {
+        val (appInfoRoot, _) = appInfoScreen()
+
+        val dialogRoot = settingsRoot()
+        val title = TestACSNodeInfo(text = "Force stop", className = "android.widget.TextView", bounds = Rect(100, 900, 980, 980))
+        val confirm = TestACSNodeInfo(
+            text = "Force stop",
+            className = "android.widget.Button",
+            viewIdResourceName = "android:id/button1",
+            isClickable = true,
+            bounds = Rect(580, 1100, 980, 1180),
+        )
+        dialogRoot.addChildren(title, confirm)
+
+        val run = runForceStopPlan(this, appInfoRoot, dialogRoot, createTestPkg())
+
+        run.confirmWindowCheckPassed shouldBe true
+        confirm.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+        title.performedActions shouldBe emptyList()
+    }
+
+    @Test
+    fun `a confirm control of a custom button class is clicked`() = runTest {
+        val (appInfoRoot, _) = appInfoScreen()
+
+        val dialogRoot = settingsRoot()
+        val title = TestACSNodeInfo(text = "Force stop", className = "android.widget.TextView", bounds = Rect(100, 900, 980, 980))
+        val confirm = TestACSNodeInfo(
+            text = "Force stop",
+            className = "com.coui.appcompat.button.COUIButton",
+            viewIdResourceName = "android:id/button1",
+            isClickable = true,
+            bounds = Rect(580, 1100, 980, 1180),
+        )
+        dialogRoot.addChildren(title, confirm)
+
+        val run = runForceStopPlan(this, appInfoRoot, dialogRoot, createTestPkg())
+
+        run.confirmWindowCheckPassed shouldBe true
+        confirm.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+        title.performedActions shouldBe emptyList()
+    }
+
+    @Test
+    fun `a label nested in a clickable wrapper clicks the wrapper`() = runTest {
+        val (appInfoRoot, _) = appInfoScreen()
+
+        val dialogRoot = settingsRoot()
+        val title = TestACSNodeInfo(text = "Force stop?", className = "android.widget.TextView", bounds = Rect(100, 900, 980, 980))
+        val wrapper = TestACSNodeInfo(
+            className = "android.widget.LinearLayout",
+            viewIdResourceName = "android:id/button1",
+            isClickable = true,
+            bounds = Rect(580, 1100, 980, 1180),
+        )
+        val label = TestACSNodeInfo(text = "Force stop", className = "android.widget.TextView", bounds = Rect(600, 1120, 960, 1160))
+        wrapper.addChild(label)
+        dialogRoot.addChildren(title, wrapper)
+
+        val run = runForceStopPlan(this, appInfoRoot, dialogRoot, createTestPkg())
+
+        run.confirmWindowCheckPassed shouldBe true
+        wrapper.performedActions shouldBe listOf(ACSNodeInfo.ACTION_CLICK)
+        label.performedActions shouldBe emptyList()
+    }
+
+    @Test
+    fun `a dry run selects cancel instead of confirming`() = runTest {
+        Bugs.isDryRun = true
+        val (appInfoRoot, _) = appInfoScreen()
+
+        val dialogRoot = settingsRoot()
+        val message = TestACSNodeInfo(
+            text = "Force stopping an app may cause it to misbehave.",
+            className = "android.widget.TextView",
+            viewIdResourceName = "android:id/message",
+            bounds = Rect(100, 900, 980, 1040),
+        )
+        val confirm = TestACSNodeInfo(
+            text = "Force stop",
+            className = "android.widget.Button",
+            viewIdResourceName = "android:id/button1",
+            isClickable = true,
+            bounds = Rect(580, 1100, 980, 1180),
+        )
+        val cancel = TestACSNodeInfo(
+            text = "Cancel",
+            className = "android.widget.Button",
+            viewIdResourceName = "android:id/button2",
+            isClickable = true,
+            bounds = Rect(100, 1100, 500, 1180),
+        )
+        dialogRoot.addChildren(message, confirm, cancel)
+
+        val run = runForceStopPlan(this, appInfoRoot, dialogRoot, createTestPkg())
+
+        run.confirmWindowCheckPassed shouldBe true
+        cancel.performedActions shouldBe listOf(ACSNodeInfo.ACTION_SELECT)
+        confirm.performedActions shouldBe emptyList()
+    }
+
+    @Test
+    fun `responsibility follows the rom type override`() = runTest {
+        val pkg = createTestPkg()
+
+        every { generalSettings.romTypeDetection } returns mockDataStoreValue(RomType.OXYGENOS)
+        createSpec().isResponsible(pkg) shouldBe true
+
+        every { generalSettings.romTypeDetection } returns mockDataStoreValue(RomType.COLOROS)
+        createSpec().isResponsible(pkg) shouldBe false
+
+        every { generalSettings.romTypeDetection } returns mockDataStoreValue(RomType.AOSP)
+        createSpec().isResponsible(pkg) shouldBe false
+    }
+
+    @Test
+    fun `responsibility falls back to device detection when set to auto`() = runTest {
+        val pkg = createTestPkg()
+        every { generalSettings.romTypeDetection } returns mockDataStoreValue(RomType.AUTO)
+
+        every { deviceDetective.getROMType() } returns RomType.OXYGENOS
+        createSpec().isResponsible(pkg) shouldBe true
+
+        every { deviceDetective.getROMType() } returns RomType.COLOROS
+        createSpec().isResponsible(pkg) shouldBe false
+
+        every { deviceDetective.getROMType() } returns RomType.AOSP
+        createSpec().isResponsible(pkg) shouldBe false
+    }
+}


### PR DESCRIPTION
## What changed

Force stop now works on OnePlus phones running OxygenOS.

Previously, turning on the "Force Stop" option made both AppControl and AppCleaner hang. The
automation would open an app's info screen, tap Force stop, and then sit on "Trying to confirm
previous action..." until it gave up, over and over for every app in the list. Nothing actually got
stopped. You could see the system's confirmation dialog sitting there behind SD Maid, never being
tapped.

OnePlus draws that confirmation dialog without a title, and the automation was waiting for the title
to appear before it would do anything. It now recognises the dialog by its buttons instead, and
knows that OnePlus labels the confirm button "Force stop" rather than "OK".

Reported by a user on a OnePlus 9 Pro running OxygenOS 14, with debug logs.

## Technical Context

- OnePlus resolves to `RomType.OXYGENOS`, and AppControl had no generator claiming it, so these
  devices fell through to `AOSPSpecs`. Its confirm step accepts the window only if some node's text
  equals the resolved dialog title, which is unsatisfiable on a COUI dialog that renders no title
  node at all: the `windowCheck` flow never emits and the 4s `withTimeout` in `Stepper` throws, once
  per attempt, forever. Two more defects sat behind it in the same step, both already described in
  571b185d8's message: the action matched only `okLbl`, and `defaultFindAndClick` resolves clicks
  through `findClickableParent` without `includeSelf`, so a positive button that is clickable itself
  can never be selected.
- `AOSPSpecs` is deliberately **not** modified. It is the fallback every unlisted device uses, and
  every previous ROM divergence here was handled by adding a generator instead — `ColorOSSpecs` came
  from 571b185d8 for an OPPO report. AppCleaner already carried an `oxygenos` spec, and this
  module's priority list already reserved the rank as a commented-out `// is OnePlusSpecs -> 30`.
- Worth a close look: the confirm action re-runs the same dialog predicate the `windowCheck` already
  passed. That is not redundant. `Stepper` computes the validated root and never hands it to
  `nodeAction`, and its retry loop re-invokes the action without re-running the check, so the action
  can run against a window the check never saw. Without the re-check, a dialog that vanished
  mid-retry would let the widened label set match the App info screen's own Force stop button,
  reopen the dialog, and return success while the app was still running.
- The candidate search is three clauses rather than two: `isClickyButton()` requires the class to be
  exactly `android.widget.Button`, which COUI's own button classes are not, and the text-only
  fallback rejects those same nodes whenever the ROM's title carries the bare verb.
- This also fixes AppCleaner's force-stop step, which submits `ForceStopAutomationTask` into the
  same module and therefore the same generator.
- No OxygenOS hardware was available, so the titleless-dialog behaviour is covered by spec-level
  tests built from the accessibility node tree in the reporter's logs.
