### PR TITLE
CorpseFinder: Fix the uninstall watcher not working after a restore

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/PackageManagerExtensions.kt
@@ -127,6 +127,14 @@ fun PackageManager.toggleSelfComponent(
     )
 }
 
+/**
+ * The read counterpart to [toggleSelfComponent]: `true` only for an explicit ENABLED write.
+ * `COMPONENT_ENABLED_STATE_DEFAULT` (never toggled by us) reads as `false`, which is not the same as
+ * "effectively enabled" for a component whose manifest declares `enabled="true"`.
+ */
+fun PackageManager.isSelfComponentExplicitlyEnabled(component: ComponentName): Boolean =
+    getComponentEnabledSetting(component) == PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+
 suspend fun PackageManager.freeStorageAndNotify(
     desiredBytes: Long = Long.MAX_VALUE - 1000L,
     storageId: String? = null,

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/UninstallWatcherControl.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/core/watcher/UninstallWatcherControl.kt
@@ -1,0 +1,93 @@
+package eu.darken.sdmse.corpsefinder.core.watcher
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.sdmse.common.coroutine.AppScope
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.sdmse.common.debug.logging.Logging.Priority.WARN
+import eu.darken.sdmse.common.debug.logging.asLog
+import eu.darken.sdmse.common.debug.logging.log
+import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.error.hasCause
+import eu.darken.sdmse.common.pkgs.isSelfComponentExplicitlyEnabled
+import eu.darken.sdmse.common.pkgs.toggleSelfComponent
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Keeps the [UninstallWatcherReceiver] component's enabled state in sync with `isPro && isWatcherEnabled`.
+ *
+ * The flag lives in our DataStore while the enabled state lives in the system's package restrictions,
+ * and routes exist that move one without the other (Auto Backup / device transfer, the in-app config
+ * restore, "Clear data"). Reconciling at app start and on every later change repairs such a divergence
+ * no matter which route produced it.
+ */
+@Singleton
+class UninstallWatcherControl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    @AppScope private val appScope: CoroutineScope,
+    private val packageManager: PackageManager,
+    private val settings: CorpseFinderSettings,
+    private val upgradeRepo: UpgradeRepo,
+) {
+
+    private val started = AtomicBoolean(false)
+
+    fun start() {
+        if (!started.compareAndSet(false, true)) return
+        log(TAG, VERBOSE) { "start()" }
+
+        combine(
+            settings.isWatcherEnabled.flow,
+            upgradeRepo.upgradeInfo,
+        ) { enabled, info ->
+            when {
+                !enabled -> false
+                info.isSettled && info.error == null -> info.isPro
+                // An entitlement that hasn't resolved yet, or whose lookup failed, is not an answer of
+                // "not pro" - acting on it would disable a paying user's receiver. Leave it untouched.
+                else -> null
+            }
+        }
+            .filterNotNull()
+            .catch {
+                // DataStoreValue.flow carries no catch and @AppScope has no CoroutineExceptionHandler,
+                // so an escaping throw here would kill the process at app start. No retry: a corrupt
+                // preferences file stays corrupt, the next launch tries again.
+                if (it.hasCause(CancellationException::class)) throw it
+                log(TAG, WARN) { "Reconciliation flow failed: ${it.asLog()}" }
+            }
+            .onEach { desired -> reconcile(desired) }
+            .launchIn(appScope)
+    }
+
+    private fun reconcile(desired: Boolean) {
+        try {
+            val component = ComponentName(context, UninstallWatcherReceiver::class.java)
+            // The receiver ships `enabled="false"`, so DEFAULT and DISABLED are the same outcome here.
+            val current = packageManager.isSelfComponentExplicitlyEnabled(component)
+            log(TAG, INFO) { "reconcile(): desired=$desired, current=$current, write=${desired != current}" }
+            if (desired == current) return
+            packageManager.toggleSelfComponent(component, desired)
+        } catch (e: Exception) {
+            log(TAG, WARN) { "reconcile($desired) failed: ${e.asLog()}" }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("CorpseFinder", "Watcher", "Uninstall", "Control")
+    }
+}

--- a/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/settings/CorpseFinderSettingsViewModel.kt
+++ b/app-tool-corpsefinder/src/main/java/eu/darken/sdmse/corpsefinder/ui/settings/CorpseFinderSettingsViewModel.kt
@@ -1,63 +1,35 @@
 package eu.darken.sdmse.corpsefinder.ui.settings
 
-import android.content.ComponentName
-import android.content.Context
-import android.content.pm.PackageManager
 import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.sdmse.common.access.AccessState
 import eu.darken.sdmse.common.compose.settings.FeatureGateState
 import eu.darken.sdmse.common.compose.settings.privilegedGateState
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.datastore.value
-import eu.darken.sdmse.common.debug.logging.Logging.Priority.INFO
-import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import eu.darken.sdmse.common.flow.combine
 import eu.darken.sdmse.common.navigation.routes.UpgradeRoute
-import eu.darken.sdmse.common.pkgs.toggleSelfComponent
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.uix.ViewModel4
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
 import eu.darken.sdmse.corpsefinder.core.CorpseFinder
 import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
-import eu.darken.sdmse.corpsefinder.core.watcher.UninstallWatcherReceiver
 import eu.darken.sdmse.setup.SetupModule
 import eu.darken.sdmse.setup.SetupRoute
 import eu.darken.sdmse.setup.SetupScreenOptions
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import javax.inject.Inject
 
 
 @HiltViewModel
 class CorpseFinderSettingsViewModel @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val packageManager: PackageManager,
     dispatcherProvider: DispatcherProvider,
     private val settings: CorpseFinderSettings,
     upgradeRepo: UpgradeRepo,
     corpseFinder: CorpseFinder,
     rootManager: RootManager,
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
-
-    init {
-        // Preserve legacy receiver side-effect: when the user toggles the watcher on/off,
-        // enable or disable the UninstallWatcherReceiver component. drop(1) skips the
-        // initial replay so we only react to user toggles, not the first flow emission.
-        settings.isWatcherEnabled.flow
-            .drop(1)
-            .onEach { enabled ->
-                packageManager.toggleSelfComponent(
-                    ComponentName(context, UninstallWatcherReceiver::class.java),
-                    enabled,
-                )
-                log(TAG, INFO) { "New uninstall watcher state: enabled=$enabled" }
-            }
-            .launchInViewModel()
-    }
 
     private data class FilterToggles(
         val sdcard: Boolean,

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/watcher/UninstallWatcherControlTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/core/watcher/UninstallWatcherControlTest.kt
@@ -1,0 +1,310 @@
+package eu.darken.sdmse.corpsefinder.core.watcher
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.sdmse.common.datastore.DataStoreValue
+import eu.darken.sdmse.common.debug.logging.Logging
+import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.corpsefinder.core.CorpseFinderSettings
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import testhelpers.coroutine.runTest2
+
+/**
+ * Drive the scheduler with `runCurrent()`, never `advanceUntilIdle()`. The coordinator collects on the
+ * scope it is handed, which is [TestScope.backgroundScope] here, and `advanceUntilIdle()` returns as soon
+ * as no *foreground* work is left - with the test body idle that is immediately, so the collector never
+ * even starts and every "no write happened" assertion passes for the wrong reason.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class UninstallWatcherControlTest : BaseTest() {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val component = ComponentName(context, UninstallWatcherReceiver::class.java)
+    private val logRecorder = LogRecorder()
+
+    @Before fun installLogRecorder() = Logging.install(logRecorder)
+
+    @After fun removeLogRecorder() = Logging.remove(logRecorder)
+
+    private class LogRecorder : Logging.Logger {
+        val entries = mutableListOf<Pair<Logging.Priority, String>>()
+        override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+            entries.add(priority to "$tag: $message")
+        }
+    }
+
+    /** A fresh mock per call: two Infos with the same content are non-equal, so MutableStateFlow won't conflate them. */
+    private fun info(
+        isPro: Boolean,
+        isSettled: Boolean = true,
+        error: Throwable? = null,
+    ): UpgradeRepo.Info = mockk<UpgradeRepo.Info>().apply {
+        every { this@apply.isPro } returns isPro
+        every { this@apply.isSettled } returns isSettled
+        every { this@apply.error } returns error
+    }
+
+    private class Harness(
+        val control: UninstallWatcherControl,
+        val packageManager: PackageManager,
+        val watcherFlow: MutableStateFlow<Boolean>,
+        val upgradeFlow: MutableStateFlow<UpgradeRepo.Info>,
+    )
+
+    private fun TestScope.harness(
+        isWatcherEnabled: Boolean = true,
+        entitlement: UpgradeRepo.Info = info(isPro = true),
+        componentState: Int = PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+        writeFails: Boolean = false,
+        watcherSource: Flow<Boolean>? = null,
+    ): Harness {
+        val watcherFlow = MutableStateFlow(isWatcherEnabled)
+        val upgradeFlow = MutableStateFlow(entitlement)
+        val watcherValue = mockk<DataStoreValue<Boolean>>().apply {
+            every { flow } returns (watcherSource ?: watcherFlow)
+        }
+        val settings = mockk<CorpseFinderSettings>().apply {
+            every { this@apply.isWatcherEnabled } returns watcherValue
+        }
+        val upgradeRepo = mockk<UpgradeRepo>().apply {
+            every { upgradeInfo } returns upgradeFlow
+        }
+        val packageManager = mockk<PackageManager>(relaxed = true).apply {
+            every { getComponentEnabledSetting(component) } returns componentState
+            if (writeFails) {
+                every { setComponentEnabledSetting(any(), any(), any()) } throws RuntimeException("ROM said no")
+            }
+        }
+        val control = UninstallWatcherControl(
+            context = context,
+            // The test scope as @AppScope: an exception escaping the collector fails the test.
+            appScope = backgroundScope,
+            packageManager = packageManager,
+            settings = settings,
+            upgradeRepo = upgradeRepo,
+        )
+        return Harness(control, packageManager, watcherFlow, upgradeFlow)
+    }
+
+    private fun Harness.verifyWrites(enabled: Int = 0, disabled: Int = 0) {
+        verify(exactly = enabled) {
+            packageManager.setComponentEnabledSetting(
+                component,
+                PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                PackageManager.DONT_KILL_APP,
+            )
+        }
+        verify(exactly = disabled) {
+            packageManager.setComponentEnabledSetting(
+                component,
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                PackageManager.DONT_KILL_APP,
+            )
+        }
+    }
+
+    @Test
+    fun `a disabled component is enabled for a pro user who wants the watcher`() = runTest2 {
+        val h = harness(
+            isWatcherEnabled = true,
+            entitlement = info(isPro = true),
+            componentState = PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+        )
+
+        h.control.start()
+        runCurrent()
+
+        h.verifyWrites(enabled = 1)
+    }
+
+    @Test
+    fun `an already enabled component is left alone`() = runTest2 {
+        val h = harness(
+            isWatcherEnabled = true,
+            entitlement = info(isPro = true),
+            componentState = PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+        )
+
+        h.control.start()
+        runCurrent()
+
+        verify(exactly = 0) { h.packageManager.setComponentEnabledSetting(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a component at its manifest default is enabled for a pro user who wants the watcher`() = runTest2 {
+        val h = harness(
+            isWatcherEnabled = true,
+            entitlement = info(isPro = true),
+            componentState = PackageManager.COMPONENT_ENABLED_STATE_DEFAULT,
+        )
+
+        h.control.start()
+        runCurrent()
+
+        h.verifyWrites(enabled = 1)
+    }
+
+    @Test
+    fun `an enabled component is disabled when the watcher preference is off`() = runTest2 {
+        val h = harness(
+            isWatcherEnabled = false,
+            entitlement = info(isPro = true),
+            componentState = PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+        )
+
+        h.control.start()
+        runCurrent()
+
+        h.verifyWrites(disabled = 1)
+    }
+
+    @Test
+    fun `an unsettled entitlement leaves the component untouched`() = runTest2 {
+        val h = harness(
+            isWatcherEnabled = true,
+            entitlement = info(isPro = false, isSettled = false),
+            componentState = PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+        )
+
+        h.control.start()
+        runCurrent()
+
+        verify(exactly = 0) { h.packageManager.setComponentEnabledSetting(any(), any(), any()) }
+    }
+
+    @Test
+    fun `a settled entitlement carrying an error leaves the component untouched`() = runTest2 {
+        val h = harness(
+            isWatcherEnabled = true,
+            entitlement = info(isPro = false, isSettled = true, error = IllegalStateException("cache read failed")),
+            componentState = PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+        )
+
+        h.control.start()
+        runCurrent()
+
+        verify(exactly = 0) { h.packageManager.setComponentEnabledSetting(any(), any(), any()) }
+    }
+
+    @Test
+    fun `an enabled component is disabled for a confirmed non-pro user`() = runTest2 {
+        val h = harness(
+            isWatcherEnabled = true,
+            entitlement = info(isPro = false),
+            componentState = PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+        )
+
+        h.control.start()
+        runCurrent()
+
+        h.verifyWrites(disabled = 1)
+    }
+
+    @Test
+    fun `an entitlement that settles as pro after start enables the component`() = runTest2 {
+        val h = harness(
+            isWatcherEnabled = true,
+            entitlement = info(isPro = false, isSettled = false),
+            componentState = PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+        )
+
+        h.control.start()
+        runCurrent()
+        verify(exactly = 0) { h.packageManager.setComponentEnabledSetting(any(), any(), any()) }
+
+        h.upgradeFlow.value = info(isPro = true)
+        runCurrent()
+
+        h.verifyWrites(enabled = 1)
+    }
+
+    @Test
+    fun `an entitlement that is lost after start disables the component`() = runTest2 {
+        val h = harness(
+            isWatcherEnabled = true,
+            entitlement = info(isPro = true),
+            componentState = PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+        )
+
+        h.control.start()
+        runCurrent()
+        verify(exactly = 0) { h.packageManager.setComponentEnabledSetting(any(), any(), any()) }
+
+        h.upgradeFlow.value = info(isPro = false)
+        runCurrent()
+
+        h.verifyWrites(disabled = 1)
+    }
+
+    @Test
+    fun `a watcher preference change after start reconciles`() = runTest2 {
+        val h = harness(
+            isWatcherEnabled = false,
+            entitlement = info(isPro = true),
+            componentState = PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+        )
+
+        h.control.start()
+        runCurrent()
+        verify(exactly = 0) { h.packageManager.setComponentEnabledSetting(any(), any(), any()) }
+
+        h.watcherFlow.value = true
+        runCurrent()
+
+        h.verifyWrites(enabled = 1)
+    }
+
+    @Test
+    fun `a failed write is retried by the next emission carrying the same desired state`() = runTest2 {
+        val h = harness(
+            isWatcherEnabled = true,
+            entitlement = info(isPro = true),
+            componentState = PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+            writeFails = true,
+        )
+
+        h.control.start()
+        runCurrent()
+
+        // Same desired state, different Info instance: a dedup on the desired value would swallow this.
+        h.upgradeFlow.value = info(isPro = true)
+        runCurrent()
+
+        h.verifyWrites(enabled = 2)
+    }
+
+    @Test
+    fun `a throwing settings flow is contained and logged`() = runTest2 {
+        val h = harness(
+            watcherSource = flow { throw IllegalStateException("corrupt preferences") },
+        )
+
+        h.control.start()
+        runCurrent()
+
+        verify(exactly = 0) { h.packageManager.setComponentEnabledSetting(any(), any(), any()) }
+        logRecorder.entries.any {
+            it.first == Logging.Priority.WARN && it.second.startsWith("SDMSE:CorpseFinder:Watcher:Uninstall:Control:")
+        } shouldBe true
+    }
+}

--- a/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/settings/CorpseFinderSettingsViewModelTest.kt
+++ b/app-tool-corpsefinder/src/test/java/eu/darken/sdmse/corpsefinder/ui/settings/CorpseFinderSettingsViewModelTest.kt
@@ -1,7 +1,5 @@
 package eu.darken.sdmse.corpsefinder.ui.settings
 
-import android.content.Context
-import android.content.pm.PackageManager
 import eu.darken.sdmse.common.access.AccessState
 import eu.darken.sdmse.common.datastore.DataStoreValue
 import eu.darken.sdmse.common.progress.Progress
@@ -15,7 +13,6 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
-import io.mockk.verify
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -73,8 +70,6 @@ class CorpseFinderSettingsViewModelTest : BaseTest() {
 
     private class Harness(
         val vm: CorpseFinderSettingsViewModel,
-        val context: Context,
-        val packageManager: PackageManager,
         val settings: CorpseFinderSettings,
         val values: Values,
         val watcherFlow: MutableStateFlow<Boolean>,
@@ -100,10 +95,6 @@ class CorpseFinderSettingsViewModelTest : BaseTest() {
         rootAccess: AccessState = AccessState.Undecided,
         cfState: CorpseFinder.State = cfState(),
     ): Harness {
-        val context = mockk<Context>().apply {
-            every { packageName } returns "eu.darken.sdmse.corpsefinder.test"
-        }
-        val packageManager = mockk<PackageManager>(relaxed = true)
         val watcherFlow = MutableStateFlow(isWatcherEnabled)
         val values = Values(
             isWatcherEnabled = rwDataStoreValue(isWatcherEnabled, watcherFlow),
@@ -149,15 +140,13 @@ class CorpseFinderSettingsViewModelTest : BaseTest() {
             every { accessState } returns flowOf(rootAccess)
         }
         val vm = CorpseFinderSettingsViewModel(
-            context = context,
-            packageManager = packageManager,
             dispatcherProvider = TestDispatcherProvider(),
             settings = settings,
             upgradeRepo = upgradeRepo,
             corpseFinder = corpseFinder,
             rootManager = rootManager,
         )
-        return Harness(vm, context, packageManager, settings, values, watcherFlow)
+        return Harness(vm, settings, values, watcherFlow)
     }
 
     @Test
@@ -308,24 +297,4 @@ class CorpseFinderSettingsViewModelTest : BaseTest() {
         coVerify(exactly = 1) { h.values.isWatcherAutoDeleteEnabled.update(capture(captured)) }
         captured.captured(true) shouldBe false
     }
-
-    @Test
-    fun `init does not toggle watcher receiver for the initial flow replay`() = runTest2 {
-        val h = harness(isWatcherEnabled = false)
-
-        // VM init subscribes to isWatcherEnabled.flow with drop(1). The initial replay must NOT
-        // trigger the receiver toggle, even after the test scope drains.
-        advanceUntilIdle()
-
-        verify(exactly = 0) { h.packageManager.setComponentEnabledSetting(any(), any(), any()) }
-    }
-
-    // NOTE: A full assertion that subsequent flow emissions DO toggle the receiver isn't possible
-    // under stock JVM tests because the production code constructs `ComponentName(context, ...)`
-    // and ComponentName's constructor + hashCode() are stubbed (throw "Stub!") in android.jar
-    // without Robolectric. Moving the test to a Robolectric class would force JUnit 4 lifecycle
-    // annotations that conflict with the JUnit 5 + BaseTest pattern used elsewhere here. The
-    // drop(1) behaviour is still covered by the test above; user-driven writes through
-    // setWatcherEnabled are covered by `setWatcherEnabled writes through when pro`.
-
 }

--- a/app/src/main/java/eu/darken/sdmse/App.kt
+++ b/app/src/main/java/eu/darken/sdmse/App.kt
@@ -28,6 +28,7 @@ import eu.darken.sdmse.common.debug.recorder.core.RecorderModule
 import eu.darken.sdmse.common.storage.StorageRescue
 import eu.darken.sdmse.common.updater.UpdateService
 import eu.darken.sdmse.common.upgrade.UpgradeRepo
+import eu.darken.sdmse.corpsefinder.core.watcher.UninstallWatcherControl
 import eu.darken.sdmse.main.core.CurriculumVitae
 import eu.darken.sdmse.main.core.GeneralSettings
 import eu.darken.sdmse.main.core.shortcuts.ShortcutManager
@@ -66,6 +67,7 @@ open class App : Application(), Configuration.Provider {
     @Inject lateinit var taskResultNotifier: TaskResultNotifier
     @Inject lateinit var storageRescue: StorageRescue
     @Inject lateinit var widgetRefreshCoordinator: WidgetRefreshCoordinator
+    @Inject lateinit var uninstallWatcherControl: UninstallWatcherControl
     @Inject lateinit var upgradeRepo: UpgradeRepo
 
     private val logCatLogger = LogCatLogger()
@@ -125,6 +127,7 @@ open class App : Application(), Configuration.Provider {
         appScope.launch { upgradeRepo.onAppStart() }
         lowSpaceMonitor.start(appScope)
         widgetRefreshCoordinator.start()
+        uninstallWatcherControl.start()
 
         val oldHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->


### PR DESCRIPTION
## What changed

The uninstall watcher could show as enabled in CorpseFinder's settings while doing nothing at all. Uninstalling an app would not trigger a scan for leftovers, and nothing surfaced that anything was wrong.

This happened whenever the setting became enabled without the CorpseFinder settings screen being open to observe it: restoring a backup, transferring to a new device, or importing a config file. Re-opening the settings screen did not repair it either. Only switching the watcher off and back on did.

The app now checks this at every start and repairs it, so a restored or transferred install actually behaves the way the switch says it does. "Clear data" is covered too, where the reverse happened: the setting was reset while the watcher stayed live.

## Technical Context

- Root cause: `UninstallWatcherReceiver` ships `android:enabled="false"`, and its enabled state was written from exactly one place, the `init` block of `CorpseFinderSettingsViewModel`, which observed the setting with `.drop(1)`. Three routes move the stored flag while that screen is not alive: Auto Backup / device transfer, the in-app config restore (which writes preference keys straight through `dataStore.edit`), and "Clear data", which resets the flag while the component setting persists in package restrictions.
- Why a process-scoped coordinator rather than the narrower options: a compare-then-write at app start covers all three routes at once and repairs installs that have already diverged. Excluding the key from backup was rejected because the user's intent should survive a device transfer and exclusion fixes nothing already broken; routing the in-app restore through the setter was rejected as a per-tool special case in a deliberately generic backup contributor.
- The reconciled state is `isPro && isWatcherEnabled`, the same expression the settings switch renders and the same condition `setWatcherEnabled` enforces. Reconciling on the stored flag alone would produce the inverse divergence, leaving a live receiver behind a switch reading OFF after a restore onto a non-Pro install.
- Worth close review: an entitlement emission is acted on only when `isSettled && error == null`. A settled `Info` is not a determined one. `UpgradeRepoFoss.Info.isSettled` is hardcoded `true` and its cache-failure path emits `isPro=false, isSettled=true, error!=null` at cold start, with GPlay's retry fallback taking the same shape, so treating that as a confirmed negative would disable a paying user's working receiver because a lookup failed. `isProSettled` already fails open on `error != null` for the same reason.
- Two deliberate omissions in the new flow: no `distinctUntilChanged` over the desired value, so a PackageManager write that throws is retried by the next emission instead of being filtered out, and the `catch` logs once without resubscribing, since `DataStoreValue.flow` carries no catch of its own and `AppCoroutineScope` has no `CoroutineExceptionHandler`, which would otherwise turn a corrupt preferences file into a launch crash.
