### PR TITLE
AppControl: Allow cancelling a scan and show its progress

### DIFF
--- a/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/progress/ProgressExtensions.kt
@@ -9,6 +9,7 @@ import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.EmptyCoroutineContext
 
 fun <T : Progress.Client> T.updateProgressPrimary(primary: String) {
@@ -114,10 +116,12 @@ suspend fun <T : Progress.Host, R> T.withProgress(
     return try {
         action()
     } finally {
-        forwardingJob.cancelAndJoin()
-        scope.cancel("Finished scope")
-        // Flow's onCompletion doesn't restore because isActive is false after cancellation
-        client.updateProgress { onCompletion(it) }
+        withContext(NonCancellable) {
+            forwardingJob.cancelAndJoin()
+            scope.cancel("Finished scope")
+            // Flow's onCompletion doesn't restore because isActive is false after cancellation
+            client.updateProgress { onCompletion(it) }
+        }
     }
 }
 

--- a/app-common/src/test/java/eu/darken/sdmse/common/progress/WithProgressCancellationTest.kt
+++ b/app-common/src/test/java/eu/darken/sdmse/common/progress/WithProgressCancellationTest.kt
@@ -1,0 +1,61 @@
+package eu.darken.sdmse.common.progress
+
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class WithProgressCancellationTest : BaseTest() {
+
+    private class FakeHost(override val progress: Flow<Progress.Data?>) : Progress.Host
+
+    private class RecordingClient : Progress.Client {
+        @Volatile
+        var current: Progress.Data? = null
+            private set
+
+        override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {
+            synchronized(this) { current = update(current) }
+        }
+    }
+
+    @Test
+    fun `cancelling the caller still restores the client progress`() = runTest2 {
+        withContext(Dispatchers.Default) {
+            val hostProgress = Progress.Data(extra = "host-progress")
+            val restored = Progress.Data(extra = "restored")
+
+            val client = RecordingClient()
+            val host = FakeHost(MutableStateFlow(hostProgress))
+            val actionStarted = CompletableDeferred<Unit>()
+
+            val job = launch {
+                host.withProgress(client, onCompletion = { restored }) {
+                    actionStarted.complete(Unit)
+                    awaitCancellation()
+                }
+            }
+            actionStarted.await()
+
+            job.cancelAndJoin()
+
+            withClue(
+                "withProgress() did not restore the client after the caller was cancelled, it is left holding " +
+                    "the host's last forwarded progress. The finally block is cancellable, so " +
+                    "forwardingJob.cancelAndJoin() throws CancellationException on an already-cancelled caller " +
+                    "and neither scope.cancel() nor the restoring updateProgress() ever run."
+            ) {
+                client.current?.extra shouldBe restored.extra
+            }
+        }
+    }
+}

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
@@ -151,34 +151,43 @@ class AppControl @Inject constructor(
         log(TAG, VERBOSE) { "performScan(): $task" }
         updateProgressPrimary(eu.darken.sdmse.common.R.string.general_progress_loading_app_data)
 
+        // Kept so a cancelled scan can hand the list back what it was already showing instead of
+        // the empty placeholder. An initial scan has nothing to restore, which is correct.
+        val previousData = internalData.value
         internalData.value = null
 
-        if (!appInventorySetupModule.isComplete()) {
-            log(TAG, WARN) { "SetupModule INVENTORY is not complete" }
-            throw IncompleteSetupException(SetupModule.Type.INVENTORY)
-        }
+        try {
+            if (!appInventorySetupModule.isComplete()) {
+                log(TAG, WARN) { "SetupModule INVENTORY is not complete" }
+                throw IncompleteSetupException(SetupModule.Type.INVENTORY)
+            }
 
-        val curState = state.first()
+            val curState = state.first()
 
-        val appInfos = appScan.withProgress(this) {
-            if (task.refreshPkgCache) refresh()
-            allApps(
-                user = if (task.includeMultiUser) null else userManager.currentUser().handle,
-                includeActive = task.loadInfoActive && curState.canInfoActive,
-                includeSize = task.loadInfoSize && curState.canInfoSize,
-                includeUsage = task.loadInfoScreenTime && curState.canInfoScreenTime,
+            val appInfos = appScan.withProgress(this) {
+                if (task.refreshPkgCache) refresh()
+                allApps(
+                    user = if (task.includeMultiUser) null else userManager.currentUser().handle,
+                    includeActive = task.loadInfoActive && curState.canInfoActive,
+                    includeSize = task.loadInfoSize && curState.canInfoSize,
+                    includeUsage = task.loadInfoScreenTime && curState.canInfoScreenTime,
+                )
+            }
+
+            internalData.value = Data(
+                apps = appInfos,
+                hasInfoScreenTime = task.loadInfoScreenTime && curState.canInfoScreenTime,
+                hasInfoActive = task.loadInfoActive && curState.canInfoActive,
+                hasInfoSize = task.loadInfoSize && curState.canInfoSize,
+                hasIncludedMultiUser = task.includeMultiUser && curState.canIncludeMultiUser,
             )
+
+            return AppControlScanTask.Result(itemCount = appInfos.size)
+        } catch (e: CancellationException) {
+            log(TAG, INFO) { "performScan(): Cancelled, restoring the previous data" }
+            internalData.value = previousData
+            throw e
         }
-
-        internalData.value = Data(
-            apps = appInfos,
-            hasInfoScreenTime = task.loadInfoScreenTime && curState.canInfoScreenTime,
-            hasInfoActive = task.loadInfoActive && curState.canInfoActive,
-            hasInfoSize = task.loadInfoSize && curState.canInfoSize,
-            hasIncludedMultiUser = task.includeMultiUser && curState.canIncludeMultiUser,
-        )
-
-        return AppControlScanTask.Result(itemCount = appInfos.size)
     }
 
     private suspend fun performToggle(task: AppControlToggleTask): AppControlToggleTask.Result {

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppControl.kt
@@ -160,7 +160,7 @@ class AppControl @Inject constructor(
 
         val curState = state.first()
 
-        val appInfos = appScan.run {
+        val appInfos = appScan.withProgress(this) {
             if (task.refreshPkgCache) refresh()
             allApps(
                 user = if (task.includeMultiUser) null else userManager.currentUser().handle,

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
@@ -3,11 +3,13 @@ package eu.darken.sdmse.appcontrol.core
 import eu.darken.sdmse.appcontrol.core.archive.ArchiveSupport
 import eu.darken.sdmse.appcontrol.core.usage.UsageInfo
 import eu.darken.sdmse.appcontrol.core.usage.UsageTool
+import eu.darken.sdmse.common.ca.toCaString
 import eu.darken.sdmse.common.coroutine.AppScope
 import eu.darken.sdmse.common.coroutine.DispatcherProvider
 import eu.darken.sdmse.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.sdmse.common.debug.logging.log
 import eu.darken.sdmse.common.debug.logging.logTag
+import eu.darken.sdmse.common.flow.throttleLatest
 import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.PkgRepo
 import eu.darken.sdmse.common.pkgs.container.NormalPkg
@@ -17,8 +19,6 @@ import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.features.SourceAvailable
 import eu.darken.sdmse.common.pkgs.isArchived
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
-import eu.darken.sdmse.common.ca.toCaString
-import eu.darken.sdmse.common.flow.throttleLatest
 import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.progress.increaseProgress
 import eu.darken.sdmse.common.progress.updateProgressCount
@@ -30,6 +30,8 @@ import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.common.user.UserProfile2
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
@@ -143,6 +145,9 @@ class AppScan @Inject constructor(
         }
 
         pkgs.map { pkg ->
+            // Nothing in this loop is guaranteed to suspend, so without this a cancel can only land
+            // once every package has been processed.
+            currentCoroutineContext().ensureActive()
             // Package name, not Pkg.label: NormalPkg.label resolves through the PackageManager and
             // the overlay resolves `secondary` on the composition thread.
             updateProgressSecondary(pkg.packageName)

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
@@ -17,6 +17,12 @@ import eu.darken.sdmse.common.pkgs.features.Installed
 import eu.darken.sdmse.common.pkgs.features.SourceAvailable
 import eu.darken.sdmse.common.pkgs.isArchived
 import eu.darken.sdmse.common.pkgs.pkgops.PkgOps
+import eu.darken.sdmse.common.ca.toCaString
+import eu.darken.sdmse.common.flow.throttleLatest
+import eu.darken.sdmse.common.progress.Progress
+import eu.darken.sdmse.common.progress.increaseProgress
+import eu.darken.sdmse.common.progress.updateProgressCount
+import eu.darken.sdmse.common.progress.updateProgressSecondary
 import eu.darken.sdmse.common.sharedresource.HasSharedResource
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.sharedresource.adoptChildResource
@@ -24,9 +30,12 @@ import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.common.user.UserProfile2
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.sync.Mutex
@@ -41,9 +50,16 @@ class AppScan @Inject constructor(
     private val usageTool: UsageTool,
     private val userManager: UserManager2,
     private val archiveSupport: ArchiveSupport,
-) : HasSharedResource<Any> {
+) : HasSharedResource<Any>, Progress.Host, Progress.Client {
 
     override val sharedResource = SharedResource.createKeepAlive(PkgOps.TAG, appScope + dispatcherProvider.IO)
+
+    private val progressPub = MutableStateFlow<Progress.Data?>(restingProgress())
+    override val progress: Flow<Progress.Data?> = progressPub.throttleLatest(250)
+
+    override fun updateProgress(update: (Progress.Data?) -> Progress.Data?) {
+        progressPub.value = update(progressPub.value)
+    }
 
     private val mutex = Mutex()
     private var activeCache: Map<InstallId, Boolean?>? = null
@@ -53,7 +69,12 @@ class AppScan @Inject constructor(
 
     private suspend fun <T> doRun(action: suspend () -> T): T = mutex.withLock {
         adoptChildResource(pkgOps.sharedResource)
-        action()
+        progressPub.value = restingProgress()
+        try {
+            action()
+        } finally {
+            progressPub.value = restingProgress()
+        }
     }
 
     suspend fun refresh() = doRun {
@@ -103,23 +124,36 @@ class AppScan @Inject constructor(
         log(TAG, VERBOSE) { "allApps(user=$user)" }
         val pkgs = pkgRepo.current().filter { user == null || it.userHandle == user }
 
-        if (includeSize && sizeCache == null) {
+        val runSizeSweep = includeSize && sizeCache == null
+        // One counter spanning both phases: two Percent(pkgs.size) counters under the same label
+        // would run 0-100 twice and read as the scan restarting.
+        updateProgressCount(Progress.Count.Percent(if (runSizeSweep) pkgs.size * 2 else pkgs.size))
+
+        if (runSizeSweep) {
             sizeCache = pkgs
                 .map { it.installId }
                 .asFlow()
                 .flatMapMerge(4) {
                     flow { emit(it to pkgOps.querySizeStats(it)) }
                 }
+                // After the merge, so the read-modify-write runs in the collecting coroutine
+                // instead of racing across the four producers.
+                .onEach { increaseProgress() }
                 .toList().associate { (id, size) -> id to size }
         }
 
-        pkgs.map {
-            it.toAppInfo(
+        pkgs.map { pkg ->
+            // Package name, not Pkg.label: NormalPkg.label resolves through the PackageManager and
+            // the overlay resolves `secondary` on the composition thread.
+            updateProgressSecondary(pkg.packageName)
+            val appInfo = pkg.toAppInfo(
                 includeUsage = includeUsage,
                 includeActive = includeActive,
                 includeSize = includeSize,
                 includeUserProfiles = user == null,
             )
+            increaseProgress()
+            appInfo
         }.toSet()
     }
 
@@ -170,6 +204,14 @@ class AppScan @Inject constructor(
     )
 
     companion object {
+        /**
+         * What the publisher holds between runs. Never null and never a finished count: the
+         * forwarder started by `withProgress` replays whatever is in there as its first emission.
+         */
+        private fun restingProgress() = Progress.Data(
+            primary = eu.darken.sdmse.common.R.string.general_progress_loading_app_data.toCaString(),
+        )
+
         private val TAG = logTag("AppControl", "AppScan")
     }
 }

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/core/AppScan.kt
@@ -103,7 +103,7 @@ class AppScan @Inject constructor(
         log(TAG, VERBOSE) { "allApps(user=$user)" }
         val pkgs = pkgRepo.current().filter { user == null || it.userHandle == user }
 
-        if (sizeCache == null) {
+        if (includeSize && sizeCache == null) {
             sizeCache = pkgs
                 .map { it.installId }
                 .asFlow()

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
@@ -184,6 +184,7 @@ fun AppControlListScreenHost(
         onExportSelected = vm::onExportRequested,
         onShareSelected = vm::onShareList,
         onRefresh = { vm.onRefresh(refreshPkgCache = true) },
+        onCancel = vm::onCancel,
     )
 
     pendingConfirm?.let { ev ->
@@ -325,6 +326,7 @@ internal fun AppControlListScreen(
     onExportSelected: (Set<InstallId>) -> Unit = {},
     onShareSelected: (Set<InstallId>) -> Unit = {},
     onRefresh: () -> Unit = {},
+    onCancel: () -> Unit = {},
 ) {
     val state by stateSource.collectAsStateWithLifecycle()
     val rows = state.rows
@@ -484,18 +486,29 @@ internal fun AppControlListScreen(
                                 )
                             },
                             actions = {
-                                if (!searchActive && !isBusy) {
-                                    SdmTooltipIconButton(
-                                        icon = Icons.TwoTone.Search,
-                                        label = stringResource(CommonR.string.general_search_action),
-                                        onClick = { searchActive = true },
-                                        modifier = Modifier.guidedTourTarget(AppControlListTour.SEARCH_TARGET),
+                                when {
+                                    // Not gated on !searchActive: a scan can start while search is
+                                    // open (a sort change that needs data the snapshot lacks), and
+                                    // that scan has to stay cancellable.
+                                    isBusy -> SdmTooltipIconButton(
+                                        icon = Icons.TwoTone.Close,
+                                        label = stringResource(CommonR.string.general_cancel_action),
+                                        onClick = onCancel,
                                     )
-                                    SdmTooltipIconButton(
-                                        icon = Icons.TwoTone.Refresh,
-                                        label = stringResource(CommonR.string.general_refresh_action),
-                                        onClick = onRefresh,
-                                    )
+
+                                    !searchActive -> {
+                                        SdmTooltipIconButton(
+                                            icon = Icons.TwoTone.Search,
+                                            label = stringResource(CommonR.string.general_search_action),
+                                            onClick = { searchActive = true },
+                                            modifier = Modifier.guidedTourTarget(AppControlListTour.SEARCH_TARGET),
+                                        )
+                                        SdmTooltipIconButton(
+                                            icon = Icons.TwoTone.Refresh,
+                                            label = stringResource(CommonR.string.general_refresh_action),
+                                            onClick = onRefresh,
+                                        )
+                                    }
                                 }
                             },
                         )

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreen.kt
@@ -670,6 +670,19 @@ internal fun AppControlListScreen(
                 modifier = Modifier.fillMaxSize(),
             ) {
                 when {
+                    rows == null && state.cancelRequested -> Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(32.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = stringResource(R.string.appcontrol_list_scan_cancelled_label),
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+
                     rows == null -> Box(modifier = Modifier.fillMaxSize())
 
                     rows.isEmpty() -> Box(

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -45,6 +45,7 @@ import eu.darken.sdmse.common.upgrade.isProForUi
 import eu.darken.sdmse.exclusion.core.ExclusionManager
 import eu.darken.sdmse.exclusion.core.types.PkgExclusion
 import eu.darken.sdmse.exclusion.ui.ExclusionsListRoute
+import eu.darken.sdmse.main.core.SDMTool
 import eu.darken.sdmse.main.core.taskmanager.TaskSubmitter
 import eu.darken.sdmse.setup.IncompleteSetupException
 import eu.darken.sdmse.setup.SetupBinding
@@ -334,6 +335,11 @@ class AppControlListViewModel @Inject constructor(
     fun onRefresh(refreshPkgCache: Boolean = false) = launch {
         log(TAG) { "onRefresh($refreshPkgCache)" }
         taskManager.submit(buildScanTask(refreshPkgCache))
+    }
+
+    fun onCancel() {
+        log(TAG, INFO) { "onCancel()" }
+        taskManager.cancel(SDMTool.Type.APPCONTROL)
     }
 
     private suspend fun refresh() = taskManager.submit(buildScanTask())

--- a/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
+++ b/app-tool-appcontrol/src/main/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListViewModel.kt
@@ -76,6 +76,10 @@ class AppControlListViewModel @Inject constructor(
     @SetupBinding(SetupModule.Type.STORAGE) private val storageSetupModule: SetupModule,
 ) : ViewModel4(dispatcherProvider, tag = TAG) {
 
+    // A scan cancelled before any data existed leaves rows == null with no progress, which is
+    // otherwise indistinguishable from cold start. Cleared on every new scan submission.
+    private val cancelRequested = MutableStateFlow(false)
+
     init {
         // Start an initial scan if AppControl has no data yet. AppControl is the entry point for
         // Dashboard, the launcher shortcut, and ExclusionList's "Add Pkg Exclusion" FAB — so the
@@ -84,7 +88,7 @@ class AppControlListViewModel @Inject constructor(
         launch {
             val initState = appControl.state.first()
             if (initState.data != null) return@launch
-            taskManager.submit(buildScanTask())
+            submitScan()
         }
         // Reset a persisted sort whose required setup has been revoked (e.g. usage access
         // permission removed while sorted by screen time), otherwise the stale mode wedges
@@ -168,10 +172,11 @@ class AppControlListViewModel @Inject constructor(
     val state: StateFlow<State> = combine(
         rowsState,
         appControl.progress,
-    ) { base, progress ->
+        cancelRequested,
+    ) { base, progress, cancelled ->
         // Outer combine: progress ticks must not invalidate the row pipeline above (which would
         // re-sort and flash the loading overlay).
-        base.copy(progress = progress)
+        base.copy(progress = progress, cancelRequested = cancelled)
     }
         .safeStateIn(initialValue = State(), onError = { State() })
 
@@ -334,15 +339,21 @@ class AppControlListViewModel @Inject constructor(
 
     fun onRefresh(refreshPkgCache: Boolean = false) = launch {
         log(TAG) { "onRefresh($refreshPkgCache)" }
-        taskManager.submit(buildScanTask(refreshPkgCache))
+        submitScan(refreshPkgCache)
     }
 
     fun onCancel() {
         log(TAG, INFO) { "onCancel()" }
+        cancelRequested.value = true
         taskManager.cancel(SDMTool.Type.APPCONTROL)
     }
 
-    private suspend fun refresh() = taskManager.submit(buildScanTask())
+    private suspend fun refresh() = submitScan()
+
+    private suspend fun submitScan(refreshPkgCache: Boolean = false) {
+        cancelRequested.value = false
+        taskManager.submit(buildScanTask(refreshPkgCache))
+    }
 
     private suspend fun buildScanTask(refreshPkgCache: Boolean = false) = AppControlScanTask(
         refreshPkgCache = refreshPkgCache,
@@ -530,6 +541,7 @@ class AppControlListViewModel @Inject constructor(
         val allowActionRestore: Boolean = false,
         val sizeSortModuleEnabled: Boolean = false,
         val allowFilterActive: Boolean = false,
+        val cancelRequested: Boolean = false,
     )
 
     data class Row(

--- a/app-tool-appcontrol/src/main/res/values/strings.xml
+++ b/app-tool-appcontrol/src/main/res/values/strings.xml
@@ -37,6 +37,7 @@
     <string name="appcontrol_list_sortmode_size_label">Size</string>
     <string name="appcontrol_list_sortmode_screentime_label">Screen time</string>
     <string name="appcontrol_list_sortmode_size_caveat_msg">App sizes are estimated for performance reasons. Use the StorageAnalyzer tool for more accurate data.</string>
+    <string name="appcontrol_list_scan_cancelled_label">Scan cancelled, no apps were loaded.</string>
     <string name="appcontrol_progress_uninstalling_app">Uninstalling app</string>
     <plurals name="appcontrol_uninstall_result_message_x">
         <item quantity="one">%d app was uninstalled</item>

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppControlTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppControlTest.kt
@@ -34,12 +34,16 @@ import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -328,6 +332,31 @@ class AppControlTest : BaseTest() {
 
         // canInfoActive=false → AND collapses to false.
         includeActiveSlot.captured shouldBe false
+    }
+
+    // ─────────────────────────── cancelled scan ───────────────────────────
+
+    @Test
+    fun `a cancelled scan restores the data the list was already showing`() = runTest2 {
+        // performScan clears the data before scanning, so at the moment a cancel lands the tool
+        // holds nothing and the list falls back to its empty placeholder. Cancelling a Refresh must
+        // not destroy the list the user already had.
+        val setup = setupAppControl(appsReturnedByScan = setOf(installedApp("eu.thlab.first")))
+
+        setup.appControl.submit(buildScanTask())
+        val before = setup.appControl.dataFromState()!!
+
+        val scanStarted = CompletableDeferred<Unit>()
+        coEvery { setup.appScan.allApps(any(), any(), any(), any()) } coAnswers {
+            scanStarted.complete(Unit)
+            awaitCancellation()
+        }
+
+        val job = launch { setup.appControl.submit(buildScanTask()) }
+        scanStarted.await()
+        job.cancelAndJoin()
+
+        setup.appControl.dataFromState() shouldBe before
     }
 
     // ─────────────────────────── export batch resilience ───────────────────────────

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppControlTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppControlTest.kt
@@ -18,6 +18,7 @@ import eu.darken.sdmse.common.pkgs.Pkg
 import eu.darken.sdmse.common.pkgs.features.InstallDetails
 import eu.darken.sdmse.common.pkgs.features.InstallId
 import eu.darken.sdmse.common.pkgs.features.Installed
+import eu.darken.sdmse.common.progress.Progress
 import eu.darken.sdmse.common.root.RootManager
 import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.user.UserHandle2
@@ -102,6 +103,8 @@ class AppControlTest : BaseTest() {
     ): Setup {
         val appScan = mockk<AppScan>().apply {
             every { sharedResource } returns SharedResource.createKeepAlive("appScan", keepAliveScope)
+            // performScan forwards the scanner's progress, so the strict mock has to answer it.
+            every { progress } returns flowOf(Progress.Data())
             coEvery { allApps(any(), any(), any(), any()) } returns appsReturnedByScan
             coJustRun { refresh() }
         }

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppScanTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppScanTest.kt
@@ -92,6 +92,27 @@ class AppScanTest : BaseTest() {
     }
 
     @Test
+    fun `a scan without sizing does not run the bulk prefetch`() = runTest2 {
+        val harness = harness(listOf(pkg("eu.thlab.one"), pkg("eu.thlab.two")))
+
+        harness.appScan.allApps(user = null, includeUsage = false, includeActive = false, includeSize = false)
+
+        coVerify(exactly = 0) { harness.pkgOps.querySizeStats(any(), any()) }
+    }
+
+    @Test
+    fun `a sizeless scan does not poison the cache for a later sizing scan`() = runTest2 {
+        val target = pkg("eu.thlab.target")
+        val targetId = target.installId
+        val harness = harness(listOf(target))
+
+        harness.appScan.allApps(user = null, includeUsage = false, includeActive = false, includeSize = false)
+        harness.appScan.allApps(user = null, includeUsage = false, includeActive = false, includeSize = true)
+
+        coVerify(exactly = 1) { harness.pkgOps.querySizeStats(targetId, any()) }
+    }
+
+    @Test
     fun `a size the bulk prefetch stored as null is not queried again`() = runTest2 {
         // The prefetch stores `id -> null` for a failed query. Reading that back as "no entry" makes
         // every single-package lookup re-run the query that already failed.

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppScanTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/core/AppScanTest.kt
@@ -11,15 +11,20 @@ import eu.darken.sdmse.common.sharedresource.SharedResource
 import eu.darken.sdmse.common.user.UserHandle2
 import eu.darken.sdmse.common.user.UserManager2
 import eu.darken.sdmse.common.user.UserProfile2
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import org.junit.After
 import org.junit.Test
@@ -110,6 +115,45 @@ class AppScanTest : BaseTest() {
         harness.appScan.allApps(user = null, includeUsage = false, includeActive = false, includeSize = true)
 
         coVerify(exactly = 1) { harness.pkgOps.querySizeStats(targetId, any()) }
+    }
+
+    @Test
+    fun `a cancel lands inside the assembly loop instead of after it`() = runTest2 {
+        // Nothing in the loop is guaranteed to suspend, so without an explicit ensureActive() a
+        // cancel is only honoured once every package has been processed.
+        lateinit var job: Job
+        val seen = mutableListOf<String>()
+        val pkgs = (1..5).map { index ->
+            val pkgName = "eu.thlab.app$index"
+            // packageName is read once per assembly-loop iteration (progress label), so it doubles
+            // as the iteration counter and as the cancel trigger.
+            pkg(pkgName).apply {
+                every { packageName } answers {
+                    seen += pkgName
+                    if (seen.size == 2) job.cancel()
+                    pkgName
+                }
+            }
+        }
+        val harness = harness(pkgs)
+
+        var thrown: Throwable? = null
+        job = launch {
+            try {
+                harness.appScan.allApps(
+                    user = null,
+                    includeUsage = false,
+                    includeActive = false,
+                    includeSize = false,
+                )
+            } catch (e: Throwable) {
+                thrown = e
+            }
+        }
+        job.join()
+
+        thrown.shouldBeInstanceOf<CancellationException>()
+        seen shouldBe listOf("eu.thlab.app1", "eu.thlab.app2")
     }
 
     @Test

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
@@ -313,6 +313,49 @@ class AppControlListScreenTest : BaseComposeRobolectricTest() {
     }
 
     @Test
+    fun `a running task offers Cancel in place of Search and Refresh`() {
+        val cancels = mutableListOf<Unit>()
+        composeRule.setContent {
+            CompositionLocalProvider(LocalGuidedTourController provides mockTourController) {
+                PreviewWrapper {
+                    AppControlListScreen(
+                        stateSource = MutableStateFlow(
+                            AppControlListViewModel.State(
+                                rows = listOf(row("com.alpha.app", label = "Alpha")),
+                                progress = Progress.Data(),
+                            ),
+                        ),
+                        onCancel = { cancels += Unit },
+                    )
+                }
+            }
+        }
+
+        composeRule.onAllNodesWithContentDescription("Search").assertCountEquals(0)
+        composeRule.onAllNodesWithContentDescription("Refresh").assertCountEquals(0)
+        composeRule.onNodeWithContentDescription("Cancel").performClick()
+        cancels.size shouldBeEqual 1
+    }
+
+    @Test
+    fun `Cancel stays available while search is open`() {
+        // A scan can start while search is open (a sort change that needs data the current snapshot
+        // lacks triggers a refresh), so gating Cancel on !searchActive would strand that scan.
+        // A restored non-empty query auto-opens the search field.
+        composeRule.setListScreen(
+            AppControlListViewModel.State(
+                rows = listOf(row("com.alpha.app", label = "Alpha")),
+                progress = Progress.Data(),
+                options = AppControlListViewModel.DisplayOptions(searchQuery = "alpha"),
+            ),
+        )
+
+        // Title replaced by the search field proves search really is open here.
+        composeRule.onAllNodesWithText("AppControl").assertCountEquals(0)
+        composeRule.onNodeWithContentDescription("Cancel").assertExists()
+    }
+
+    @Test
     fun `filter row and top bar actions are visible when no task is executing`() {
         composeRule.setListScreen(
             AppControlListViewModel.State(

--- a/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
+++ b/app-tool-appcontrol/src/test/java/eu/darken/sdmse/appcontrol/ui/list/AppControlListScreenTest.kt
@@ -416,6 +416,36 @@ class AppControlListScreenTest : BaseComposeRobolectricTest() {
         composeRule.onNodeWithText("Beta").assertExists()
     }
 
+    @Test
+    fun `the cancelled message appears only after a cancel, not on cold start`() {
+        // Cancelling the initial scan restores AppControl's pre-scan data, which is null, so the
+        // screen is left with rows == null and progress == null. That is the same combination as
+        // cold start, so the content area can only tell them apart via the explicit cancel flag.
+        // Without a flag-driven branch the area renders a bare Box: no rows, no "Empty", no filter
+        // row, no count, nothing explaining why the screen is blank.
+        val cancelledMessage = "Scan cancelled, no apps were loaded."
+        val stateSource = MutableStateFlow(
+            AppControlListViewModel.State(rows = null, progress = null),
+        )
+        composeRule.setContent {
+            CompositionLocalProvider(LocalGuidedTourController provides mockTourController) {
+                PreviewWrapper {
+                    AppControlListScreen(stateSource = stateSource)
+                }
+            }
+        }
+
+        // Cold start: no cancel yet, so the message must stay away (it would otherwise flash on
+        // every first open, which is why the flag exists instead of a bare rows/progress check).
+        composeRule.onAllNodesWithText(cancelledMessage).assertCountEquals(0)
+
+        // Only the flag changes — rows and progress stay exactly as they were.
+        stateSource.value = stateSource.value.copy(cancelRequested = true)
+        composeRule.waitForIdle()
+
+        composeRule.onNodeWithText(cancelledMessage).assertExists()
+    }
+
     private infix fun <T> T.shouldBeEqual(other: T) {
         if (this != other) throw AssertionError("Expected <$other> but was <$this>")
     }


### PR DESCRIPTION
## What changed

The AppControl scan can now be stopped. While a scan or any other AppControl task is running, the toolbar offers a Cancel action. Cancelling a refresh keeps the app list you already had instead of wiping the screen, and cancelling the very first scan, where there is no list yet, says so rather than leaving a blank page.

The scan also reports real progress. It used to show a spinning circle with no indication of how far along it was, no matter how long it took. It now counts through the apps it is working on and names the one it is on.

Scans do less work when app sizes are turned off. The scan measured every app's storage use on every run, refreshes included, and discarded the numbers when the sizing module was disabled or its permissions were missing.

Separately, a progress bug affecting every cleaning tool is fixed: cancelling a task could leave its progress overlay on screen with no task behind it, blocking the list until the app was restarted.

## Technical Context

- The reported slowness is not diagnosed. The case carried no log, app version, device, Android version, access tier or installed-app count, and nothing here claims to explain it. What changed is the set of defects the code itself showed, plus the cancel affordance that was asked for.
- `AppScan`'s bulk storage-stats prefetch was gated only on its cache being empty, never on the `includeSize` flag it receives, so it issued one `queryStatsForPackage` per installed app and threw every result away when sizing was off. Refresh nulls that cache, so it re-ran in full each time.
- `withProgress`'s cleanup block was cancellable: `cancelAndJoin()` throws at the join on an already-cancelled caller, so the progress restore never ran and nothing waited for the forwarding coroutine. A late forward could then land after a task had cleared its progress, wedging the overlay. That helper is shared by all eight tools and five of them already pair it with a cancel, so this is not AppControl-specific. The best place to look closely.
- The Cancel action covers every AppControl task rather than scans alone, matching what the other tools' dashboard cards already do. Cancelling a toggle or uninstall part-way can leave the list showing pre-action state until the next refresh; those mutation loops are deliberately untouched.
- A cancel still waits for whichever binder call is already in flight, since `queryStatsForPackage` and the archive probe are synchronous. The per-app cancellation check bounds that wait to one call instead of the whole loop. Per-call timeouts with discarded late results were considered and not adopted, there being no evidence any single call is slow.
