### PR TITLE
General: Show Xiaomi tips when the accessibility service is stopped

### DIFF
--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupCard.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationSetupCard.kt
@@ -132,6 +132,16 @@ internal fun AutomationSetupCard(
             )
         }
 
+        if (ui.showMiuiStoppedHint) {
+            Text(
+                text = stringResource(R.string.setup_acs_state_stopped_hint_miui_killed),
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 32.dp),
+            )
+        }
+
         if (ui.showAllowAction) {
             Button(
                 onClick = item.onGrantAction,
@@ -219,6 +229,37 @@ private fun AutomationSetupCardPreview() {
                     isServiceRunning = false,
                     isShortcutOrButtonEnabled = false,
                     needsXiaomiAutostart = false,
+                    liftRestrictionsIntent = Intent(),
+                    showAppOpsRestrictionHint = false,
+                    showAdvancedProtectionHint = false,
+                    isAdvancedProtectionBlocked = false,
+                    settingsIntent = Intent(),
+                ),
+                onGrantAction = {},
+                onDismiss = {},
+                onHelp = {},
+                onRestrictionsHelp = {},
+                onRestrictionsShow = {},
+                onAdvancedProtectionHelp = {},
+            ),
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun AutomationSetupCardXiaomiStoppedPreview() {
+    PreviewWrapper {
+        AutomationSetupCard(
+            item = AutomationSetupCardItem(
+                state = AutomationSetupModule.Result(
+                    isNotRequired = false,
+                    hasConsent = true,
+                    canSelfEnable = false,
+                    isServiceEnabled = true,
+                    isServiceRunning = false,
+                    isShortcutOrButtonEnabled = false,
+                    needsXiaomiAutostart = true,
                     liftRestrictionsIntent = Intent(),
                     showAppOpsRestrictionHint = false,
                     showAdvancedProtectionHint = false,

--- a/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationUiModel.kt
+++ b/app/src/main/java/eu/darken/sdmse/setup/automation/AutomationUiModel.kt
@@ -15,6 +15,7 @@ internal data class AutomationUiModel(
     val showAdvancedProtectionHint: Boolean,
     val runningState: StateChip?,
     val showRunningStateHint: Boolean,
+    val showMiuiStoppedHint: Boolean,
     val showAllowAction: Boolean,
     val allowActionText: AllowActionText,
     val showShortcutHint: Boolean,
@@ -77,15 +78,20 @@ internal fun AutomationSetupModule.Result.toUiModel(): AutomationUiModel {
         else -> AutomationUiModel.AllowActionText.CONSENT_POSITIVE
     }
 
+    // Advanced Protection takes precedence; the MIUI hints would be a false remedy here.
+    val showMiuiAutostartHint = hasConsent == true && !isServiceEnabled && needsXiaomiAutostart
+            && !isAdvancedProtectionBlocked
+    val showMiuiStoppedHint = hasConsent == true && isServiceEnabled && !isServiceRunning && needsXiaomiAutostart
+            && !isAdvancedProtectionBlocked
+
     return AutomationUiModel(
         enabledState = enabledChip,
-        // Advanced Protection takes precedence; the MIUI autostart hint would be a false remedy here.
-        showMiuiAutostartHint = hasConsent == true && !isServiceEnabled && needsXiaomiAutostart
-                && !isAdvancedProtectionBlocked,
+        showMiuiAutostartHint = showMiuiAutostartHint,
         showAppOpsRestrictionHint = showAppOpsRestrictionHint,
         showAdvancedProtectionHint = showAdvancedProtectionHint,
         runningState = runningChip,
         showRunningStateHint = !isServiceRunning && isServiceEnabled,
+        showMiuiStoppedHint = showMiuiStoppedHint,
         showAllowAction = showAllow,
         allowActionText = allowText,
         showShortcutHint = hasConsent == true && isShortcutOrButtonEnabled,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,6 +307,7 @@
     <string name="setup_acs_state_stopped">Accessibility service is stopped</string>
     <string name="setup_acs_state_stopped_hint">The service is enabled, but not running. Toggle it off/on or reboot your device. Check that SD Maid is not being "optimized" by the system.</string>
     <string name="setup_acs_state_stopped_hint_miui">If the service keeps getting disabled after a while, try enabling the "Auto Start" option for SD Maid in the system settings.</string>
+    <string name="setup_acs_state_stopped_hint_miui_killed">If the system keeps closing SD Maid, enable the \"Auto Start\" option for SD Maid in the system settings and lock SD Maid in the recent apps view.</string>
     <string name="setup_acs_consent_positive_action">Enable service and grant access</string>
     <string name="setup_acs_consent_negative_action">Don\'t use accessibility service</string>
     <string name="setup_acs_allow_hint">The accessibility shortcut or button for SD Maid SE is enabled. Open your device\'s Accessibility settings and disable the shortcut/button option to prevent an unwanted icon on the screen edge.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -259,7 +259,7 @@
 
     <string name="setup_manage_storage_card_title">Manage storage</string>
     <string name="setup_manage_storage_card_body">Allow SD Maid to manage your storage.</string>
-    <string name="setup_manage_storage_card_body2">Basic access to public storage, e.g. "Download/" and "DCIM/", but not always "Android/data".</string>
+    <string name="setup_manage_storage_card_body2">Basic access to public storage, e.g. \"Download/\" and \"DCIM/\", but not always \"Android/data\".</string>
 
     <string name="setup_root_card_title">Root access</string>
     <string name="setup_root_card_body">Should SD Maid use root access if it is available? Root access can be used to check additional system folders and private application data.</string>
@@ -305,8 +305,8 @@
     <string name="setup_acs_state_running">Accessibility service is running</string>
     <string name="setup_acs_state_ondemand">Service will be launched on demand</string>
     <string name="setup_acs_state_stopped">Accessibility service is stopped</string>
-    <string name="setup_acs_state_stopped_hint">The service is enabled, but not running. Toggle it off/on or reboot your device. Check that SD Maid is not being "optimized" by the system.</string>
-    <string name="setup_acs_state_stopped_hint_miui">If the service keeps getting disabled after a while, try enabling the "Auto Start" option for SD Maid in the system settings.</string>
+    <string name="setup_acs_state_stopped_hint">The service is enabled, but not running. Toggle it off/on or reboot your device. Check that SD Maid is not being \"optimized\" by the system.</string>
+    <string name="setup_acs_state_stopped_hint_miui">If the service keeps getting disabled after a while, try enabling the \"Auto Start\" option for SD Maid in the system settings.</string>
     <string name="setup_acs_state_stopped_hint_miui_killed">If the system keeps closing SD Maid, enable the \"Auto Start\" option for SD Maid in the system settings and lock SD Maid in the recent apps view.</string>
     <string name="setup_acs_consent_positive_action">Enable service and grant access</string>
     <string name="setup_acs_consent_negative_action">Don\'t use accessibility service</string>

--- a/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/SetupScreenTest.kt
@@ -532,7 +532,55 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
         }
     }
 
+    @Test
+    fun `automation card shows the Xiaomi stopped hint when enabled but stopped on a Xiaomi ROM`() {
+        composeRule.setSetupContent {
+            SetupScreen(
+                uiState = SetupUiState.Cards(
+                    items = listOf(
+                        automationCardItem(
+                            state = automationResult(
+                                isServiceEnabled = true,
+                                isServiceRunning = false,
+                                needsXiaomiAutostart = true,
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        }
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_acs_state_stopped_hint)).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_acs_state_stopped_hint_miui_killed))
+            .assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_acs_state_stopped_hint_miui))
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun `automation card keeps the Xiaomi stopped hint off when the service is running`() {
+        composeRule.setSetupContent {
+            SetupScreen(
+                uiState = SetupUiState.Cards(
+                    items = listOf(
+                        automationCardItem(
+                            state = automationResult(
+                                isServiceEnabled = true,
+                                isServiceRunning = true,
+                                needsXiaomiAutostart = true,
+                            ),
+                        ),
+                    ),
+                ),
+            )
+        }
+        composeRule.onAllNodesWithText(context.getString(R.string.setup_acs_state_stopped_hint_miui_killed))
+            .assertCountEquals(0)
+    }
+
     private fun automationResult(
+        isServiceEnabled: Boolean = false,
+        isServiceRunning: Boolean = false,
+        needsXiaomiAutostart: Boolean = false,
         showAppOpsRestrictionHint: Boolean = false,
         showAdvancedProtectionHint: Boolean = false,
         isAdvancedProtectionBlocked: Boolean = false,
@@ -540,10 +588,10 @@ class SetupScreenTest : BaseComposeRobolectricTest() {
         isNotRequired = false,
         hasConsent = true,
         canSelfEnable = false,
-        isServiceEnabled = false,
-        isServiceRunning = false,
+        isServiceEnabled = isServiceEnabled,
+        isServiceRunning = isServiceRunning,
         isShortcutOrButtonEnabled = false,
-        needsXiaomiAutostart = false,
+        needsXiaomiAutostart = needsXiaomiAutostart,
         liftRestrictionsIntent = Intent(),
         showAppOpsRestrictionHint = showAppOpsRestrictionHint,
         showAdvancedProtectionHint = showAdvancedProtectionHint,

--- a/app/src/test/java/eu/darken/sdmse/setup/automation/AutomationUiModelTest.kt
+++ b/app/src/test/java/eu/darken/sdmse/setup/automation/AutomationUiModelTest.kt
@@ -95,6 +95,7 @@ class AutomationUiModelTest : BaseTest() {
         ui.runningState?.tint shouldBe AutomationUiModel.ChipTint.ERROR
         ui.runningState?.textRes shouldBe R.string.setup_acs_state_stopped
         ui.showRunningStateHint shouldBe true
+        ui.showMiuiStoppedHint shouldBe false
         ui.showAllowAction shouldBe true
         ui.allowActionText shouldBe AutomationUiModel.AllowActionText.ENABLE_SERVICE
     }
@@ -107,6 +108,7 @@ class AutomationUiModelTest : BaseTest() {
             needsXiaomiAutostart = true,
         ).toUiModel()
         enabled.showMiuiAutostartHint shouldBe false
+        enabled.showMiuiStoppedHint shouldBe true
 
         val disabled = result(
             hasConsent = true,
@@ -114,6 +116,65 @@ class AutomationUiModelTest : BaseTest() {
             needsXiaomiAutostart = true,
         ).toUiModel()
         disabled.showMiuiAutostartHint shouldBe true
+        disabled.showMiuiStoppedHint shouldBe false
+    }
+
+    @Test
+    fun `stopped MIUI hint needs enabled, not running and autostart`() {
+        val stopped = result(
+            hasConsent = true,
+            isServiceEnabled = true,
+            isServiceRunning = false,
+            needsXiaomiAutostart = true,
+        ).toUiModel()
+        stopped.showMiuiStoppedHint shouldBe true
+
+        val running = result(
+            hasConsent = true,
+            isServiceEnabled = true,
+            isServiceRunning = true,
+            needsXiaomiAutostart = true,
+        ).toUiModel()
+        running.showMiuiStoppedHint shouldBe false
+
+        val notXiaomi = result(
+            hasConsent = true,
+            isServiceEnabled = true,
+            isServiceRunning = false,
+            needsXiaomiAutostart = false,
+        ).toUiModel()
+        notXiaomi.showMiuiStoppedHint shouldBe false
+    }
+
+    @Test
+    fun `stopped MIUI hint requires consent`() {
+        val undecided = result(
+            hasConsent = null,
+            isServiceEnabled = true,
+            isServiceRunning = false,
+            needsXiaomiAutostart = true,
+        ).toUiModel()
+        undecided.showMiuiStoppedHint shouldBe false
+
+        val denied = result(
+            hasConsent = false,
+            isServiceEnabled = true,
+            isServiceRunning = false,
+            needsXiaomiAutostart = true,
+        ).toUiModel()
+        denied.showMiuiStoppedHint shouldBe false
+    }
+
+    @Test
+    fun `stopped MIUI hint is suppressed while Advanced Protection blocks the service`() {
+        val ui = result(
+            hasConsent = true,
+            isServiceEnabled = true,
+            isServiceRunning = false,
+            needsXiaomiAutostart = true,
+            isAdvancedProtectionBlocked = true,
+        ).toUiModel()
+        ui.showMiuiStoppedHint shouldBe false
     }
 
     @Test


### PR DESCRIPTION
## What changed

On Xiaomi and HyperOS devices the system can close SD Maid while the accessibility service toggle stays on. The setup card then reported the service as "enabled" but "stopped" and only offered the generic advice to toggle it off and on or reboot. That state now also shows the Xiaomi-specific advice: enable the "Auto Start" option for SD Maid and lock SD Maid in the recent apps view. Previously that advice only appeared while the service toggle was off.

Three setup card texts lost their quotation marks on device: the storage card's folder examples ("Download/", "DCIM/", "Android/data"), the stopped-service hint's "optimized", and the Xiaomi hint's "Auto Start". They now render with the quotes.

Refs #1723, #7

## Technical Context

- Root cause: the Xiaomi hint gate has required the service toggle to be off since the 2023 commit that closed #7, even though #7 itself described the kill case. On HyperOS the toggle survives the kill, so the enabled-but-stopped state never matched.
- A second flag with its own string (conditional wording, English only) was added instead of widening the old gate, so the existing hint and its translations stay valid. Translations for the new string come through Crowdin.
- The quote loss is the Android resource compiler stripping unescaped double quotes from string values, confirmed on the compiled resources. Escaping them changes three Crowdin source strings.
- The enabled-but-unbound state has no deterministic route on an emulator, so coverage is the gate logic unit tests plus Robolectric rendering tests of the setup card.
