### PR TITLE
General: Document copy style, automation and test pitfalls

### DIFF
--- a/.claude/rules/automation.md
+++ b/.claude/rules/automation.md
@@ -25,3 +25,29 @@ SD Maid SE uses an accessibility service for automation features (AppCleaner aut
 - Automation tasks are built using a stepper pattern for complex UI interactions
 - Supports different automation specs per app and Android version
 - Debug recorder available for capturing automation sessions
+
+## AppCleaner: where automation actually runs
+
+The scan path contains no automation at all. `AppCleaner.performScan` never touches the accessibility
+path. ACS work happens in `performProcessing`, gated on `AppCleanerProcessingTask.includeInaccessible`,
+which builds the `ClearCacheTask` via `InaccessibleDeleter`. `AutomationCompatibilityException`
+("Automation compatibility") has a single throw site, in `ClearCacheModule`, raised once
+`FAILURE_LIMIT` targets have failed with an unusable-automation error and nothing has succeeded.
+
+Consequences:
+
+- A debug log recorded while only scanning contains no automation activity. Reproducing an automation
+  error requires running the actual clean/delete step.
+- With the accessibility service off, the same path raises "Service isn't enabled" instead, so a report
+  naming the compatibility error implies the service was on.
+
+## Debugging: the service sees a different tree
+
+A `uiautomator dump` is not evidence about what `AutomationService` sees. It shows nodes the app's own
+service cannot reach: clear-cache buttons that are marked `NAF="true"`, or that carry a
+`content-desc` and are clickable in the dump, while `findClearCacheCandidate` still returns null. The
+DPAD fallback exists because the service gets a different tree.
+
+To learn what the service sees, capture the app's own ACS-DEBUG dump with debug recording enabled
+during a run. Use uiautomator only for questions about platform behaviour, such as where DPAD focus
+lands.

--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -45,6 +45,24 @@ caString { getString(R.plurals.xxx, count, count) }
   - Postfix with `_action` instead of prefixing with `button_`
   - Instead of `module_screen_button_open` it should be `module_screen_open_action`
 
+## Copy Style
+
+Rules for the English source text of user-facing strings:
+
+- No em dashes. Use a period or a comma.
+- A settings description never states the default ("Off by default: …"). The switch next to it already
+  shows the state.
+- Descriptions are two or three plain sentences: what the option covers, what happens to those files.
+  No justification clauses ("to keep memory use in check"), no "Enable to …" instructions.
+- Captions and hints must not repeat what the button label next to them already says.
+- Never over-promise on the one-time purchase. No "lifetime" or "forever" phrasing; the approved
+  wording is "One payment, no renewals."
+- Whimsy is welcome where it fits, e.g. the mascot mood variants reacting to app state.
+- Section headers get a translatability check before they are proposed. Puns rarely survive; prefer
+  wording that maps 1:1 into other languages.
+- Modelling a new string on an existing one is not a defence. Older strings predate these rules; new
+  strings are held to them regardless.
+
 ## Translator Context on Crowdin
 
 String context, character limits and file context are managed on Crowdin through the android-translation

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -192,6 +192,46 @@ pickerResults.tryEmit(PickerResult(selectedPaths = paths))
 advanceUntilIdle()
 ```
 
+## Pitfalls
+
+### Robolectric renders with stub font metrics
+
+`BaseComposeRobolectricTest` does not measure text realistically, so assertions that depend on text
+measurement prove nothing there:
+
+- Width is a flat ~1.0dp per character, identical across text styles and unchanged by font scale. A
+  13-character headline measures 13.0dp. **Text therefore never wraps**, at any width or font scale.
+- Line heights are wrong in both directions: `bodyMedium` measures ~36dp at font scale 1.0 against a
+  real M3 line height of ~20dp, and grows only to ~38dp at scale 2.0. `labelSmall` measures ~12dp at
+  scale 1.0 and ~36dp at scale 2.0.
+
+So a rendered `assertIsDisplayed()` check can fail on content that ships fine (phantom height overflows
+a fixed-height card), and a bounds assertion cannot guard a wrap-driven regression. Existing font-scale
+bounds tests pass largely because the card grows while the stub text does not; treat them as
+gross-overflow guards, not as evidence about real layout.
+
+Layout that depends on text metrics needs the `screenshotTest` source set
+(`android.experimental.enableScreenshotTest=true` is on) or on-device inspection. Before claiming any
+layout test guards something, reintroduce the defect and confirm the test goes red.
+
+### A green run can be testing stale bytecode
+
+Gradle in this repo has run tests against compiled classes that did not match the source on disk, in
+both directions, most often in a worktree with the `built_in_kotlinc` compiler. A newly added `@Test`
+was absent from the compiled class and the run reported success without it; after a fix was reverted,
+the class still contained the fix and the test still passed.
+
+Never accept a pass/fail on a test just added or a source just reverted without checking the binary.
+Cheapest check: compare `grep -c '@Test'` in the source against `tests="N"` in
+`<module>/build/test-results/<task>/TEST-<fqcn>.xml`. A mismatch means a stale compile, not a flaky
+test. To force a rebuild, delete the module's `build/intermediates/built_in_kotlinc/<variant>` and
+`build/intermediates/classes/<variant>`, and confirm with
+`javap -p <Class>.class | grep <method-or-token>`.
+
+Reading that XML: a passing testcase is self-closing, but the `/` follows the `time="…"` attribute
+(`<testcase name="…" classname="…" time="0.067"/>`), so a regex anchored right after `name="…"`
+misreports passes as failures. Cross-check `failures="0"` on the `<testsuite>` element.
+
 ## Testing Libraries
 
 - **Assertions**: Use Kotest matchers (`io.kotest.matchers.shouldBe`, `shouldThrow`, etc.)


### PR DESCRIPTION
## What changed

No user-facing behavior change. This is documentation only: three sections added to the rule files in `.claude/rules/`, which are the in-repo guidance that coding assistants load when they touch matching files.

## Technical Context

- `localization.md` gains a "Copy Style" section for the English source text of user-facing strings: no em dashes, a settings description never states the default, two or three plain sentences without justification clauses, headers get a translatability check. These constraints have come up repeatedly in copy review and were nowhere in the repo.
- `automation.md` documents where AppCleaner automation actually runs. `performScan` touches no accessibility code; the ACS path is `performProcessing` to `InaccessibleDeleter` to `ClearCacheModule`, which also holds the only `AutomationCompatibilityException` throw site. That makes "reproduce by tapping Scan" an impossible instruction when asking a user for a debug log. It also records that a `uiautomator dump` is not evidence about what `AutomationService` sees, which is the reason the DPAD fallback exists.
- `testing.md` gains a "Pitfalls" section covering two traps that produce confidently wrong results: `BaseComposeRobolectricTest` renders with stub font metrics (roughly 1dp per character, text never wraps, line heights wrong in both directions), so rendered layout assertions there carry no information; and a green Gradle run can be executing stale bytecode, with the `@Test`-count versus `tests="N"` cross-check to catch it.
- Every claim was checked against the current tree before it was written, including the throw site's actual condition (`FAILURE_LIMIT` unusable failures with zero successes) and `android.experimental.enableScreenshotTest=true` in `gradle.properties`.
- `automation.md` and `testing.md` are path-scoped, so these sections only load when files in those areas are touched.
