### PR TITLE
General: Show a bigger mascot and a roomier welcome screen

### DIFF
--- a/app-common-automation/src/main/java/eu/darken/sdmse/automation/ui/AutomationOverlay.kt
+++ b/app-common-automation/src/main/java/eu/darken/sdmse/automation/ui/AutomationOverlay.kt
@@ -68,7 +68,7 @@ internal fun AutomationOverlay(
 
             SdmMascot(
                 modifier = Modifier
-                    .heightIn(max = 108.dp)
+                    .heightIn(max = 172.dp)
                     .padding(horizontal = 32.dp),
             )
 

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/AnniversaryDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/AnniversaryDashboardCard.kt
@@ -55,7 +55,7 @@ internal fun AnniversaryDashboardCard(item: AnniversaryDashboardCardItem) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             SdmMascot(
                 modifier = Modifier
-                    .height(44.dp)
+                    .height(96.dp)
                     .padding(start = 4.dp),
                 mode = SdmMascotMode.Party,
             )

--- a/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/dashboard/cards/TitleDashboardCard.kt
@@ -160,7 +160,7 @@ internal fun TitleDashboardCard(
             mascot = {
                 SdmMascot(
                     modifier = Modifier
-                        .height(44.dp)
+                        .height(56.dp)
                         .graphicsLayer {
                             val impact = mascotImpact.value
                             translationY = impact * 3.dp.toPx()

--- a/app/src/main/java/eu/darken/sdmse/main/ui/onboarding/welcome/OnboardingWelcomeScreen.kt
+++ b/app/src/main/java/eu/darken/sdmse/main/ui/onboarding/welcome/OnboardingWelcomeScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
-import eu.darken.sdmse.common.compose.layout.SdmScaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -34,6 +33,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.sdmse.R
 import eu.darken.sdmse.common.BuildConfigWrap
 import eu.darken.sdmse.common.compose.SdmMascot
+import eu.darken.sdmse.common.compose.layout.SdmScaffold
 import eu.darken.sdmse.common.compose.preview.Preview2
 import eu.darken.sdmse.common.compose.preview.PreviewWrapper
 import eu.darken.sdmse.common.error.ErrorEventHandler
@@ -95,6 +95,8 @@ internal fun OnboardingWelcomeScreen(
                     SdmMascot(
                         modifier = Modifier.height(116.dp),
                     )
+
+                    Spacer(modifier = Modifier.height(32.dp))
 
                     Text(
                         text = stringResource(R.string.onboarding_welcome_title),


### PR DESCRIPTION
## What changed

The mascot now shows up larger in three places: the dashboard title card, the anniversary card, and the overlay that appears while an automated cleaning run is in progress. The welcome screen shown on first launch also gets more breathing room between the mascot and its heading.

No functional change: nothing about cleaning, scanning, or automation behaves differently.

## Technical Context

- Visual-only change. It touches Compose sizing modifiers and adds one `Spacer`; no state, logic, or behavior is affected.
- The three mascot heights are independent per-surface values rather than one shared constant, so they were adjusted separately.
- Biggest single jump is the anniversary card, which roughly doubles. That one is worth a look on small screens and in landscape, where the card has the least vertical room.
- The welcome screen's `SdmScaffold` import moved into alphabetical order with the other imports. No functional effect.
