### PR TITLE
Fix: App inventory could get stuck loading and freeze other tools

### DIFF
--- a/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
+++ b/app-common-io/src/main/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOps.kt
@@ -120,13 +120,11 @@ class PkgOps @Inject constructor(
         return when {
             mode == Mode.NORMAL || (mode == Mode.AUTO && userHandle == userManager2.currentUser().handle) -> ipcFunnel.use {
                 try {
-                    ipcFunnel.use {
-                        if (hasApiLevel(33)) {
-                            @Suppress("NewApi")
-                            packageManager.getPackageInfo(id.name, PackageInfoFlags.of(flags))
-                        } else {
-                            packageManager.getPackageInfo(id.name, flags.toInt())
-                        }
+                    if (hasApiLevel(33)) {
+                        @Suppress("NewApi")
+                        packageManager.getPackageInfo(id.name, PackageInfoFlags.of(flags))
+                    } else {
+                        packageManager.getPackageInfo(id.name, flags.toInt())
                     }
                 } catch (_: NameNotFoundException) {
                     log(TAG, VERBOSE) { "queryPkg($id, $flags): null" }
@@ -196,9 +194,7 @@ class PkgOps @Inject constructor(
 
     suspend fun getLabel(pkgId: Pkg.Id): String? = ipcFunnel.use {
         try {
-            ipcFunnel.use {
-                packageManager.getLabel2(pkgId)
-            }
+            packageManager.getLabel2(pkgId)
         } catch (_: NameNotFoundException) {
             log(TAG, WARN) { "getLabel(packageName=$pkgId) packageName not found." }
             null

--- a/app-common-io/src/test/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOpsFunnelTest.kt
+++ b/app-common-io/src/test/java/eu/darken/sdmse/common/pkgs/pkgops/PkgOpsFunnelTest.kt
@@ -1,0 +1,105 @@
+package eu.darken.sdmse.common.pkgs.pkgops
+
+import android.app.usage.StorageStatsManager
+import android.app.usage.UsageStatsManager
+import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import eu.darken.sdmse.common.adb.AdbManager
+import eu.darken.sdmse.common.funnel.IPCFunnel
+import eu.darken.sdmse.common.hasApiLevel
+import eu.darken.sdmse.common.pkgs.toPkgId
+import eu.darken.sdmse.common.root.RootManager
+import eu.darken.sdmse.common.user.UserHandle2
+import eu.darken.sdmse.common.user.UserManager2
+import eu.darken.sdmse.common.user.UserProfile2
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+class PkgOpsFunnelTest : BaseTest() {
+
+    private val testPkgId = "test.pkg".toPkgId()
+    private val testUser = UserHandle2(0)
+
+    private val context = mockk<Context>()
+    private val packageManager = mockk<PackageManager>()
+    private val rootManager = mockk<RootManager>()
+    private val adbManager = mockk<AdbManager>()
+    private val usageStatsManager = mockk<UsageStatsManager>()
+    private val storageStatsManager = mockk<StorageStatsManager>()
+    private val userManager2 = mockk<UserManager2>()
+
+    private val testAppInfo = ApplicationInfo().apply {
+        packageName = "test.pkg"
+        labelRes = 0
+        nonLocalizedLabel = "TestLabel"
+    }
+    private val testPkgInfo = PackageInfo().apply {
+        packageName = "test.pkg"
+        applicationInfo = testAppInfo
+    }
+
+    @BeforeEach
+    fun setup() {
+        // API 26 makes IPCFunnel build with a single permit. hasApiLevel(n) means "device SDK >= n",
+        // so a single monotonic answer keeps every call consistent.
+        mockkStatic("eu.darken.sdmse.common.BuildWrapKt")
+        every { hasApiLevel(any()) } answers { 26 >= firstArg<Int>() }
+
+        every { context.packageManager } returns packageManager
+        every { packageManager.getPackageInfo("test.pkg", 0) } returns testPkgInfo
+        coEvery { userManager2.currentUser() } returns UserProfile2(handle = testUser)
+    }
+
+    @AfterEach
+    fun teardown() {
+        unmockkAll()
+    }
+
+    private fun create(scope: CoroutineScope) = PkgOps(
+        appScope = scope,
+        dispatcherProvider = TestDispatcherProvider(),
+        context = context,
+        ipcFunnel = IPCFunnel(context, TestDispatcherProvider()),
+        rootManager = rootManager,
+        adbManager = adbManager,
+        usageStatsManager = usageStatsManager,
+        storageStatsManager = storageStatsManager,
+        userManager2 = userManager2,
+    )
+
+    @Test
+    fun `queryPkg completes with a single funnel permit`() = runTest2 {
+        val pkgOps = create(this)
+
+        val result = withTimeout(5_000) {
+            pkgOps.queryPkg(testPkgId, 0L, testUser, PkgOps.Mode.NORMAL)
+        }
+
+        result shouldBe testPkgInfo
+    }
+
+    @Test
+    fun `getLabel completes with a single funnel permit`() = runTest2 {
+        val pkgOps = create(this)
+
+        val result = withTimeout(5_000) {
+            pkgOps.getLabel(testPkgId)
+        }
+
+        result shouldBe "TestLabel"
+    }
+}

--- a/app-common/src/main/java/eu/darken/sdmse/common/funnel/IPCFunnel.kt
+++ b/app-common/src/main/java/eu/darken/sdmse/common/funnel/IPCFunnel.kt
@@ -44,6 +44,11 @@ class IPCFunnel @Inject constructor(
         log(TAG) { "IPCFunnel initialized." }
     }
 
+    /**
+     * The semaphore is not reentrant: a [use] block must not open another [use], directly or through a
+     * helper it calls. The nested call waits for a second permit while the outer one still holds the
+     * first, which can wedge the funnel for the whole process.
+     */
     suspend fun <T> use(block: suspend FunnelEnvironment.() -> T): T = withContext(dispatcherProvider.IO) {
         execLock.withPermit {
             try {


### PR DESCRIPTION
## What changed

SD Maid could get permanently stuck while loading the app inventory. The setup card would sit on its
loading spinner and never finish, and every other feature that needs the list of installed apps would
stop responding along with it, until the app was closed and started again. This removes the cause, so
inventory loading completes normally.

## Technical Context

- Root cause: `IPCFunnel.execLock` is a non-reentrant `kotlinx.coroutines.sync.Semaphore`, sized
  3/2/1 permits by API level. `PkgOps.queryPkg` (NORMAL / current-user branch) and
  `PkgOps.getLabel(Pkg.Id)` each opened a second `ipcFunnel.use` inside the first, so a single call
  needed two permits at once. On API 29-30 two concurrent nesting callers take one permit each and
  then wait on each other; on API 26-28 a single call self-deadlocks. `InventorySetupModule` cannot
  recover on its own, because its `try`/`catch` covers a thrown failure rather than an indefinite
  suspend.
- Dropping the nesting rather than making the funnel reentrant: a `CoroutineContext` marker would be
  inherited by child coroutines, so a funnel block fanning out with `async` would let every child
  bypass the semaphore, defeating the IPC-buffer throttling the class exists for. Raising the permit
  count was rejected too, since it lowers collision probability without removing hold-and-wait.
- A repo-wide sweep found exactly two nesting sites, both in `PkgOps`. Useful for future sweeps: a
  single-line grep cannot see call sites that wrap the receiver and `.use` onto separate lines, so
  `rg -Un 'ipcFunnel\s*\n?\s*\.use'` is the form that enumerates all of them.
- Worth a close look: the regression test forces the single-permit configuration by faking the API
  level, which is what makes the defect deterministic rather than racy.
- Smoke-tested on a fresh API 30 emulator, which CI cannot cover: app inventory setup completes,
  AppControl and AppCleaner both populate, no crashes.

Closes #2779
